### PR TITLE
Sort BTRFS subvolumes in a way that child never appears before parent

### DIFF
--- a/src/lib/plugin_apis/btrfs.api
+++ b/src/lib/plugin_apis/btrfs.api
@@ -260,6 +260,9 @@ BDBtrfsDeviceInfo** bd_btrfs_list_devices (gchar *device, GError **error);
  *
  * Returns: (array zero-terminated=1): information about the subvolumes that are part of the btrfs volume
  * mounted at @mountpoint or %NULL in case of error
+ *
+ * The subvolumes are sorted in a way that no child subvolume appears in the
+ * list before its parent (sub)volume.
  */
 BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (gchar *mountpoint, gboolean snapshots_only, GError **error);
 

--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -206,6 +206,12 @@ class BtrfsTestCreateDeleteSubvolume(BtrfsTestCase):
         subvols = BlockDev.btrfs_list_subvolumes(TEST_MNT, False)
         self.assertEqual(len(subvols), 2)
 
+        # make sure subvolumes are sorted properly (parents before children)
+        seen = set()
+        for subvol in subvols:
+            seen.add(subvol)
+            self.assertTrue(subvol.parent_id == BlockDev.BTRFS_MAIN_VOLUME_ID or any(subvol.parent_id == other.id for other in seen))
+
 class BtrfsTestCreateSnapshot(BtrfsTestCase):
     def test_create_snapshot(self):
         succ = BlockDev.btrfs_create_volume([self.loop_dev], "myShinyBtrfs", None, None)


### PR DESCRIPTION
Resolves: rhbz#1201120

When processing subvolumes, it is often desirable to process the parent
(sub)volume first because child subvolumes often have references to their
parents. That's why we need to sort subvolumes that way when returning a list of
them.