### PR TITLE
Make unimplemented libblockdev methods raise an exception (#1201475)

### DIFF
--- a/site_scons/boilerplate_generator.py
+++ b/site_scons/boilerplate_generator.py
@@ -154,7 +154,9 @@ def get_func_boilerplate(fn_info):
 
     # first add the stub function doing nothing and just reporting error
     ret = ("{0.rtype} {0.name}_stub ({0.args}) {{\n" +
-           "    g_critical(\"The function '{0.name}' called, but not implemented!\");\n" +
+           "    g_critical (\"The function '{0.name}' called, but not implemented!\");\n" +
+           "    g_set_error (error, BD_INIT_ERROR, BD_INIT_ERROR_NOT_IMPLEMENTED,\n"+
+           "                \"The function '{0.name}' called, but not implemented!\");\n"
            "    return {1};\n"
            "}}\n\n").format(fn_info, default_ret)
 

--- a/site_scons/boilerplate_generator.py
+++ b/site_scons/boilerplate_generator.py
@@ -241,6 +241,17 @@ def get_loading_func(fn_infos, module_name):
 
     return ret
 
+def get_unloading_func(fn_infos, module_name):
+    ret = 'gboolean unload_{0} (gpointer handle) {{\n'.format(module_name)
+    for info in fn_infos:
+        # revert the functions to stubs
+        ret += '    _{0.name} = {0.name}_stub;\n'.format(info)
+    ret += '\n'
+    ret += '    return dlclose(handle) == 0;\n'
+    ret += '}\n\n'
+
+    return ret
+
 def get_fn_code(fn_info):
     ret = ("{0.doc}{0.rtype} {0.name} ({0.args}) {{\n" +
             "    {0.body}" +
@@ -268,6 +279,7 @@ def generate_source_header(api_file, out_dir):
         for info in api_fn_infos:
             src_f.write(get_func_boilerplate(info))
         src_f.write(get_loading_func(api_fn_infos, mod_name))
+        src_f.write(get_unloading_func(api_fn_infos, mod_name))
 
     written_fns = set()
     with open(os.path.join(out_dir, mod_name + ".h"), "w") as hdr_f:

--- a/src/lib/blockdev.c
+++ b/src/lib/blockdev.c
@@ -115,7 +115,7 @@ static gboolean load_plugins (BDPluginSpec **require_plugins, gboolean reload) {
     return requested_loaded;
 }
 
-GQuark bd_init_error_quark (void)
+GQuark bd_init_error_quark ()
 {
     return g_quark_from_static_string ("g-bd-init-error-quark");
 }

--- a/src/lib/blockdev.c
+++ b/src/lib/blockdev.c
@@ -61,16 +61,46 @@ static void set_plugin_so_name (BDPlugin name, gchar *so_name) {
     plugins[name].spec.so_name = so_name;
 }
 
+static gboolean unload_plugins () {
+    if (plugins[BD_PLUGIN_LVM].handle && !unload_lvm (plugins[BD_PLUGIN_LVM].handle))
+        g_warning ("Failed to close the lvm plugin");
+    plugins[BD_PLUGIN_LVM].handle = NULL;
+
+    if (plugins[BD_PLUGIN_BTRFS].handle && !unload_btrfs (plugins[BD_PLUGIN_BTRFS].handle))
+        g_warning ("Failed to close the btrfs plugin");
+    plugins[BD_PLUGIN_BTRFS].handle = NULL;
+
+    if (plugins[BD_PLUGIN_SWAP].handle && !unload_swap (plugins[BD_PLUGIN_SWAP].handle))
+        g_warning ("Failed to close the swap plugin");
+    plugins[BD_PLUGIN_SWAP].handle = NULL;
+
+    if (plugins[BD_PLUGIN_LOOP].handle && !unload_loop (plugins[BD_PLUGIN_LOOP].handle))
+        g_warning ("Failed to close the loop plugin");
+    plugins[BD_PLUGIN_LOOP].handle = NULL;
+
+    if (plugins[BD_PLUGIN_CRYPTO].handle && !unload_crypto (plugins[BD_PLUGIN_CRYPTO].handle))
+        g_warning ("Failed to close the crypto plugin");
+    plugins[BD_PLUGIN_CRYPTO].handle = NULL;
+
+    if (plugins[BD_PLUGIN_MPATH].handle && !unload_mpath (plugins[BD_PLUGIN_MPATH].handle))
+        g_warning ("Failed to close the mpath plugin");
+    plugins[BD_PLUGIN_MPATH].handle = NULL;
+
+    if (plugins[BD_PLUGIN_DM].handle && !unload_dm (plugins[BD_PLUGIN_DM].handle))
+        g_warning ("Failed to close the dm plugin");
+    plugins[BD_PLUGIN_DM].handle = NULL;
+
+    if (plugins[BD_PLUGIN_MDRAID].handle && !unload_mdraid (plugins[BD_PLUGIN_MDRAID].handle))
+        g_warning ("Failed to close the mdraid plugin");
+    plugins[BD_PLUGIN_MDRAID].handle = NULL;
+}
+
 static gboolean load_plugins (BDPluginSpec **require_plugins, gboolean reload) {
     guint8 i = 0;
     gboolean requested_loaded = TRUE;
 
     if (reload)
-        for (i=0; i < BD_PLUGIN_UNDEF; i++) {
-            if (plugins[i].handle && (dlclose (plugins[i].handle) != 0))
-                g_warning ("Failed to close %s plugin", plugin_names[i]);
-            plugins[i].handle = NULL;
-        }
+        unload_plugins ();
 
     /* clean all so names and populate back those that are requested or the
        defaults */

--- a/src/lib/blockdev.h
+++ b/src/lib/blockdev.h
@@ -6,9 +6,14 @@
 
 #include "plugins.h"
 
+/**
+ * bd_init_error_quark: (skip)
+ */
+GQuark bd_init_error_quark ();
 #define BD_INIT_ERROR bd_init_error_quark ()
 typedef enum {
     BD_INIT_ERROR_PLUGINS_FAILED,
+    BD_INIT_ERROR_NOT_IMPLEMENTED,
 } BDInitError;
 
 gboolean bd_init (BDPluginSpec **require_plugins, BDUtilsLogFunc log_func, GError **error);

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -21,12 +21,13 @@ typedef enum {
 
 /**
  * bd_crypto_generate_backup_passphrase:
+ * @error: (out): place to store error (if any)
  *
  * Returns: A newly generated %BD_CRYPTO_BACKUP_PASSPHRASE_LENGTH-long passphrase.
  *
  * See %BD_CRYPTO_BACKUP_PASSPHRASE_CHARSET for the definition of the charset used for the passphrase.
  */
-gchar* bd_crypto_generate_backup_passphrase();
+gchar* bd_crypto_generate_backup_passphrase(GError **error);
 
 /**
  * bd_crypto_device_is_luks:

--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -205,30 +205,34 @@ GType bd_lvm_lvdata_get_type () {
 /**
  * bd_lvm_is_supported_pe_size:
  * @size: size (in bytes) to test
+ * @error: (out): place to store error (if any)
  *
  * Returns: whether the given size is supported physical extent size or not
  */
-gboolean bd_lvm_is_supported_pe_size (guint64 size);
+gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error);
 
 /**
  * bd_lvm_get_supported_pe_sizes:
+ * @error: (out): place to store error (if any)
  *
  * Returns: (transfer full) (array zero-terminated=1): list of supported PE sizes
  */
-guint64 *bd_lvm_get_supported_pe_sizes ();
+guint64 *bd_lvm_get_supported_pe_sizes (GError **error);
 
 /**
  * bd_lvm_get_max_lv_size:
+ * @error: (out): place to store error (if any)
  *
  * Returns: maximum LV size in bytes
  */
-guint64 bd_lvm_get_max_lv_size ();
+guint64 bd_lvm_get_max_lv_size (GError **error);
 
 /**
  * bd_lvm_round_size_to_pe:
  * @size: size to be rounded
  * @pe_size: physical extent (PE) size or 0 to use the default
  * @roundup: whether to round up or down (ceil or floor)
+ * @error: (out): place to store error (if any)
  *
  * Returns: @size rounded to @pe_size according to the @roundup
  *
@@ -237,47 +241,51 @@ guint64 bd_lvm_get_max_lv_size ();
  * return type, the result is rounded down (floored) regardless of the @roundup
  * parameter.
  */
-guint64 bd_lvm_round_size_to_pe (guint64 size, guint64 pe_size, gboolean roundup);
+guint64 bd_lvm_round_size_to_pe (guint64 size, guint64 pe_size, gboolean roundup, GError **error);
 
 /**
  * bd_lvm_get_lv_physical_size:
  * @lv_size: LV size
  * @pe_size: PE size
+ * @error: (out): place to store error (if any)
  *
  * Returns: space taken on disk(s) by the LV with given @size
  *
  * Gives number of bytes needed for an LV with the size @lv_size on an LVM stack
  * using given @pe_size.
  */
-guint64 bd_lvm_get_lv_physical_size (guint64 lv_size, guint64 pe_size);
+guint64 bd_lvm_get_lv_physical_size (guint64 lv_size, guint64 pe_size, GError **error);
 
 /**
  * bd_lvm_get_thpool_padding:
  * @size: size of the thin pool
  * @pe_size: PE size or 0 if the default value should be used
  * @included: if padding is already included in the size
+ * @error: (out): place to store error (if any)
  *
  * Returns: size of the padding needed for a thin pool with the given @size
  *         according to the @pe_size and @included
  */
-guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean included);
+guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean included, GError **error);
 
 /**
  * bd_lvm_is_valid_thpool_md_size:
  * @size: the size to be tested
+ * @error: (out): place to store error (if any)
  *
  * Returns: whether the given size is a valid thin pool metadata size or not
  */
-gboolean bd_lvm_is_valid_thpool_md_size (guint64 size);
+gboolean bd_lvm_is_valid_thpool_md_size (guint64 size, GError **error);
 
 /**
  * bd_lvm_is_valid_thpool_chunk_size:
  * @size: the size to be tested
  * @discard: whether discard/TRIM is required to be supported or not
+ * @error: (out): place to store error (if any)
  *
  * Returns: whether the given size is a valid thin pool chunk size or not
  */
-gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard);
+gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard, GError **error);
 
 /**
  * bd_lvm_pvcreate:
@@ -611,10 +619,11 @@ gboolean bd_lvm_set_global_config (gchar *new_config, GError **error);
 
 /**
  * bd_lvm_get_global_config:
+ * @error: (out): place to store error (if any)
  *
  * Returns: a copy of a string representation of the currently set LVM global
  *          configuration
  */
-gchar* bd_lvm_get_global_config ();
+gchar* bd_lvm_get_global_config (GError **error);
 
 #endif  /* BD_LVM_API */

--- a/src/lib/plugin_apis/mdraid.api
+++ b/src/lib/plugin_apis/mdraid.api
@@ -159,11 +159,12 @@ GType bd_md_detail_data_get_type () {
  * bd_md_get_superblock_size:
  * @size: size of the array
  * @version: (allow-none): metadata version or %NULL to use the current default version
+ * @error: (out): place to store error (if any)
  *
  * Returns: Calculated superblock size for given array @size and metadata @version
  * or default if unsupported @version is used.
  */
-guint64 bd_md_get_superblock_size (guint64 size, gchar *version);
+guint64 bd_md_get_superblock_size (guint64 size, gchar *version, GError **error);
 
 /**
  * bd_md_create:

--- a/src/lib/test_blockdev.c
+++ b/src/lib/test_blockdev.c
@@ -19,7 +19,7 @@ int main (int argc, char* argv[]) {
     else
         puts ("'undef' plugin not available");
 
-    g_printf ("max LV size: %"G_GUINT64_FORMAT"\n", bd_lvm_get_max_lv_size());
+    g_printf ("max LV size: %"G_GUINT64_FORMAT"\n", bd_lvm_get_max_lv_size(&error));
 
     return 0;
 }

--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -55,12 +55,13 @@ GQuark bd_crypto_error_quark (void)
 
 /**
  * bd_crypto_generate_backup_passphrase:
+ * @error: (out): place to store error (if any)
  *
  * Returns: (transfer full): A newly generated %BD_CRYPTO_BACKUP_PASSPHRASE_LENGTH-long passphrase.
  *
  * See %BD_CRYPTO_BACKUP_PASSPHRASE_CHARSET for the definition of the charset used for the passphrase.
  */
-gchar* bd_crypto_generate_backup_passphrase() {
+gchar* bd_crypto_generate_backup_passphrase(GError **error __attribute__((unused))) {
     guint8 i = 0;
     guint8 offset = 0;
     guint8 charset_length = strlen (BD_CRYPTO_BACKUP_PASSPHRASE_CHARSET);

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -32,7 +32,7 @@ typedef enum {
 #define DEFAULT_LUKS_KEYSIZE_BITS 256
 #define DEFAULT_LUKS_CIPHER "aes-xts-plain64"
 
-gchar* bd_crypto_generate_backup_passphrase();
+gchar* bd_crypto_generate_backup_passphrase(GError **error);
 gboolean bd_crypto_device_is_luks (gchar *device, GError **error);
 gchar* bd_crypto_luks_uuid (gchar *device, GError **error);
 gchar* bd_crypto_luks_status (gchar *luks_device, GError **error);

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -75,14 +75,14 @@ typedef struct BDLVMLVdata {
 void bd_lvm_lvdata_free (BDLVMLVdata *data);
 BDLVMLVdata* bd_lvm_lvdata_copy (BDLVMLVdata *data);
 
-gboolean bd_lvm_is_supported_pe_size (guint64 size);
-guint64 *bd_lvm_get_supported_pe_sizes ();
-guint64 bd_lvm_get_max_lv_size ();
-guint64 bd_lvm_round_size_to_pe (guint64 size, guint64 pe_size, gboolean roundup);
-guint64 bd_lvm_get_lv_physical_size (guint64 lv_size, guint64 pe_size);
-guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean included);
-gboolean bd_lvm_is_valid_thpool_md_size (guint64 size);
-gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard);
+gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error);
+guint64 *bd_lvm_get_supported_pe_sizes (GError **error);
+guint64 bd_lvm_get_max_lv_size (GError **error);
+guint64 bd_lvm_round_size_to_pe (guint64 size, guint64 pe_size, gboolean roundup, GError **error);
+guint64 bd_lvm_get_lv_physical_size (guint64 lv_size, guint64 pe_size, GError **error);
+guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean included, GError **error);
+gboolean bd_lvm_is_valid_thpool_md_size (guint64 size, GError **error);
+gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard, GError **error);
 
 gboolean bd_lvm_pvcreate (gchar *device, guint64 data_alignment, guint64 metadata_size, GError **error);
 gboolean bd_lvm_pvresize (gchar *device, guint64 size, GError **error);
@@ -117,6 +117,6 @@ gboolean bd_lvm_thlvcreate (gchar *vg_name, gchar *pool_name, gchar *lv_name, gu
 gchar* bd_lvm_thlvpoolname (gchar *vg_name, gchar *lv_name, GError **error);
 gboolean bd_lvm_thsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *snapshot_name, gchar *pool_name, GError **error);
 gboolean bd_lvm_set_global_config (gchar *new_config, GError **error);
-gchar* bd_lvm_get_global_config ();
+gchar* bd_lvm_get_global_config (GError **error);
 
 #endif /* BD_LVM */

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -289,11 +289,12 @@ static BDMDDetailData* get_detail_data_from_table (GHashTable *table, gboolean f
  * bd_md_get_superblock_size:
  * @size: size of the array
  * @version: (allow-none): metadata version or %NULL to use the current default version
+ * @error: (out): place to store error (if any)
  *
  * Returns: Calculated superblock size for given array @size and metadata @version
  * or default if unsupported @version is used.
  */
-guint64 bd_md_get_superblock_size (guint64 size, gchar *version) {
+guint64 bd_md_get_superblock_size (guint64 size, gchar *version, GError **error __attribute__((unused))) {
     guint64 headroom = BD_MD_SUPERBLOCK_SIZE;
     guint64 min_headroom = (1 MiB);
 

--- a/src/plugins/mdraid.h
+++ b/src/plugins/mdraid.h
@@ -53,7 +53,7 @@ typedef struct BDMDDetailData {
 void bd_md_detail_data_free (BDMDDetailData *data);
 BDMDDetailData* bd_md_detail_data_copy (BDMDDetailData *data);
 
-guint64 bd_md_get_superblock_size (guint64 size, gchar *version);
+guint64 bd_md_get_superblock_size (guint64 size, gchar *version, GError **error);
 gboolean bd_md_create (gchar *device_name, gchar *level, gchar **disks, guint64 spares, gchar *version, gboolean bitmap, GError **error);
 gboolean bd_md_destroy (gchar *device, GError **error);
 gboolean bd_md_deactivate (gchar *device_name, GError **error);

--- a/src/plugins/test_lvm.c
+++ b/src/plugins/test_lvm.c
@@ -44,47 +44,57 @@ int main (void) {
     }
     g_clear_error (&error);
 
-    if (bd_lvm_is_supported_pe_size(16 MEBIBYTE))
+    if (bd_lvm_is_supported_pe_size(16 MEBIBYTE, &error))
         puts ("16 MiB PE: Supported.");
     else
         puts ("16 MiB PE: Unsupported.");
+    g_clear_error (&error);
 
-    sizes = bd_lvm_get_supported_pe_sizes ();
+    sizes = bd_lvm_get_supported_pe_sizes (&error);
     g_printf ("Supported PE sizes: ");
     for (i=0; sizes[i] != 0; i++)
         g_printf ("%s, ", bd_utils_size_human_readable (sizes[i]));
     puts ("");
+    g_clear_error (&error);
     g_free (sizes);
 
-    g_printf ("max LV size: %s\n", bd_utils_size_human_readable(bd_lvm_get_max_lv_size()));
+    g_printf ("max LV size: %s\n", bd_utils_size_human_readable(bd_lvm_get_max_lv_size(&error)));
 
-    result = bd_lvm_round_size_to_pe ((13 MiB), USE_DEFAULT_PE_SIZE, TRUE);
+    result = bd_lvm_round_size_to_pe ((13 MiB), USE_DEFAULT_PE_SIZE, TRUE, &error);
+    g_clear_error (&error);
     g_printf ("up-rounded size 13 MiB: %s\n", bd_utils_size_human_readable(result));
-    result = bd_lvm_round_size_to_pe ((13 MiB), USE_DEFAULT_PE_SIZE, FALSE);
+    result = bd_lvm_round_size_to_pe ((13 MiB), USE_DEFAULT_PE_SIZE, FALSE, &error);
+    g_clear_error (&error);
     g_printf ("down-rounded size 13 MiB: %s\n", bd_utils_size_human_readable(result));
 
-    result = bd_lvm_get_lv_physical_size ((13 MiB), USE_DEFAULT_PE_SIZE);
+    result = bd_lvm_get_lv_physical_size ((13 MiB), USE_DEFAULT_PE_SIZE, &error);
+    g_clear_error (&error);
     g_printf ("13 MiB physical size: %s\n", bd_utils_size_human_readable(result));
 
-    result = bd_lvm_get_thpool_padding ((1 GiB), USE_DEFAULT_PE_SIZE, TRUE);
+    result = bd_lvm_get_thpool_padding ((1 GiB), USE_DEFAULT_PE_SIZE, TRUE, &error);
+    g_clear_error (&error);
     g_printf ("1 GiB ThPool padding size (included): %s\n", bd_utils_size_human_readable(result));
-    result = bd_lvm_get_thpool_padding ((1 GiB), USE_DEFAULT_PE_SIZE, FALSE);
+    result = bd_lvm_get_thpool_padding ((1 GiB), USE_DEFAULT_PE_SIZE, FALSE, &error);
+    g_clear_error (&error);
     g_printf ("1 GiB ThPool padding size (not included): %s\n", bd_utils_size_human_readable(result));
 
-    if (bd_lvm_is_valid_thpool_md_size (512 MiB))
+    if (bd_lvm_is_valid_thpool_md_size (512 MiB, &error))
         puts ("512 MiB ThPool MD size: Valid.");
     else
         puts ("512 MiB ThPool MD size: Invalid.");
+    g_clear_error (&error);
 
-    if (bd_lvm_is_valid_thpool_chunk_size ((192 KiB), TRUE))
+    if (bd_lvm_is_valid_thpool_chunk_size ((192 KiB), TRUE, &error))
         puts ("192 KiB ThPool chunk size (discard): Valid.");
     else
         puts ("192 KiB ThPool chunk size (discard): Invalid.");
+    g_clear_error (&error);
 
-    if (bd_lvm_is_valid_thpool_chunk_size ((192 KiB), FALSE))
+    if (bd_lvm_is_valid_thpool_chunk_size ((192 KiB), FALSE, &error))
         puts ("192 KiB ThPool chunk size (no discard): Valid.");
     else
         puts ("192 KiB ThPool chunk size (no discard): Invalid.");
+    g_clear_error (&error);
 
     succ = bd_lvm_pvcreate ("/dev/xd1", 0, 0, &error);
     if (!succ)

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -2,7 +2,7 @@ import os
 import unittest
 import re
 
-from gi.repository import BlockDev
+from gi.repository import GLib, BlockDev
 if not BlockDev.is_initialized():
     assert BlockDev.init(None, None)
 
@@ -131,6 +131,27 @@ class LibraryOpsTestCase(unittest.TestCase):
         self.assertTrue(BlockDev.reinit([ps], True, None))
         self.assertEqual(BlockDev.get_available_plugin_names(), ["btrfs"])
         self.assertTrue(BlockDev.reinit(None, True, None))
+
+    def test_not_implemented(self):
+        """Verify that unloaded/unimplemented functions report errors"""
+
+        # should be loaded and working
+        self.assertTrue(BlockDev.lvm_get_max_lv_size() > 0)
+
+        ps = BlockDev.PluginSpec()
+        ps.name = BlockDev.Plugin.BTRFS
+        ps.so_name = ""
+        self.assertTrue(BlockDev.reinit([ps], True, None))
+        self.assertEqual(BlockDev.get_available_plugin_names(), ["btrfs"])
+
+        # no longer loaded
+        with self.assertRaises(GLib.GError):
+            BlockDev.lvm_get_max_lv_size()
+
+        self.assertTrue(BlockDev.reinit(None, True, None))
+
+        # loaded again
+        self.assertTrue(BlockDev.lvm_get_max_lv_size() > 0)
 
     def test_try_init(self):
         """Verify that try_init just returns when already initialized"""


### PR DESCRIPTION
As the commit message of the first commit explains:
> Printing out some message to stderr is not "loud enough" even if it is CRITICAL
    and can be silently ignored (especially if the stderr is redirected somewhere).
    We need to report error/raise exception if an unimplemented function is called.
    Such error/exception can be handled by the caller just fine or they can
    propagate it if they want to.

I know there could be improvements making the code a bit nicer (using pointers to load/unload functions and for-cycles instead of calling each of them separately) and further improvements (like adding the ``bd_unload()`` function to unload the library), but I'm leaving that for future development.