### PR TITLE
The KBD plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,11 @@ fast-test: build
 	@sudo SKIP_SLOW= GI_TYPELIB_PATH=build LD_LIBRARY_PATH=build PYTHONPATH=.:tests/:src/python \
 		python -m unittest discover -v -s tests/ -p '*_test.py'
 
+test-all: build
+	pylint -E src/python/gi/overrides/BlockDev.py
+	@sudo FEELINGLUCKY= GI_TYPELIB_PATH=build LD_LIBRARY_PATH=build PYTHONPATH=.:tests/:src/python \
+		python -m unittest discover -v -s tests/ -p '*_test.py'
+
 documentation: $(wildcard src/plugins/*.[ch]) $(wildcard src/lib/*.[ch]) $(wildcard src/utils/*.[ch])
 	-mkdir -p build/docs
 	cp docs/libblockdev-docs.xml docs/libblockdev-sections.txt build/docs

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ build:
 	scons -Q build
 	@echo
 
+rebuild: clean
+	$(MAKE) build
+
 install:
 	scons -Q --prefix=${PREFIX} --sitedirs=${SITEDIRS} install
 	-mkdir -p ${PREFIX}/usr/share/gtk-doc/html/libblockdev/

--- a/Sconscript
+++ b/Sconscript
@@ -7,7 +7,7 @@ MAIN_VERSION = "0.1.0"
 MAJOR_MINOR = MAIN_VERSION.rsplit(".", 1)[0]
 MAJOR_VERSION = MAIN_VERSION.split(".", 1)[0]
 LIB_FILES = ["src/lib/blockdev.c", "src/lib/blockdev.h", "src/lib/plugins.h"]
-PLUGIN_NAMES = ["crypto", "dm", "loop", "lvm", "mpath", "swap", "btrfs", "mdraid"]
+PLUGIN_NAMES = ["crypto", "dm", "loop", "lvm", "mpath", "swap", "btrfs", "mdraid", "kbd"]
 PLUGIN_HEADER_FILES = ["build/plugin_apis/"+name+".h" for name in PLUGIN_NAMES]
 UTILS_FILES = ["src/utils/exec.c", "src/utils/sizes.c", "src/utils/exec.h", "src/utils/sizes.h"]
 
@@ -78,6 +78,9 @@ swap_env.Append(LIBPATH=".")
 swap_env.Append(LIBS="bd_utils")
 plugins.append(swap_env.SharedLibrary("bd_swap", ["src/plugins/swap.c"]))
 
+kbd_env = glib_warnall_env.Clone()
+plugins.append(kbd_env.SharedLibrary("bd_kbd", ["src/plugins/kbd.c"]))
+
 
 ## boilerplate code generation
 bpg_builder = Builder(action=generate_boilerplate_files)
@@ -93,6 +96,7 @@ boiler_code.append(bpg_env.BpG(["plugin_apis/loop.h", "plugin_apis/loop.c"], "sr
 boiler_code.append(bpg_env.BpG(["plugin_apis/mdraid.h", "plugin_apis/mdraid.c"], "src/lib/plugin_apis/mdraid.api"))
 boiler_code.append(bpg_env.BpG(["plugin_apis/mpath.h", "plugin_apis/mpath.c"], "src/lib/plugin_apis/mpath.api"))
 boiler_code.append(bpg_env.BpG(["plugin_apis/swap.h", "plugin_apis/swap.c"], "src/lib/plugin_apis/swap.api"))
+boiler_code.append(bpg_env.BpG(["plugin_apis/kbd.h", "plugin_apis/kbd.c"], "src/lib/plugin_apis/kbd.api"))
 
 
 ## the library itself

--- a/Sconscript
+++ b/Sconscript
@@ -80,6 +80,9 @@ plugins.append(swap_env.SharedLibrary("bd_swap", ["src/plugins/swap.c"]))
 
 kbd_env = glib_warnall_env.Clone()
 kbd_env.ParseConfig("pkg-config --cflags --libs libkmod")
+kbd_env.Append(CPPPATH="src/utils")
+kbd_env.Append(LIBPATH=".")
+kbd_env.Append(LIBS="bd_utils")
 plugins.append(kbd_env.SharedLibrary("bd_kbd", ["src/plugins/kbd.c"]))
 
 

--- a/Sconscript
+++ b/Sconscript
@@ -79,6 +79,7 @@ swap_env.Append(LIBS="bd_utils")
 plugins.append(swap_env.SharedLibrary("bd_swap", ["src/plugins/swap.c"]))
 
 kbd_env = glib_warnall_env.Clone()
+kbd_env.ParseConfig("pkg-config --cflags --libs libkmod")
 plugins.append(kbd_env.SharedLibrary("bd_kbd", ["src/plugins/kbd.c"]))
 
 

--- a/dist/libblockdev.spec
+++ b/dist/libblockdev.spec
@@ -116,6 +116,27 @@ This package contains header files and pkg-config files needed for development
 with the libblockdev-dm plugin/library.
 
 
+%package kbd
+Summary:     The KBD plugin for the libblockdev library
+Requires: %{name}-utils%{?_isa} >= 0.11
+Requires: bcache-tools >= 1.0.8
+
+%description kbd
+The libblockdev library plugin (and in the same time a standalone library)
+proving the functionality related to kernel block devices (namely zRAM and
+Bcache).
+
+%package kbd-devel
+Summary:     Development files for the libblockdev-kbd plugin/library
+Requires: %{name}-kbd%{?_isa} = %{version}-%{release}
+Requires: %{name}-utils-devel%{?_isa}
+Requires: glib2-devel
+
+%description kbd-devel
+This package contains header files and pkg-config files needed for development
+with the libblockdev-kbd plugin/library.
+
+
 %package loop
 Summary:     The loop plugin for the libblockdev library
 Requires: util-linux
@@ -217,6 +238,7 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 Requires: %{name}-btrfs%{?_isa} = %{version}-%{release}
 Requires: %{name}-crypto%{?_isa} = %{version}-%{release}
 Requires: %{name}-dm%{?_isa} = %{version}-%{release}
+Requires: %{name}-kbd%{?_isa} = %{version}-%{release}
 Requires: %{name}-loop%{?_isa} = %{version}-%{release}
 Requires: %{name}-lvm%{?_isa} = %{version}-%{release}
 Requires: %{name}-mdraid%{?_isa} = %{version}-%{release}
@@ -315,6 +337,15 @@ CFLAGS="%{optflags}" make PREFIX=%{buildroot} SITEDIRS=%{buildroot}%{python2_sit
 %{_libdir}/libbd_dm.so
 %dir %{_includedir}/blockdev
 %{_includedir}/blockdev/dm.h
+
+
+%files kbd
+%{_libdir}/libbd_kbd.so.*
+
+%files kbd-devel
+%{_libdir}/libbd_kbd.so
+%dir %{_includedir}/blockdev
+%{_includedir}/blockdev/kbd.h
 
 
 %files loop

--- a/docs/libblockdev-docs.xml
+++ b/docs/libblockdev-docs.xml
@@ -30,6 +30,7 @@
     <xi:include href="xml/mpath.xml"/>
     <xi:include href="xml/plugins.xml"/>
     <xi:include href="xml/swap.xml"/>
+    <xi:include href="xml/kbd.xml"/>
     <xi:include href="xml/utils.xml"/>
   </chapter>
 

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -259,3 +259,6 @@ bd_swap_swapoff
 bd_swap_swapstatus
 </SECTION>
 
+<SECTION>
+<FILE>kbd</FILE>
+</SECTION>

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -6,6 +6,7 @@ bd_init
 bd_try_init
 bd_reinit
 bd_is_initialized
+bd_init_error_quark
 </SECTION>
 
 <SECTION>
@@ -257,6 +258,34 @@ bd_swap_mkswap
 bd_swap_swapon
 bd_swap_swapoff
 bd_swap_swapstatus
+</SECTION>
+
+<SECTION>
+<FILE>kbd</FILE>
+BDKBDBcacheMode
+BDKBDBcacheStats
+BDKBDError
+BDKBDZramStats
+BD_KBD_ERROR
+bd_kbd_bcache_attach
+bd_kbd_bcache_create
+bd_kbd_bcache_destroy
+bd_kbd_bcache_detach
+bd_kbd_bcache_get_backing_device
+bd_kbd_bcache_get_cache_device
+bd_kbd_bcache_get_mode
+bd_kbd_bcache_get_mode_from_str
+bd_kbd_bcache_get_mode_str
+bd_kbd_bcache_set_mode
+bd_kbd_bcache_stats_copy
+bd_kbd_bcache_stats_free
+bd_kbd_bcache_status
+bd_kbd_error_quark
+bd_kbd_zram_create_devices
+bd_kbd_zram_destroy_devices
+bd_kbd_zram_get_stats
+bd_kbd_zram_stats_copy
+bd_kbd_zram_stats_free
 </SECTION>
 
 <SECTION>

--- a/features.rst
+++ b/features.rst
@@ -255,6 +255,7 @@ KBD (Kernel Block Devices)
 
    * zram_create_devices [DONE]
    * zram_destroy_devices [DONE]
+   * zram_get_stats [DONE]
 
 
 utils

--- a/features.rst
+++ b/features.rst
@@ -252,8 +252,8 @@ KBD (Kernel Block Devices)
    * bcache_set_mode
    * bcache_get_mode
 
-   * zram_create
-   * zram_destroy
+   * zram_create_devices [DONE]
+   * zram_destroy_devices
 
 
 utils

--- a/features.rst
+++ b/features.rst
@@ -245,9 +245,10 @@ KBD (Kernel Block Devices)
    bcache, zram
 
 :functions:
-   * bcache_create
-   * bcache_destroy
-   * bcache_detach
+   * bcache_create [DONE]
+   * bcache_destroy [DONE]
+   * bcache_attach [DONE]
+   * bcache_detach [DONE]
    * bcache_status
    * bcache_set_mode
    * bcache_get_mode

--- a/features.rst
+++ b/features.rst
@@ -249,7 +249,7 @@ KBD (Kernel Block Devices)
    * bcache_destroy [DONE]
    * bcache_attach [DONE]
    * bcache_detach [DONE]
-   * bcache_status
+   * bcache_status [DONE]
    * bcache_set_mode [DONE]
    * bcache_get_mode [DONE]
 

--- a/features.rst
+++ b/features.rst
@@ -253,7 +253,7 @@ KBD (Kernel Block Devices)
    * bcache_get_mode
 
    * zram_create_devices [DONE]
-   * zram_destroy_devices
+   * zram_destroy_devices [DONE]
 
 
 utils

--- a/features.rst
+++ b/features.rst
@@ -252,6 +252,8 @@ KBD (Kernel Block Devices)
    * bcache_status [DONE]
    * bcache_set_mode [DONE]
    * bcache_get_mode [DONE]
+   * bcache_get_backing_device [DONE]
+   * bcache_get_cache_device [DONE]
 
    * zram_create_devices [DONE]
    * zram_destroy_devices [DONE]

--- a/features.rst
+++ b/features.rst
@@ -250,8 +250,8 @@ KBD (Kernel Block Devices)
    * bcache_attach [DONE]
    * bcache_detach [DONE]
    * bcache_status
-   * bcache_set_mode
-   * bcache_get_mode
+   * bcache_set_mode [DONE]
+   * bcache_get_mode [DONE]
 
    * zram_create_devices [DONE]
    * zram_destroy_devices [DONE]

--- a/site_scons/boilerplate_generator.py
+++ b/site_scons/boilerplate_generator.py
@@ -12,7 +12,7 @@ import sys
 import os
 
 FuncInfo = namedtuple("FuncInfo", ["name", "doc", "rtype", "args", "body"])
-FUNC_SPEC_RE = re.compile(r'(?P<rtype>\**\s*\w+\s*\**)'
+FUNC_SPEC_RE = re.compile(r'(?P<rtype>(const\s+)?\**\s*\w+\s*\**)'
                           r'\s*'
                           r'(?P<name>\w+)'
                           r'\s*\('

--- a/site_scons/boilerplate_generator.py
+++ b/site_scons/boilerplate_generator.py
@@ -149,8 +149,12 @@ def get_func_boilerplate(fn_info):
         default_ret = "0.0"
     elif "bool" in fn_info.rtype:
         default_ret = "FALSE"
-    else:
+    elif fn_info.rtype.endswith("*"):
+        # a pointer
         default_ret = "NULL"
+    else:
+        # enum or whatever
+        default_ret = 0
 
     # first add the stub function doing nothing and just reporting error
     ret = ("{0.rtype} {0.name}_stub ({0.args}) {{\n" +

--- a/src/lib/blockdev.c
+++ b/src/lib/blockdev.c
@@ -311,7 +311,7 @@ gchar** bd_get_available_plugin_names () {
         if (plugins[i].handle)
             num_loaded++;
 
-    gchar **ret_plugin_names = g_new (gchar*, num_loaded + 1);
+    gchar **ret_plugin_names = g_new0 (gchar*, num_loaded + 1);
     for (i=0; i < BD_PLUGIN_UNDEF; i++)
         if (plugins[i].handle) {
             ret_plugin_names[next] = plugin_names[i];

--- a/src/lib/blockdev.c
+++ b/src/lib/blockdev.c
@@ -19,6 +19,9 @@
 #include "plugin_apis/dm.h"
 #include "plugin_apis/mdraid.h"
 #include "plugin_apis/mdraid.c"
+#include "plugin_apis/kbd.h"
+#include "plugin_apis/kbd.c"
+
 
 /**
  * SECTION: blockdev
@@ -41,7 +44,8 @@ static gchar * default_plugin_so[BD_PLUGIN_UNDEF] = {
     "libbd_lvm.so."MAJOR_VER, "libbd_btrfs.so."MAJOR_VER,
     "libbd_swap.so."MAJOR_VER, "libbd_loop.so."MAJOR_VER,
     "libbd_crypto.so."MAJOR_VER, "libbd_mpath.so."MAJOR_VER,
-    "libbd_dm.so."MAJOR_VER, "libbd_mdraid.so."MAJOR_VER
+    "libbd_dm.so."MAJOR_VER, "libbd_mdraid.so."MAJOR_VER,
+    "libbd_kbd.so."MAJOR_VER,
 };
 static BDPluginStatus plugins[BD_PLUGIN_UNDEF] = {
     {{BD_PLUGIN_LVM, NULL}, NULL},
@@ -51,10 +55,11 @@ static BDPluginStatus plugins[BD_PLUGIN_UNDEF] = {
     {{BD_PLUGIN_CRYPTO, NULL}, NULL},
     {{BD_PLUGIN_MPATH, NULL}, NULL},
     {{BD_PLUGIN_DM, NULL}, NULL},
-    {{BD_PLUGIN_MDRAID, NULL}, NULL}
+    {{BD_PLUGIN_MDRAID, NULL}, NULL},
+    {{BD_PLUGIN_KBD, NULL}, NULL},
 };
 static gchar* plugin_names[BD_PLUGIN_UNDEF] = {
-    "lvm", "btrfs", "swap", "loop", "crypto", "mpath", "dm", "mdraid"
+    "lvm", "btrfs", "swap", "loop", "crypto", "mpath", "dm", "mdraid", "kbd"
 };
 
 static void set_plugin_so_name (BDPlugin name, gchar *so_name) {
@@ -93,6 +98,11 @@ static void unload_plugins () {
     if (plugins[BD_PLUGIN_MDRAID].handle && !unload_mdraid (plugins[BD_PLUGIN_MDRAID].handle))
         g_warning ("Failed to close the mdraid plugin");
     plugins[BD_PLUGIN_MDRAID].handle = NULL;
+
+    if (plugins[BD_PLUGIN_KBD].handle && !unload_kbd (plugins[BD_PLUGIN_KBD].handle))
+        g_warning ("Failed to close the kbd plugin");
+    plugins[BD_PLUGIN_KBD].handle = NULL;
+
 }
 
 static gboolean load_plugins (BDPluginSpec **require_plugins, gboolean reload) {
@@ -137,6 +147,8 @@ static gboolean load_plugins (BDPluginSpec **require_plugins, gboolean reload) {
         plugins[BD_PLUGIN_DM].handle = load_dm_from_plugin(plugins[BD_PLUGIN_DM].spec.so_name);
     if (!plugins[BD_PLUGIN_MDRAID].handle && plugins[BD_PLUGIN_MDRAID].spec.so_name)
         plugins[BD_PLUGIN_MDRAID].handle = load_mdraid_from_plugin(plugins[BD_PLUGIN_MDRAID].spec.so_name);
+    if (!plugins[BD_PLUGIN_KBD].handle && plugins[BD_PLUGIN_KBD].spec.so_name)
+        plugins[BD_PLUGIN_KBD].handle = load_kbd_from_plugin(plugins[BD_PLUGIN_KBD].spec.so_name);
 
     for (i=0; (i < BD_PLUGIN_UNDEF) && requested_loaded; i++)
         if (plugins[i].spec.so_name)

--- a/src/lib/plugin_apis/btrfs.api
+++ b/src/lib/plugin_apis/btrfs.api
@@ -27,7 +27,7 @@ typedef struct BDBtrfsDeviceInfo {
  * Creates a new copy of @info.
  */
 BDBtrfsDeviceInfo* bd_btrfs_device_info_copy (BDBtrfsDeviceInfo *info) {
-    BDBtrfsDeviceInfo *new_info = g_new (BDBtrfsDeviceInfo, 1);
+    BDBtrfsDeviceInfo *new_info = g_new0 (BDBtrfsDeviceInfo, 1);
 
     new_info->id = info->id;
     new_info->path = g_strdup (info->path);
@@ -75,7 +75,7 @@ typedef struct BDBtrfsSubvolumeInfo {
  * Creates a new copy of @info.
  */
 BDBtrfsSubvolumeInfo* bd_btrfs_subvolume_info_copy (BDBtrfsSubvolumeInfo *info) {
-    BDBtrfsSubvolumeInfo *new_info = g_new (BDBtrfsSubvolumeInfo, 1);
+    BDBtrfsSubvolumeInfo *new_info = g_new0 (BDBtrfsSubvolumeInfo, 1);
 
     new_info->id = info->id;
     new_info->parent_id = info->parent_id;
@@ -123,7 +123,7 @@ typedef struct BDBtrfsFilesystemInfo {
  * Creates a new copy of @info.
  */
 BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info_copy (BDBtrfsFilesystemInfo *info) {
-    BDBtrfsFilesystemInfo *new_info = g_new (BDBtrfsFilesystemInfo, 1);
+    BDBtrfsFilesystemInfo *new_info = g_new0 (BDBtrfsFilesystemInfo, 1);
 
     new_info->label = g_strdup (info->label);
     new_info->uuid = g_strdup (info->uuid);

--- a/src/lib/plugin_apis/kbd.api
+++ b/src/lib/plugin_apis/kbd.api
@@ -87,6 +87,63 @@ GType bd_kbd_zram_stats_get_type () {
     return type;
 }
 
+#define BD_KBD_TYPE_BCACHE_STATS (bd_kbd_bcache_stats_get_type ())
+GType bd_kbd_bcache_stats_get_type();
+
+typedef struct BDKBDBcacheStats {
+    gchar *state;
+    guint64 block_size;
+    guint64 cache_size;
+    guint64 cache_used;
+    guint64 hits;
+    guint64 misses;
+    guint64 bypass_hits;
+    guint64 bypass_misses;
+} BDKBDBcacheStats;
+
+/**
+ * bd_kbd_bcache_stats_copy: (skip)
+ *
+ * Creates a new copy of @data.
+ */
+BDKBDBcacheStats* bd_kbd_bcache_stats_copy (BDKBDBcacheStats *data) {
+    BDKBDBcacheStats *new = g_new (BDKBDBcacheStats, 1);
+
+    new->state = g_strdup (data->state);
+    new->block_size = data->block_size;
+    new->cache_size = data->cache_size;
+    new->cache_used = data->cache_used;
+    new->hits = data->hits;
+    new->misses = data->misses;
+    new->bypass_hits = data->bypass_hits;
+    new->bypass_misses = data->bypass_misses;
+
+    return new;
+}
+
+/**
+ * bd_kbd_bcache_stats_free: (skip)
+ *
+ * Frees @data.
+ */
+void bd_kbd_bcache_stats_free (BDKBDBcacheStats *data) {
+    g_free (data->state);
+    g_free (data);
+}
+
+GType bd_kbd_bcache_stats_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDKBDBcacheStats",
+                                            (GBoxedCopyFunc) bd_kbd_bcache_stats_copy,
+                                            (GBoxedFreeFunc) bd_kbd_bcache_stats_free);
+    }
+
+    return type;
+}
+
+
 /**
  * bd_kbd_zram_create_devices:
  * @num_devices: number of devices to create
@@ -200,5 +257,15 @@ BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (gchar *mode_str, GError **error
  * Returns: whether the mode was successfully set or not
  */
 gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GError **error);
+
+/**
+ * bd_kbd_bcache_status:
+ * @bcache_device: bcache device to get status for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): status of the @bcache_device or %NULL in case of
+ *                           error (@error is set)
+ */
+BDKBDBcacheStats* bd_kbd_bcache_status (gchar *bcache_device, GError **error);
 
 #endif  /* BD_KBD_API */

--- a/src/lib/plugin_apis/kbd.api
+++ b/src/lib/plugin_apis/kbd.api
@@ -30,4 +30,45 @@ gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint6
  */
 gboolean bd_kbd_zram_destroy_devices (GError **error);
 
+/**
+ * bd_kbd_bcache_create:
+ * @backing_device: backing (slow) device of the cache
+ * @cache_device: cache (fast) device of the cache
+ * @bcache_device: (out) (allow-none): place to store the name of the new bcache device (if any)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the bcache device was successfully created or not
+ */
+gboolean bd_kbd_bcache_create (gchar *backing_device, gchar *cache_device, gchar **bcache_device, GError **error);
+
+/**
+ * bd_kbd_bcache_attach:
+ * @c_set_uuid: cache set UUID of the cache to attach
+ * @bcache_device: bcache device to attach @c_set_uuid cache to
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @c_set_uuid cache was successfully attached to @bcache_device or not
+ */
+gboolean bd_kbd_bcache_attach (gchar *c_set_uuid, gchar *bcache_device, GError **error);
+
+/**
+ * bd_kbd_bcache_detach:
+ * @bcache_device: bcache device to detach the cache from
+ * @c_set_uuid: (out) (allow-none) (transfer full): cache set UUID of the detached cache
+ * @error: (out): place to store error (if any)
+ * Returns: whether the bcache device @bcache_device was successfully destroyed or not
+ *
+ * Note: Flushes the cache first.
+ */
+gboolean bd_kbd_bcache_detach (gchar *bcache_device, gchar **c_set_uuid, GError **error);
+
+/**
+ * bd_kbd_bcache_destroy:
+ * @bcache_device: bcache device to destroy
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the bcache device @bcache_device was successfully destroyed or not
+ */
+gboolean bd_kbd_bcache_destroy (gchar *bcache_device, GError **error);
+
 #endif  /* BD_KBD_API */

--- a/src/lib/plugin_apis/kbd.api
+++ b/src/lib/plugin_apis/kbd.api
@@ -3,6 +3,66 @@
 #ifndef BD_KBD_API
 #define BD_KBD_API
 
+#define BD_KBD_TYPE_ZRAM_STATS (bd_kbd_zram_stats_get_type ())
+GType bd_kbd_zram_stats_get_type();
+
+/* see zRAM kernel documentation for details */
+typedef struct BDKBDZramStats {
+    guint64 disksize;
+    guint64 num_reads;
+    guint64 num_writes;
+    guint64 invalid_io;
+    guint64 zero_pages;
+    guint64 max_comp_streams;
+    gchar* comp_algorithm;
+    guint64 orig_data_size;
+    guint64 compr_data_size;
+    guint64 mem_used_total;
+} BDKBDZramStats;
+
+/**
+ * bd_kbd_zram_stats_copy: (skip)
+ *
+ * Creates a new copy of @data.
+ */
+BDKBDZramStats* bd_kbd_zram_stats_copy (BDKBDZramStats *data) {
+    BDKBDZramStats *new = g_new (BDKBDZramStats, 1);
+    new->disksize = data->disksize;
+    new->num_reads = data->num_reads;
+    new->num_writes = data->num_writes;
+    new->invalid_io = data->invalid_io;
+    new->zero_pages = data->zero_pages;
+    new->max_comp_streams = data->max_comp_streams;
+    new->comp_algorithm = g_strdup (data->comp_algorithm);
+    new->orig_data_size = data->orig_data_size;
+    new->compr_data_size = data->compr_data_size;
+    new->mem_used_total = data->mem_used_total;
+
+    return new;
+}
+
+/**
+ * bd_kbd_zram_stats_free: (skip)
+ *
+ * Frees @data.
+ */
+void bd_kbd_zram_stats_free (BDKBDZramStats *data) {
+    g_free (data->comp_algorithm);
+    g_free (data);
+}
+
+GType bd_kbd_zram_stats_get_type () {
+    static GType type = 0;
+
+    if (G_UNLIKELY(type == 0)) {
+        type = g_boxed_type_register_static("BDKBDZramStats",
+                                            (GBoxedCopyFunc) bd_kbd_zram_stats_copy,
+                                            (GBoxedFreeFunc) bd_kbd_zram_stats_free);
+    }
+
+    return type;
+}
+
 /**
  * bd_kbd_zram_create_devices:
  * @num_devices: number of devices to create
@@ -29,6 +89,15 @@ gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint6
  * specification of which devices should be destroyed.
  */
 gboolean bd_kbd_zram_destroy_devices (GError **error);
+
+/**
+ * bd_kbd_zram_get_stats:
+ * @device: zRAM device to get stats for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): statistics for the zRAM device
+ */
+BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error);
 
 /**
  * bd_kbd_bcache_create:

--- a/src/lib/plugin_apis/kbd.api
+++ b/src/lib/plugin_apis/kbd.api
@@ -3,6 +3,30 @@
 #ifndef BD_KBD_API
 #define BD_KBD_API
 
+#define BD_KBD_ERROR bd_kbd_error_quark ()
+typedef enum {
+    BD_KBD_ERROR_KMOD_INIT_FAIL,
+    BD_KBD_ERROR_MODULE_FAIL,
+    BD_KBD_ERROR_MODULE_NOEXIST,
+    BD_KBD_ERROR_ZRAM_NOEXIST,
+    BD_KBD_ERROR_ZRAM_INVAL,
+    BD_KBD_ERROR_BCACHE_PARSE,
+    BD_KBD_ERROR_BCACHE_SETUP_FAIL,
+    BD_KBD_ERROR_BCACHE_DETACH_FAIL,
+    BD_KBD_ERROR_BCACHE_NOT_ATTACHED,
+    BD_KBD_ERROR_BCACHE_UUID,
+    BD_KBD_ERROR_BCACHE_MODE_FAIL,
+    BD_KBD_ERROR_BCACHE_MODE_INVAL,
+} BDKBDError;
+
+typedef enum {
+    BD_KBD_MODE_WRITETHROUGH,
+    BD_KBD_MODE_WRITEBACK,
+    BD_KBD_MODE_WRITEAROUND,
+    BD_KBD_MODE_NONE,
+    BD_KBD_MODE_UNKNOWN,
+} BDKBDBcacheMode;
+
 #define BD_KBD_TYPE_ZRAM_STATS (bd_kbd_zram_stats_get_type ())
 GType bd_kbd_zram_stats_get_type();
 
@@ -139,5 +163,42 @@ gboolean bd_kbd_bcache_detach (gchar *bcache_device, gchar **c_set_uuid, GError 
  * Returns: whether the bcache device @bcache_device was successfully destroyed or not
  */
 gboolean bd_kbd_bcache_destroy (gchar *bcache_device, GError **error);
+
+/**
+ * bd_kbd_bcache_get_mode:
+ * @bcache_device: device to get mode of
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: current mode of the @bcache_device
+ */
+BDKBDBcacheMode bd_kbd_bcache_get_mode (gchar *bcache_device, GError **error);
+
+/**
+ * bd_kbd_bcache_get_mode_str:
+ * @mode: mode to get string representation of
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer none): string representation of @mode or %NULL in case of error
+ */
+const gchar* bd_kbd_bcache_get_mode_str (BDKBDBcacheMode mode, GError **error);
+
+/**
+ * bd_kbd_bcache_get_mode_from_str:
+ * @mode_str: string representation of mode
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: mode matching the @mode_str given or %BD_KBD_MODE_UNKNOWN in case of no match
+ */
+BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (gchar *mode_str, GError **error);
+
+/**
+ * bd_kbd_bcache_set_mode:
+ * @bcache_device: bcache device to set mode of
+ * @mode: mode to set
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the mode was successfully set or not
+ */
+gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GError **error);
 
 #endif  /* BD_KBD_API */

--- a/src/lib/plugin_apis/kbd.api
+++ b/src/lib/plugin_apis/kbd.api
@@ -50,7 +50,7 @@ typedef struct BDKBDZramStats {
  * Creates a new copy of @data.
  */
 BDKBDZramStats* bd_kbd_zram_stats_copy (BDKBDZramStats *data) {
-    BDKBDZramStats *new = g_new (BDKBDZramStats, 1);
+    BDKBDZramStats *new = g_new0 (BDKBDZramStats, 1);
     new->disksize = data->disksize;
     new->num_reads = data->num_reads;
     new->num_writes = data->num_writes;
@@ -107,7 +107,7 @@ typedef struct BDKBDBcacheStats {
  * Creates a new copy of @data.
  */
 BDKBDBcacheStats* bd_kbd_bcache_stats_copy (BDKBDBcacheStats *data) {
-    BDKBDBcacheStats *new = g_new (BDKBDBcacheStats, 1);
+    BDKBDBcacheStats *new = g_new0 (BDKBDBcacheStats, 1);
 
     new->state = g_strdup (data->state);
     new->block_size = data->block_size;

--- a/src/lib/plugin_apis/kbd.api
+++ b/src/lib/plugin_apis/kbd.api
@@ -1,0 +1,6 @@
+#include <glib.h>
+
+#ifndef BD_KBD_API
+#define BD_KBD_API
+
+#endif  /* BD_KBD_API */

--- a/src/lib/plugin_apis/kbd.api
+++ b/src/lib/plugin_apis/kbd.api
@@ -3,4 +3,19 @@
 #ifndef BD_KBD_API
 #define BD_KBD_API
 
+/**
+ * bd_kbd_zram_create_devices:
+ * @num_devices: number of devices to create
+ * @sizes: (array zero-terminated=1): requested sizes (in bytes) for created zRAM
+ *                                    devices
+ * @nstreams: (allow-none) (array zero-terminated=1): numbers of streams for created
+ *                                                    zRAM devices
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether @num_devices zRAM devices were successfully created or not
+ *
+ * **Lengths of @size and @nstreams (if given) have to be >= @num_devices!**
+ */
+gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error);
+
 #endif  /* BD_KBD_API */

--- a/src/lib/plugin_apis/kbd.api
+++ b/src/lib/plugin_apis/kbd.api
@@ -268,4 +268,27 @@ gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GEr
  */
 BDKBDBcacheStats* bd_kbd_bcache_status (gchar *bcache_device, GError **error);
 
+/**
+ * bd_kbd_bcache_get_backing_device:
+ * @bcache_device: Bcache device to get the backing device for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): name of the backing device of the @bcache_device
+ *                           or %NULL if failed to determine (@error is populated)
+ */
+gchar* bd_kbd_bcache_get_backing_device (gchar *bcache_device, GError **error);
+
+/**
+ * bd_kbd_bcache_get_cache_device:
+ * @bcache_device: Bcache device to get the cache device for
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): name of the cache device of the @bcache_device
+ *                           or %NULL if failed to determine (@error is populated)
+ *
+ * Note: returns the name of the first cache device of @bcache_device (in case
+ *       there are more)
+ */
+gchar* bd_kbd_bcache_get_cache_device (gchar *bcache_device, GError **error);
+
 #endif  /* BD_KBD_API */

--- a/src/lib/plugin_apis/kbd.api
+++ b/src/lib/plugin_apis/kbd.api
@@ -18,4 +18,16 @@
  */
 gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error);
 
+/**
+ * bd_kbd_zram_destroy_devices:
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether zRAM devices were successfully destroyed or not
+ *
+ * The only way how to destroy zRAM device right now is to unload the 'zram'
+ * module and thus destroy all of them. That's why this function doesn't allow
+ * specification of which devices should be destroyed.
+ */
+gboolean bd_kbd_zram_destroy_devices (GError **error);
+
 #endif  /* BD_KBD_API */

--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -50,7 +50,7 @@ typedef struct BDLVMPVdata {
  * Creates a new copy of @data.
  */
 BDLVMPVdata* bd_lvm_pvdata_copy (BDLVMPVdata *data) {
-    BDLVMPVdata *new_data = g_new (BDLVMPVdata, 1);
+    BDLVMPVdata *new_data = g_new0 (BDLVMPVdata, 1);
 
     new_data->pv_name = g_strdup (data->pv_name);
     new_data->pv_uuid = g_strdup (data->pv_uuid);
@@ -110,7 +110,7 @@ typedef struct BDLVMVGdata {
  * Creates a new copy of @data.
  */
 BDLVMVGdata* bd_lvm_vgdata_copy (BDLVMVGdata *data) {
-    BDLVMVGdata *new_data = g_new (BDLVMVGdata, 1);
+    BDLVMVGdata *new_data = g_new0 (BDLVMVGdata, 1);
 
     new_data->name = g_strdup (data->name);
     new_data->uuid = g_strdup (data->uuid);
@@ -165,7 +165,7 @@ typedef struct BDLVMLVdata {
  * Creates a new copy of @data.
  */
 BDLVMLVdata* bd_lvm_lvdata_copy (BDLVMLVdata *data) {
-    BDLVMLVdata *new_data = g_new (BDLVMLVdata, 1);
+    BDLVMLVdata *new_data = g_new0 (BDLVMLVdata, 1);
 
     new_data->lv_name = g_strdup (data->lv_name);
     new_data->vg_name = g_strdup (data->vg_name);

--- a/src/lib/plugin_apis/mdraid.api
+++ b/src/lib/plugin_apis/mdraid.api
@@ -38,7 +38,7 @@ typedef struct BDMDExamineData {
  * Creates a new copy of @data.
  */
 BDMDExamineData* bd_md_examine_data_copy (BDMDExamineData *data) {
-    BDMDExamineData *new_data = g_new (BDMDExamineData, 1);
+    BDMDExamineData *new_data = g_new0 (BDMDExamineData, 1);
 
     new_data->device = g_strdup (data->device);
     new_data->level = g_strdup (data->level);
@@ -107,7 +107,7 @@ typedef struct BDMDDetailData {
  * Creates a new copy of @data.
  */
 BDMDDetailData* bd_md_detail_data_copy (BDMDDetailData *data) {
-    BDMDDetailData *new_data = g_new (BDMDDetailData, 1);
+    BDMDDetailData *new_data = g_new0 (BDMDDetailData, 1);
 
     new_data->device = g_strdup (data->device);
     new_data->name = g_strdup (data->name);

--- a/src/lib/plugins.c
+++ b/src/lib/plugins.c
@@ -15,7 +15,7 @@
  * Creates a new copy of @spec.
  */
 BDPluginSpec* bd_plugin_spec_copy (BDPluginSpec *spec) {
-    BDPluginSpec *new_spec = g_new (BDPluginSpec, 1);
+    BDPluginSpec *new_spec = g_new0 (BDPluginSpec, 1);
 
     new_spec->name = spec->name;
     new_spec->so_name = g_strdup (spec->so_name);

--- a/src/lib/plugins.h
+++ b/src/lib/plugins.h
@@ -13,6 +13,7 @@ typedef enum {
     BD_PLUGIN_MPATH,
     BD_PLUGIN_DM,
     BD_PLUGIN_MDRAID,
+    BD_PLUGIN_KBD,
     BD_PLUGIN_UNDEF
 } BDPlugin;
 

--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -42,7 +42,7 @@ GQuark bd_btrfs_error_quark (void)
 }
 
 BDBtrfsDeviceInfo* bd_btrfs_device_info_copy (BDBtrfsDeviceInfo *info) {
-    BDBtrfsDeviceInfo *new_info = g_new (BDBtrfsDeviceInfo, 1);
+    BDBtrfsDeviceInfo *new_info = g_new0 (BDBtrfsDeviceInfo, 1);
 
     new_info->id = info->id;
     new_info->path = g_strdup (info->path);
@@ -58,7 +58,7 @@ void bd_btrfs_device_info_free (BDBtrfsDeviceInfo *info) {
 }
 
 BDBtrfsSubvolumeInfo* bd_btrfs_subvolume_info_copy (BDBtrfsSubvolumeInfo *info) {
-    BDBtrfsSubvolumeInfo *new_info = g_new (BDBtrfsSubvolumeInfo, 1);
+    BDBtrfsSubvolumeInfo *new_info = g_new0 (BDBtrfsSubvolumeInfo, 1);
 
     new_info->id = info->id;
     new_info->parent_id = info->parent_id;
@@ -73,7 +73,7 @@ void bd_btrfs_subvolume_info_free (BDBtrfsSubvolumeInfo *info) {
 }
 
 BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info_copy (BDBtrfsFilesystemInfo *info) {
-    BDBtrfsFilesystemInfo *new_info = g_new (BDBtrfsFilesystemInfo, 1);
+    BDBtrfsFilesystemInfo *new_info = g_new0 (BDBtrfsFilesystemInfo, 1);
 
     new_info->label = g_strdup (info->label);
     new_info->uuid = g_strdup (info->uuid);
@@ -209,7 +209,7 @@ gboolean bd_btrfs_create_volume (gchar **devices, gchar *label, gchar *data_leve
     if (md_level)
         num_args += 2;
 
-    argv = g_new (gchar*, num_args + 2);
+    argv = g_new0 (gchar*, num_args + 2);
     argv[0] = "mkfs.btrfs";
     if (label) {
         argv[next_arg] = "--label";
@@ -467,7 +467,7 @@ BDBtrfsDeviceInfo** bd_btrfs_list_devices (gchar *device, GError **error) {
     }
 
     /* now create the return value -- NULL-terminated array of BDBtrfsDeviceInfo */
-    ret = g_new (BDBtrfsDeviceInfo*, dev_infos->len + 1);
+    ret = g_new0 (BDBtrfsDeviceInfo*, dev_infos->len + 1);
     for (i=0; i < dev_infos->len; i++)
         ret[i] = (BDBtrfsDeviceInfo*) g_ptr_array_index (dev_infos, i);
     ret[i] = NULL;
@@ -549,7 +549,7 @@ BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (gchar *mountpoint, gboolean sna
     }
 
     /* now we know how much space to allocate for the result (subvols + NULL) */
-    ret = g_new (BDBtrfsSubvolumeInfo*, subvol_infos->len + 1);
+    ret = g_new0 (BDBtrfsSubvolumeInfo*, subvol_infos->len + 1);
 
     /* we need to sort the subvolumes in a way that no child subvolume appears
        in the list before its parent (sub)volume */

--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -67,7 +67,7 @@ gchar* bd_crypto_generate_backup_passphrase(GError **error __attribute__((unused
     guint8 charset_length = strlen (BD_CRYPTO_BACKUP_PASSPHRASE_CHARSET);
 
     /* passphrase with groups of 5 characters separated with dashes */
-    gchar *ret = g_new (gchar, BD_CRYPTO_BACKUP_PASSPHRASE_LENGTH + (BD_CRYPTO_BACKUP_PASSPHRASE_LENGTH / 5) - 1);
+    gchar *ret = g_new0 (gchar, BD_CRYPTO_BACKUP_PASSPHRASE_LENGTH + (BD_CRYPTO_BACKUP_PASSPHRASE_LENGTH / 5) - 1);
 
     for (i=0; i < BD_CRYPTO_BACKUP_PASSPHRASE_LENGTH; i++) {
         if (i > 0 && (i % 5 == 0)) {

--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -417,7 +417,7 @@ gchar** bd_dm_get_member_raid_sets (gchar *name, gchar *uuid, gint major, gint m
     }
 
     /* now create the return value -- NULL-terminated array of strings */
-    ret = g_new (gchar*, ret_sets->len + 1);
+    ret = g_new0 (gchar*, ret_sets->len + 1);
     for (i=0; i < ret_sets->len; i++)
         ret[i] = (gchar*) g_ptr_array_index (ret_sets, i);
     ret[i] = NULL;

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -20,6 +20,9 @@
 #include <libkmod.h>
 #include <string.h>
 #include <syslog.h>
+#include <glob.h>
+#include <unistd.h>
+#include <utils.h>
 
 #include "kbd.h"
 
@@ -252,4 +255,250 @@ gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint6
  */
 gboolean bd_kbd_zram_destroy_devices (GError **error) {
     return unload_kernel_module ("zram", error);
+}
+
+/**
+ * bd_kbd_bcache_create:
+ * @backing_device: backing (slow) device of the cache
+ * @cache_device: cache (fast) device of the cache
+ * @bcache_device: (out) (allow-none) (transfer full): place to store the name of the new bcache device (if any)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the bcache device was successfully created or not
+ */
+gboolean bd_kbd_bcache_create (gchar *backing_device, gchar *cache_device, gchar **bcache_device, GError **error) {
+    gchar *argv[6] = {"make-bcache", "-B", backing_device, "-C", cache_device, NULL};
+    gboolean success = FALSE;
+    gchar *output = NULL;
+    gchar **lines = NULL;
+    GRegex *regex = NULL;
+    GMatchInfo *match_info = NULL;
+    gchar *set_uuid = NULL;
+    guint i = 0;
+    gboolean found = FALSE;
+    glob_t globbuf;
+    gchar *pattern = NULL;
+    gchar *path = NULL;
+    gchar *dev_name = NULL;
+    gchar *dev_name_end = NULL;
+
+    /* create cache device metadata and try to get Set UUID (needed later) */
+    success = bd_utils_exec_and_capture_output (argv, &output, error);
+    if (!success) {
+        /* error is already populated */
+        g_free (output);
+        return FALSE;
+    }
+
+    lines = g_strsplit (output, "\n", 0);
+
+    regex = g_regex_new ("Set UUID:\\s+([-a-z0-9]+)", 0, 0, error);
+    if (!regex) {
+        /* error is already populated */
+        g_free (output);
+        g_strfreev (lines);
+        return FALSE;
+    }
+
+    for (i=0; !found && lines[i]; i++) {
+        success = g_regex_match (regex, lines[i], 0, &match_info);
+        if (success) {
+            found = TRUE;
+            set_uuid = g_match_info_fetch (match_info, 1);
+        }
+        g_match_info_free (match_info);
+    }
+    g_regex_unref (regex);
+    g_strfreev (lines);
+
+    if (!found) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_BCACHE_PARSE,
+                     "Failed to determine Set UUID from: %s", output);
+        g_free (output);
+        return FALSE;
+    }
+    g_free (output);
+
+
+    /* attach the cache device to the backing device */
+    /* get the name of the bcache device based on the @backing_device being its slave */
+    dev_name = strrchr (backing_device, '/');
+    if (!dev_name)
+        /* error is already populated */
+        return FALSE;
+    /* move right after the last '/' (that's where the device name starts) */
+    dev_name++;
+
+    /* make sure the bcache device is registered */
+    success = echo_str_to_file (backing_device, "/sys/fs/bcache/register", error);
+    if (!success)
+        /* error is already populated */
+        return FALSE;
+
+    pattern = g_strdup_printf ("/sys/block/*/slaves/%s", dev_name);
+    if (glob (pattern, GLOB_NOSORT, NULL, &globbuf) != 0) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_BCACHE_SETUP_FAIL,
+                     "Failed to determine bcache device name for '%s'", dev_name);
+        g_free (pattern);
+        return FALSE;
+    }
+    g_free (pattern);
+
+    /* get the first and only match */
+    path = (*globbuf.gl_pathv);
+
+    /* move three '/'s forward */
+    dev_name = path + 1;
+    for (i=0; i < 2 && dev_name; i++) {
+        dev_name = strchr (dev_name, '/');
+        dev_name = dev_name ? dev_name + 1: dev_name;
+    }
+    if (!dev_name) {
+        globfree (&globbuf);
+        return FALSE;
+    }
+    /* get everything till the next '/' */
+    dev_name_end = strchr (dev_name, '/');
+    dev_name = g_strndup (dev_name, (dev_name_end - dev_name));
+
+    globfree (&globbuf);
+
+    success = bd_kbd_bcache_attach (set_uuid, dev_name, error);
+    if (!success) {
+        g_prefix_error (error, "Failed to attach the cache to the backing device: ");
+        g_free (dev_name);
+        return FALSE;
+    }
+
+    if (bcache_device)
+        *bcache_device = dev_name;
+    else
+        g_free (dev_name);
+
+    return TRUE;
+}
+
+/**
+ * bd_kbd_bcache_attach:
+ * @c_set_uuid: cache set UUID of the cache to attach
+ * @bcache_device: bcache device to attach @c_set_uuid cache to
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @c_set_uuid cache was successfully attached to @bcache_device or not
+ */
+gboolean bd_kbd_bcache_attach (gchar *c_set_uuid, gchar *bcache_device, GError **error) {
+    gchar *path = NULL;
+    gboolean success = FALSE;
+
+    if (g_str_has_prefix (bcache_device, "/dev/"))
+        bcache_device += 5;
+
+    path = g_strdup_printf ("/sys/block/%s/bcache/attach", bcache_device);
+    success = echo_str_to_file (c_set_uuid, path, error);
+    g_free (path);
+
+    /* error is already populated (if any) */
+    return success;
+}
+
+/**
+ * bd_kbd_bcache_detach:
+ * @bcache_device: bcache device to detach the cache from
+ * @c_set_uuid: (out) (allow-none) (transfer full): cache set UUID of the detached cache
+ * @error: (out): place to store error (if any)
+ * Returns: whether the bcache device @bcache_device was successfully destroyed or not
+ *
+ * Note: Flushes the cache first.
+ */
+gboolean bd_kbd_bcache_detach (gchar *bcache_device, gchar **c_set_uuid, GError **error) {
+    gchar *path = NULL;
+    gchar *link = NULL;
+    gchar *uuid = NULL;
+    gboolean success = FALSE;
+
+    if (g_str_has_prefix (bcache_device, "/dev/"))
+        bcache_device += 5;
+
+    path = g_strdup_printf ("/sys/block/%s/bcache/cache", bcache_device);
+    if (access (path, R_OK) != 0) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_BCACHE_NOT_ATTACHED,
+                     "No cache attached to '%s' or '%s' not set up", bcache_device, bcache_device);
+        g_free (path);
+        return FALSE;
+    }
+
+    /* if existing, /sys/block/SOME_BCACHE/bcache/cache is a symlink to /sys/fs/bcache/C_SET_UUID */
+    link = g_file_read_link (path, error);
+    g_free (path);
+    if (!link) {
+        g_prefix_error (error, "Failed to determine cache set UUID for '%s'", bcache_device);
+        return FALSE;
+    }
+
+    /* find the last '/' */
+    uuid = strrchr (link, '/');
+    if (!uuid) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_BCACHE_UUID,
+                     "Failed to determine cache set UUID for '%s'", bcache_device);
+        g_free (link);
+        return FALSE;
+    }
+    /* move right after the '/' */
+    uuid++;
+
+    path = g_strdup_printf ("/sys/block/%s/bcache/detach", bcache_device);
+    success = echo_str_to_file (uuid, path, error);
+    if (!success) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_BCACHE_DETACH_FAIL,
+                     "Failed to detach '%s' from '%s'", uuid, bcache_device);
+        g_free (link);
+        g_free (path);
+        return FALSE;
+    }
+
+    if (c_set_uuid)
+        *c_set_uuid = g_strdup (uuid);
+
+    g_free (link);
+    g_free (path);
+    return TRUE;
+}
+
+/**
+ * bd_kbd_bcache_destroy:
+ * @bcache_device: bcache device to destroy
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the bcache device @bcache_device was successfully destroyed or not
+ */
+gboolean bd_kbd_bcache_destroy (gchar *bcache_device, GError **error) {
+    gchar *path = NULL;
+    gchar *c_set_uuid = NULL;
+    gboolean success = FALSE;
+
+    if (g_str_has_prefix (bcache_device, "/dev/"))
+        bcache_device += 5;
+
+    success = bd_kbd_bcache_detach (bcache_device, &c_set_uuid, error);
+    if (!success)
+        /* error is already populated */
+        return FALSE;
+
+    path = g_strdup_printf ("/sys/fs/bcache/%s/stop", c_set_uuid);
+    success = echo_str_to_file ("1", path, error);
+    g_free (path);
+    if (!success) {
+        g_prefix_error (error, "Failed to stop the cache set: ");
+        return FALSE;
+    }
+
+    path = g_strdup_printf ("/sys/block/%s/bcache/stop", bcache_device);
+    success = echo_str_to_file ("1", path, error);
+    g_free (path);
+    if (!success) {
+        g_prefix_error (error, "Failed to stop the bcache: ");
+        return FALSE;
+    }
+
+    return TRUE;
 }

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -382,9 +382,11 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
         g_free (path);
         return NULL;
     }
+    g_free (path);
 
     path = g_strdup_printf ("/sys/block/%s/disksize", device);
     ret->disksize = get_number_from_file (path, error);
+    g_free (path);
     if (*error) {
         g_clear_error (error);
         g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_ZRAM_INVAL,
@@ -395,6 +397,7 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
 
     path = g_strdup_printf ("/sys/block/%s/num_reads", device);
     ret->num_reads = get_number_from_file (path, error);
+    g_free (path);
     if (*error) {
         g_clear_error (error);
         g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_ZRAM_INVAL,
@@ -415,6 +418,7 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
 
     path = g_strdup_printf ("/sys/block/%s/invalid_io", device);
     ret->invalid_io = get_number_from_file (path, error);
+    g_free (path);
     if (*error) {
         g_clear_error (error);
         g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_ZRAM_INVAL,
@@ -425,6 +429,7 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
 
     path = g_strdup_printf ("/sys/block/%s/zero_pages", device);
     ret->zero_pages = get_number_from_file (path, error);
+    g_free (path);
     if (*error) {
         g_clear_error (error);
         g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_ZRAM_INVAL,
@@ -435,6 +440,7 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
 
     path = g_strdup_printf ("/sys/block/%s/max_comp_streams", device);
     ret->max_comp_streams = get_number_from_file (path, error);
+    g_free (path);
     if (*error) {
         g_clear_error (error);
         g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_ZRAM_INVAL,
@@ -445,6 +451,7 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
 
     path = g_strdup_printf ("/sys/block/%s/orig_data_size", device);
     ret->orig_data_size = get_number_from_file (path, error);
+    g_free (path);
     if (*error) {
         g_clear_error (error);
         g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_ZRAM_INVAL,
@@ -455,6 +462,7 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
 
     path = g_strdup_printf ("/sys/block/%s/compr_data_size", device);
     ret->compr_data_size = get_number_from_file (path, error);
+    g_free (path);
     if (*error) {
         g_clear_error (error);
         g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_ZRAM_INVAL,
@@ -465,6 +473,7 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
 
     path = g_strdup_printf ("/sys/block/%s/mem_used_total", device);
     ret->mem_used_total = get_number_from_file (path, error);
+    g_free (path);
     if (*error) {
         g_clear_error (error);
         g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_ZRAM_INVAL,
@@ -475,10 +484,12 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
 
     path = g_strdup_printf ("/sys/block/%s/comp_algorithm", device);
     success = g_file_get_contents (path, &(ret->comp_algorithm), NULL, error);
+    g_free (path);
     if (!success) {
         g_clear_error (error);
         g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_ZRAM_INVAL,
                      "Failed to get 'comp_algorithm' for '%s' zRAM device", device);
+        g_free (path);
         g_free (ret);
         return NULL;
     }

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -48,7 +48,7 @@ GQuark bd_kbd_error_quark (void)
 }
 
 BDKBDZramStats* bd_kbd_zram_stats_copy (BDKBDZramStats *data) {
-    BDKBDZramStats *new = g_new (BDKBDZramStats, 1);
+    BDKBDZramStats *new = g_new0 (BDKBDZramStats, 1);
     new->disksize = data->disksize;
     new->num_reads = data->num_reads;
     new->num_writes = data->num_writes;
@@ -69,7 +69,7 @@ void bd_kbd_zram_stats_free (BDKBDZramStats *data) {
 }
 
 BDKBDBcacheStats* bd_kbd_bcache_stats_copy (BDKBDBcacheStats *data) {
-    BDKBDBcacheStats *new = g_new (BDKBDBcacheStats, 1);
+    BDKBDBcacheStats *new = g_new0 (BDKBDBcacheStats, 1);
 
     new->state = g_strdup (data->state);
     new->block_size = data->block_size;
@@ -392,7 +392,7 @@ static guint64 get_number_from_file (gchar *path, GError **error) {
 BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
     gchar *path = NULL;
     gboolean success = FALSE;
-    BDKBDZramStats *ret = g_new (BDKBDZramStats, 1);
+    BDKBDZramStats *ret = g_new0 (BDKBDZramStats, 1);
 
     if (g_str_has_prefix (device, "/dev/"))
         device += 5;

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -234,3 +234,17 @@ gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint6
 
     return TRUE;
 }
+
+/**
+ * bd_kbd_zram_destroy_devices:
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether zRAM devices were successfully destroyed or not
+ *
+ * The only way how to destroy zRAM device right now is to unload the 'zram'
+ * module and thus destroy all of them. That's why this function doesn't allow
+ * specification of which devices should be destroyed.
+ */
+gboolean bd_kbd_zram_destroy_devices (GError **error) {
+    return unload_kernel_module ("zram", error);
+}

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -17,6 +17,12 @@
  * Author: Vratislav Podzimek <vpodzime@redhat.com>
  */
 
+#include <libkmod.h>
+#include <string.h>
+#include <syslog.h>
+
+#include "kbd.h"
+
 /**
  * SECTION: kbd
  * @short_description: plugin for operations with kernel block devices
@@ -26,4 +32,205 @@
  * A plugin for operations with kernel block devices.
  */
 
-/* nothing here yet */
+/**
+ * bd_kbd_error_quark: (skip)
+ */
+GQuark bd_kbd_error_quark (void)
+{
+    return g_quark_from_static_string ("g-bd-kbd-error-quark");
+}
+
+static gboolean load_kernel_module (gchar *module_name, gchar *options, GError **error) {
+    gint ret = 0;
+    struct kmod_ctx *ctx = NULL;
+    struct kmod_module *mod = NULL;
+    gchar *null_config = NULL;
+
+    ctx = kmod_new (NULL, (const gchar * const*) &null_config);
+    if (!ctx) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_KMOD_INIT_FAIL,
+                     "Failed to initialize kmod context");
+        return FALSE;
+    }
+    /* prevent libkmod from spamming our STDERR */
+    kmod_set_log_priority(ctx, LOG_CRIT);
+
+    ret = kmod_module_new_from_name (ctx, module_name, &mod);
+    if (ret < 0) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_MODULE_FAIL,
+                     "Failed to get the module: %s", strerror (-ret));
+        kmod_unref (ctx);
+        return FALSE;
+    }
+
+    if (!kmod_module_get_path (mod)) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_MODULE_NOEXIST,
+                     "Module '%s' doesn't exist", module_name);
+        kmod_module_unref (mod);
+        kmod_unref (ctx);
+        return FALSE;
+    }
+
+    /* module, flags, options */
+    ret = kmod_module_insert_module (mod, 0, options);
+    if (ret < 0) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_MODULE_FAIL,
+                     "Failed to load the module '%s' with options '%s': %s",
+                     module_name, options, strerror (-ret));
+        kmod_module_unref (mod);
+        kmod_unref (ctx);
+        return FALSE;
+    }
+
+    kmod_module_unref (mod);
+    kmod_unref (ctx);
+    return TRUE;
+}
+
+static gboolean unload_kernel_module (gchar *module_name, GError **error) {
+    gint ret = 0;
+    struct kmod_ctx *ctx = NULL;
+    struct kmod_module *mod = NULL;
+    struct kmod_list *list = NULL;
+    struct kmod_list *cur = NULL;
+    gchar *null_config = NULL;
+    gboolean found = FALSE;
+
+    ctx = kmod_new (NULL, (const gchar * const*) &null_config);
+    if (!ctx) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_KMOD_INIT_FAIL,
+                     "Failed to initialize kmod context");
+        return FALSE;
+    }
+    /* prevent libkmod from spamming our STDERR */
+    kmod_set_log_priority(ctx, LOG_CRIT);
+
+    ret = kmod_module_new_from_loaded (ctx, &list);
+    if (ret < 0) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_MODULE_FAIL,
+                     "Failed to get the module: %s", strerror (-ret));
+        kmod_unref (ctx);
+        return FALSE;
+    }
+
+    for (cur=list; !found && cur != NULL; cur = kmod_list_next(list, cur)) {
+        mod = kmod_module_get_module (cur);
+        if (g_strcmp0 (kmod_module_get_name (mod), module_name) == 0)
+            found = TRUE;
+        else
+            kmod_module_unref (mod);
+    }
+
+    if (!found) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_MODULE_NOEXIST,
+                     "Module '%s' is not loaded", module_name);
+        kmod_unref (ctx);
+        return FALSE;
+    }
+
+    /* module, flags */
+    ret = kmod_module_remove_module (mod, 0);
+    if (ret < 0) {
+        g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_MODULE_FAIL,
+                     "Failed to unload the module '%s': %s",
+                     module_name, strerror (-ret));
+        kmod_module_unref (mod);
+        kmod_unref (ctx);
+        return FALSE;
+    }
+
+    kmod_module_unref (mod);
+    kmod_unref (ctx);
+    return TRUE;
+}
+
+/**
+ * bd_kbd_zram_create_devices:
+ * @num_devices: number of devices to create
+ * @sizes: (array zero-terminated=1): requested sizes (in bytes) for created zRAM
+ *                                    devices
+ * @nstreams: (allow-none) (array zero-terminated=1): numbers of streams for created
+ *                                                    zRAM devices
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether @num_devices zRAM devices were successfully created or not
+ *
+ * **Lengths of @size and @nstreams (if given) have to be >= @num_devices!**
+ */
+gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error) {
+    gchar *opts = NULL;
+    gboolean success = FALSE;
+    guint64 i = 0;
+    gchar *num_str = NULL;
+    gchar *file_name = NULL;
+    GIOChannel *out_file = NULL;
+    gsize bytes_written = 0;
+
+    opts = g_strdup_printf ("num_devices=%"G_GUINT64_FORMAT, num_devices);
+    success = load_kernel_module ("zram", opts, error);
+
+    /* maybe it's loaded? Try to unload it first */
+    if (!success && g_error_matches (*error, BD_KBD_ERROR, BD_KBD_ERROR_MODULE_FAIL)) {
+        g_clear_error (error);
+        success = unload_kernel_module ("zram", error);
+        if (!success) {
+            g_prefix_error (error, "zram module already loaded: ");
+            g_free (opts);
+            return FALSE;
+        }
+        success = load_kernel_module ("zram", opts, error);
+        if (!success) {
+            g_free (opts);
+            return FALSE;
+        }
+    }
+    g_free (opts);
+
+    if (!success)
+        /* error is already populated */
+        return FALSE;
+
+    /* compression streams have to be specified before the device is activated
+       by setting its size */
+    if (nstreams)
+        for (i=0; i < num_devices; i++) {
+            file_name = g_strdup_printf ("/sys/block/zram%"G_GUINT64_FORMAT"/max_comp_streams", i);
+            num_str = g_strdup_printf ("%"G_GUINT64_FORMAT, nstreams[i]);
+            out_file = g_io_channel_new_file (file_name, "w", error);
+            g_free (file_name);
+            if (!out_file || g_io_channel_write_chars (out_file, num_str, -1, &bytes_written, error) != G_IO_STATUS_NORMAL) {
+                g_prefix_error (error, "Failed to set the number of compression streams: ");
+                g_free (num_str);
+                return FALSE;
+            }
+            g_free (num_str);
+            if (g_io_channel_shutdown (out_file, TRUE, error) != G_IO_STATUS_NORMAL) {
+                g_prefix_error (error, "Failed to set the number of compression streams: ");
+                g_io_channel_unref (out_file);
+                return FALSE;
+            }
+            g_io_channel_unref (out_file);
+        }
+
+    /* now activate the devices by setting their sizes */
+    for (i=0; i < num_devices; i++) {
+        file_name = g_strdup_printf ("/sys/block/zram%"G_GUINT64_FORMAT"/disksize", i);
+        num_str = g_strdup_printf ("%"G_GUINT64_FORMAT, sizes[i]);
+        out_file = g_io_channel_new_file (file_name, "w", error);
+        g_free (file_name);
+        if (!out_file || g_io_channel_write_chars (out_file, num_str, -1, &bytes_written, error) != G_IO_STATUS_NORMAL) {
+            g_prefix_error (error, "Failed to set the size for the device: ");
+            g_free (num_str);
+            return FALSE;
+        }
+        g_free (num_str);
+        if (g_io_channel_shutdown (out_file, TRUE, error) != G_IO_STATUS_NORMAL) {
+            g_prefix_error (error, "Failed to set the size for the device: ");
+            g_io_channel_unref (out_file);
+            return FALSE;
+        }
+        g_io_channel_unref (out_file);
+    }
+
+    return TRUE;
+}

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015  Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Vratislav Podzimek <vpodzime@redhat.com>
+ */
+
+/**
+ * SECTION: kbd
+ * @short_description: plugin for operations with kernel block devices
+ * @title: KernelBlockDevices
+ * @include: kbd.h
+ *
+ * A plugin for operations with kernel block devices.
+ */
+
+/* nothing here yet */

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -3,4 +3,14 @@
 #ifndef BD_KBD
 #define BD_KBD
 
+GQuark bd_kbd_error_quark (void);
+#define BD_KBD_ERROR bd_kbd_error_quark ()
+typedef enum {
+    BD_KBD_ERROR_KMOD_INIT_FAIL,
+    BD_KBD_ERROR_MODULE_FAIL,
+    BD_KBD_ERROR_MODULE_NOEXIST,
+} BDKBDError;
+
+gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error);
+
 #endif  /* BD_KBD */

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -9,9 +9,19 @@ typedef enum {
     BD_KBD_ERROR_KMOD_INIT_FAIL,
     BD_KBD_ERROR_MODULE_FAIL,
     BD_KBD_ERROR_MODULE_NOEXIST,
+    BD_KBD_ERROR_BCACHE_PARSE,
+    BD_KBD_ERROR_BCACHE_SETUP_FAIL,
+    BD_KBD_ERROR_BCACHE_DETACH_FAIL,
+    BD_KBD_ERROR_BCACHE_NOT_ATTACHED,
+    BD_KBD_ERROR_BCACHE_UUID,
 } BDKBDError;
 
 gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error);
 gboolean bd_kbd_zram_destroy_devices (GError **error);
+
+gboolean bd_kbd_bcache_create (gchar *backing_device, gchar *cache_device, gchar **bcache_device, GError **error);
+gboolean bd_kbd_bcache_attach (gchar *c_set_uuid, gchar *bcache_device, GError **error);
+gboolean bd_kbd_bcache_detach (gchar *bcache_device, gchar **c_set_uuid, GError **error);
+gboolean bd_kbd_bcache_destroy (gchar *bcache_device, GError **error);
 
 #endif  /* BD_KBD */

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -12,5 +12,6 @@ typedef enum {
 } BDKBDError;
 
 gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error);
+gboolean bd_kbd_zram_destroy_devices (GError **error);
 
 #endif  /* BD_KBD */

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -6,6 +6,7 @@
 GQuark bd_kbd_error_quark (void);
 #define BD_KBD_ERROR bd_kbd_error_quark ()
 typedef enum {
+    BD_KBD_ERROR_INVAL,
     BD_KBD_ERROR_KMOD_INIT_FAIL,
     BD_KBD_ERROR_MODULE_FAIL,
     BD_KBD_ERROR_MODULE_NOEXIST,
@@ -74,5 +75,7 @@ const gchar* bd_kbd_bcache_get_mode_str (BDKBDBcacheMode mode, GError **error);
 BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (gchar *mode_str, GError **error);
 gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GError **error);
 BDKBDBcacheStats* bd_kbd_bcache_status (gchar *bcache_device, GError **error);
+gchar* bd_kbd_bcache_get_backing_device (gchar *bcache_device, GError **error);
+gchar* bd_kbd_bcache_get_cache_device (gchar *bcache_device, GError **error);
 
 #endif  /* BD_KBD */

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -16,7 +16,17 @@ typedef enum {
     BD_KBD_ERROR_BCACHE_DETACH_FAIL,
     BD_KBD_ERROR_BCACHE_NOT_ATTACHED,
     BD_KBD_ERROR_BCACHE_UUID,
+    BD_KBD_ERROR_BCACHE_MODE_FAIL,
+    BD_KBD_ERROR_BCACHE_MODE_INVAL,
 } BDKBDError;
+
+typedef enum {
+    BD_KBD_MODE_WRITETHROUGH,
+    BD_KBD_MODE_WRITEBACK,
+    BD_KBD_MODE_WRITEAROUND,
+    BD_KBD_MODE_NONE,
+    BD_KBD_MODE_UNKNOWN,
+} BDKBDBcacheMode;
 
 /* see zRAM kernel documentation for details */
 typedef struct BDKBDZramStats {
@@ -44,5 +54,9 @@ gboolean bd_kbd_bcache_create (gchar *backing_device, gchar *cache_device, gchar
 gboolean bd_kbd_bcache_attach (gchar *c_set_uuid, gchar *bcache_device, GError **error);
 gboolean bd_kbd_bcache_detach (gchar *bcache_device, gchar **c_set_uuid, GError **error);
 gboolean bd_kbd_bcache_destroy (gchar *bcache_device, GError **error);
+BDKBDBcacheMode bd_kbd_bcache_get_mode (gchar *bcache_device, GError **error);
+const gchar* bd_kbd_bcache_get_mode_str (BDKBDBcacheMode mode, GError **error);
+BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (gchar *mode_str, GError **error);
+gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GError **error);
 
 #endif  /* BD_KBD */

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -9,6 +9,8 @@ typedef enum {
     BD_KBD_ERROR_KMOD_INIT_FAIL,
     BD_KBD_ERROR_MODULE_FAIL,
     BD_KBD_ERROR_MODULE_NOEXIST,
+    BD_KBD_ERROR_ZRAM_NOEXIST,
+    BD_KBD_ERROR_ZRAM_INVAL,
     BD_KBD_ERROR_BCACHE_PARSE,
     BD_KBD_ERROR_BCACHE_SETUP_FAIL,
     BD_KBD_ERROR_BCACHE_DETACH_FAIL,
@@ -16,8 +18,27 @@ typedef enum {
     BD_KBD_ERROR_BCACHE_UUID,
 } BDKBDError;
 
+/* see zRAM kernel documentation for details */
+typedef struct BDKBDZramStats {
+    guint64 disksize;
+    guint64 num_reads;
+    guint64 num_writes;
+    guint64 invalid_io;
+    guint64 zero_pages;
+    guint64 max_comp_streams;
+    gchar* comp_algorithm;
+    guint64 orig_data_size;
+    guint64 compr_data_size;
+    guint64 mem_used_total;
+} BDKBDZramStats;
+
+BDKBDZramStats* bd_kbd_zram_stats_copy (BDKBDZramStats *data);
+void bd_kbd_zram_stats_free (BDKBDZramStats *data);
+
+
 gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error);
 gboolean bd_kbd_zram_destroy_devices (GError **error);
+BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error);
 
 gboolean bd_kbd_bcache_create (gchar *backing_device, gchar *cache_device, gchar **bcache_device, GError **error);
 gboolean bd_kbd_bcache_attach (gchar *c_set_uuid, gchar *bcache_device, GError **error);

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -1,0 +1,6 @@
+#include <glib.h>
+
+#ifndef BD_KBD
+#define BD_KBD
+
+#endif  /* BD_KBD */

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -18,6 +18,8 @@ typedef enum {
     BD_KBD_ERROR_BCACHE_UUID,
     BD_KBD_ERROR_BCACHE_MODE_FAIL,
     BD_KBD_ERROR_BCACHE_MODE_INVAL,
+    BD_KBD_ERROR_BCACHE_NOEXIST,
+    BD_KBD_ERROR_BCACHE_INVAL,
 } BDKBDError;
 
 typedef enum {
@@ -45,6 +47,19 @@ typedef struct BDKBDZramStats {
 BDKBDZramStats* bd_kbd_zram_stats_copy (BDKBDZramStats *data);
 void bd_kbd_zram_stats_free (BDKBDZramStats *data);
 
+typedef struct BDKBDBcacheStats {
+    gchar *state;
+    guint64 block_size;
+    guint64 cache_size;
+    guint64 cache_used;
+    guint64 hits;
+    guint64 misses;
+    guint64 bypass_hits;
+    guint64 bypass_misses;
+} BDKBDBcacheStats;
+
+BDKBDBcacheStats* bd_kbd_bcache_stats_copy (BDKBDBcacheStats *data);
+void bd_kbd_bcache_stats_free (BDKBDBcacheStats *data);
 
 gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error);
 gboolean bd_kbd_zram_destroy_devices (GError **error);
@@ -58,5 +73,6 @@ BDKBDBcacheMode bd_kbd_bcache_get_mode (gchar *bcache_device, GError **error);
 const gchar* bd_kbd_bcache_get_mode_str (BDKBDBcacheMode mode, GError **error);
 BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (gchar *mode_str, GError **error);
 gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GError **error);
+BDKBDBcacheStats* bd_kbd_bcache_status (gchar *bcache_device, GError **error);
 
 #endif  /* BD_KBD */

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -47,7 +47,7 @@ GQuark bd_lvm_error_quark (void)
 }
 
 BDLVMPVdata* bd_lvm_pvdata_copy (BDLVMPVdata *data) {
-    BDLVMPVdata *new_data = g_new (BDLVMPVdata, 1);
+    BDLVMPVdata *new_data = g_new0 (BDLVMPVdata, 1);
 
     new_data->pv_name = g_strdup (data->pv_name);
     new_data->pv_uuid = g_strdup (data->pv_uuid);
@@ -71,7 +71,7 @@ void bd_lvm_pvdata_free (BDLVMPVdata *data) {
 }
 
 BDLVMVGdata* bd_lvm_vgdata_copy (BDLVMVGdata *data) {
-    BDLVMVGdata *new_data = g_new (BDLVMVGdata, 1);
+    BDLVMVGdata *new_data = g_new0 (BDLVMVGdata, 1);
 
     new_data->name = g_strdup (data->name);
     new_data->uuid = g_strdup (data->uuid);
@@ -91,7 +91,7 @@ void bd_lvm_vgdata_free (BDLVMVGdata *data) {
 }
 
 BDLVMLVdata* bd_lvm_lvdata_copy (BDLVMLVdata *data) {
-    BDLVMLVdata *new_data = g_new (BDLVMLVdata, 1);
+    BDLVMLVdata *new_data = g_new0 (BDLVMLVdata, 1);
 
     new_data->lv_name = g_strdup (data->lv_name);
     new_data->vg_name = g_strdup (data->vg_name);
@@ -146,7 +146,7 @@ static gboolean call_lvm_and_report_error (gchar **args, GError **error) {
     g_mutex_lock (&global_config_lock);
 
     /* allocate enough space for the args plus "lvm", "--config" and NULL */
-    gchar **argv = g_new (gchar*, args_length + 3);
+    gchar **argv = g_new0 (gchar*, args_length + 3);
 
     /* construct argv from args with "lvm" prepended */
     argv[0] = "lvm";
@@ -172,7 +172,7 @@ static gboolean call_lvm_and_capture_output (gchar **args, gchar **output, GErro
     g_mutex_lock (&global_config_lock);
 
     /* allocate enough space for the args plus "lvm", "--config" and NULL */
-    gchar **argv = g_new (gchar*, args_length + 3);
+    gchar **argv = g_new0 (gchar*, args_length + 3);
 
     /* construct argv from args with "lvm" prepended */
     argv[0] = "lvm";
@@ -222,7 +222,7 @@ static GHashTable* parse_lvm_vars (gchar *str, guint *num_items) {
 }
 
 static BDLVMPVdata* get_pv_data_from_table (GHashTable *table, gboolean free_table) {
-    BDLVMPVdata *data = g_new (BDLVMPVdata, 1);
+    BDLVMPVdata *data = g_new0 (BDLVMPVdata, 1);
     gchar *value = NULL;
 
     data->pv_name = g_strdup ((gchar*) g_hash_table_lookup (table, "LVM2_PV_NAME"));
@@ -280,7 +280,7 @@ static BDLVMPVdata* get_pv_data_from_table (GHashTable *table, gboolean free_tab
 }
 
 static BDLVMVGdata* get_vg_data_from_table (GHashTable *table, gboolean free_table) {
-    BDLVMVGdata *data = g_new (BDLVMVGdata, 1);
+    BDLVMVGdata *data = g_new0 (BDLVMVGdata, 1);
     gchar *value = NULL;
 
     data->name = g_strdup (g_hash_table_lookup (table, "LVM2_VG_NAME"));
@@ -329,7 +329,7 @@ static BDLVMVGdata* get_vg_data_from_table (GHashTable *table, gboolean free_tab
 }
 
 static BDLVMLVdata* get_lv_data_from_table (GHashTable *table, gboolean free_table) {
-    BDLVMLVdata *data = g_new (BDLVMLVdata, 1);
+    BDLVMLVdata *data = g_new0 (BDLVMLVdata, 1);
     gchar *value = NULL;
 
     data->lv_name = g_strdup (g_hash_table_lookup (table, "LVM2_LV_NAME"));
@@ -372,7 +372,7 @@ guint64 *bd_lvm_get_supported_pe_sizes (GError **error __attribute__((unused))) 
     guint8 i;
     guint64 val = BD_LVM_MIN_PE_SIZE;
     guint8 num_items = ((guint8) round (log2 ((double) BD_LVM_MAX_PE_SIZE))) - ((guint8) round (log2 ((double) BD_LVM_MIN_PE_SIZE))) + 2;
-    guint64 *ret = g_new (guint64, num_items);
+    guint64 *ret = g_new0 (guint64, num_items);
 
     for (i=0; (val <= BD_LVM_MAX_PE_SIZE); i++, val = val * 2)
         ret[i] = val;
@@ -698,7 +698,7 @@ BDLVMPVdata** bd_lvm_pvs (GError **error) {
         if (g_error_matches (*error, BD_UTILS_EXEC_ERROR, BD_UTILS_EXEC_ERROR_NOOUT)) {
             /* no output => no VGs, not an error */
             g_clear_error (error);
-            ret = g_new (BDLVMPVdata*, 1);
+            ret = g_new0 (BDLVMPVdata*, 1);
             ret[0] = NULL;
             return ret;
         }
@@ -731,7 +731,7 @@ BDLVMPVdata** bd_lvm_pvs (GError **error) {
     }
 
     /* now create the return value -- NULL-terminated array of BDLVMPVdata */
-    ret = g_new (BDLVMPVdata*, pvs->len + 1);
+    ret = g_new0 (BDLVMPVdata*, pvs->len + 1);
     for (i=0; i < pvs->len; i++)
         ret[i] = (BDLVMPVdata*) g_ptr_array_index (pvs, i);
     ret[i] = NULL;
@@ -753,7 +753,7 @@ BDLVMPVdata** bd_lvm_pvs (GError **error) {
 gboolean bd_lvm_vgcreate (gchar *name, gchar **pv_list, guint64 pe_size, GError **error) {
     guint8 i = 0;
     guint8 pv_list_len = pv_list ? g_strv_length (pv_list) : 0;
-    gchar **argv = g_new (gchar*, pv_list_len + 5);
+    gchar **argv = g_new0 (gchar*, pv_list_len + 5);
     pe_size = RESOLVE_PE_SIZE (pe_size);
     gboolean success = FALSE;
 
@@ -925,7 +925,7 @@ BDLVMVGdata** bd_lvm_vgs (GError **error) {
         if (g_error_matches (*error, BD_UTILS_EXEC_ERROR, BD_UTILS_EXEC_ERROR_NOOUT)) {
             /* no output => no VGs, not an error */
             g_clear_error (error);
-            ret = g_new (BDLVMVGdata*, 1);
+            ret = g_new0 (BDLVMVGdata*, 1);
             ret[0] = NULL;
             return ret;
         }
@@ -958,7 +958,7 @@ BDLVMVGdata** bd_lvm_vgs (GError **error) {
     }
 
     /* now create the return value -- NULL-terminated array of BDLVMVGdata */
-    ret = g_new (BDLVMVGdata*, vgs->len + 1);
+    ret = g_new0 (BDLVMVGdata*, vgs->len + 1);
     for (i=0; i < vgs->len; i++)
         ret[i] = (BDLVMVGdata*) g_ptr_array_index (vgs, i);
     ret[i] = NULL;
@@ -1006,7 +1006,7 @@ gchar* bd_lvm_lvorigin (gchar *vg_name, gchar *lv_name, GError **error) {
  */
 gboolean bd_lvm_lvcreate (gchar *vg_name, gchar *lv_name, guint64 size, gchar **pv_list, GError **error) {
     guint8 pv_list_len = pv_list ? g_strv_length (pv_list) : 0;
-    gchar **args = g_new (gchar*, pv_list_len + 8);
+    gchar **args = g_new0 (gchar*, pv_list_len + 8);
     gboolean success = FALSE;
     guint8 i = 0;
 
@@ -1256,7 +1256,7 @@ BDLVMLVdata** bd_lvm_lvs (gchar *vg_name, GError **error) {
         if (g_error_matches (*error, BD_UTILS_EXEC_ERROR, BD_UTILS_EXEC_ERROR_NOOUT)) {
             /* no output => no LVs, not an error */
             g_clear_error (error);
-            ret = g_new (BDLVMLVdata*, 1);
+            ret = g_new0 (BDLVMLVdata*, 1);
             ret[0] = NULL;
             return ret;
         }
@@ -1289,7 +1289,7 @@ BDLVMLVdata** bd_lvm_lvs (gchar *vg_name, GError **error) {
     }
 
     /* now create the return value -- NULL-terminated array of BDLVMLVdata */
-    ret = g_new (BDLVMLVdata*, lvs->len + 1);
+    ret = g_new0 (BDLVMLVdata*, lvs->len + 1);
     for (i=0; i < lvs->len; i++)
         ret[i] = (BDLVMLVdata*) g_ptr_array_index (lvs, i);
     ret[i] = NULL;

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -49,7 +49,7 @@ GQuark bd_md_error_quark (void)
  * Creates a new copy of @data.
  */
 BDMDExamineData* bd_md_examine_data_copy (BDMDExamineData *data) {
-    BDMDExamineData *new_data = g_new (BDMDExamineData, 1);
+    BDMDExamineData *new_data = g_new0 (BDMDExamineData, 1);
 
     new_data->device = g_strdup (data->device);
     new_data->level = g_strdup (data->level);
@@ -85,7 +85,7 @@ void bd_md_examine_data_free (BDMDExamineData *data) {
  * Creates a new copy of @data.
  */
 BDMDDetailData* bd_md_detail_data_copy (BDMDDetailData *data) {
-    BDMDDetailData *new_data = g_new (BDMDDetailData, 1);
+    BDMDDetailData *new_data = g_new0 (BDMDDetailData, 1);
 
     new_data->device = g_strdup (data->device);
     new_data->name = g_strdup (data->name);
@@ -171,7 +171,7 @@ static GHashTable* parse_mdadm_vars (gchar *str, gchar *item_sep, gchar *key_val
 }
 
 static BDMDExamineData* get_examine_data_from_table (GHashTable *table, gboolean free_table, GError **error) {
-    BDMDExamineData *data = g_new (BDMDExamineData, 1);
+    BDMDExamineData *data = g_new0 (BDMDExamineData, 1);
     gchar *value = NULL;
 
     data->level = g_strdup ((gchar*) g_hash_table_lookup (table, "MD_LEVEL"));
@@ -219,7 +219,7 @@ static BDMDExamineData* get_examine_data_from_table (GHashTable *table, gboolean
 }
 
 static BDMDDetailData* get_detail_data_from_table (GHashTable *table, gboolean free_table) {
-    BDMDDetailData *data = g_new (BDMDDetailData, 1);
+    BDMDDetailData *data = g_new0 (BDMDDetailData, 1);
     gchar *value = NULL;
     gchar *first_space = NULL;
 
@@ -363,7 +363,7 @@ gboolean bd_md_create (gchar *device_name, gchar *level, gchar **disks, guint64 
     num_disks = g_strv_length (disks);
     argv_len += num_disks;
 
-    argv = g_new (gchar*, argv_len + 1);
+    argv = g_new0 (gchar*, argv_len + 1);
 
     level_str = g_strdup_printf ("--level=%s", level);
     rdevices_str = g_strdup_printf ("--raid-devices=%"G_GUINT64_FORMAT, (num_disks - spares));
@@ -459,11 +459,11 @@ gboolean bd_md_activate (gchar *device_name, gchar **members, gchar *uuid, GErro
 
     /* mdadm, --assemble, device_name, --run, --uuid=uuid, member1, member2,..., NULL*/
     if (uuid) {
-        argv = g_new (gchar*, num_members + 6);
+        argv = g_new0 (gchar*, num_members + 6);
         uuid_str = g_strdup_printf ("--uuid=%s", uuid);
     }
     else
-        argv = g_new (gchar*, num_members + 5);
+        argv = g_new0 (gchar*, num_members + 5);
 
     argv[argv_top++] = "mdadm";
     argv[argv_top++] = "--assemble";
@@ -790,7 +790,7 @@ BDMDDetailData* bd_md_detail (gchar *raid_name, GError **error) {
  */
 gchar* bd_md_canonicalize_uuid (gchar *uuid, GError **error) {
     gchar *next_set = uuid;
-    gchar *ret = g_new (gchar, 37);
+    gchar *ret = g_new0 (gchar, 37);
     gchar *dest = ret;
     GRegex *regex = NULL;
 
@@ -860,7 +860,7 @@ gchar* bd_md_canonicalize_uuid (gchar *uuid, GError **error) {
  */
 gchar* bd_md_get_md_uuid (gchar *uuid, GError **error) {
     gchar *next_set = uuid;
-    gchar *ret = g_new (gchar, 37);
+    gchar *ret = g_new0 (gchar, 37);
     gchar *dest = ret;
     GRegex *regex = NULL;
 

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -45,6 +45,7 @@ bd_plugins = { "lvm": BlockDev.Plugin.LVM,
                "swap": BlockDev.Plugin.SWAP,
                "mdraid": BlockDev.Plugin.MDRAID,
                "mpath": BlockDev.Plugin.MPATH,
+               "kbd": BlockDev.Plugin.KBD,
 }
 
 _init = BlockDev.init

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -259,6 +259,13 @@ def swap_swapon(device, priority=-1):
 __all__.append("swap_swapon")
 
 
+_kbd_zram_create_devices = BlockDev.kbd_zram_create_devices
+@override(BlockDev.kbd_zram_create_devices)
+def kbd_zram_create_devices(num_devices, sizes, nstreams=None):
+    return _kbd_zram_create_devices(num_devices, sizes, nstreams)
+__all__.append("kbd_zram_create_devices")
+
+
 ## defined in this overrides only!
 def plugin_specs_from_names(plugin_names):
     ret = []

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -432,6 +432,10 @@ class SwapError(BlockDevError):
     pass
 __all__.append("SwapError")
 
+class KbdError(BlockDevError):
+    pass
+__all__.append("KbdError")
+
 class UtilsError(BlockDevError):
     pass
 __all__.append("UtilsError")
@@ -465,6 +469,9 @@ __all__.append("mpath")
 
 swap = ErrorProxy("swap", BlockDev, [(GLib.Error, SwapError)], [not_implemented_rule])
 __all__.append("swap")
+
+kbd = ErrorProxy("kbd", BlockDev, [(GLib.Error, KbdError)], [not_implemented_rule])
+__all__.append("kbd")
 
 utils = ErrorProxy("utils", BlockDev, [(GLib.Error, UtilsError)])
 __all__.append("utils")

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -282,6 +282,34 @@ class KbdTestBcacheGetSetMode(KbdBcacheTestCase):
 
         wipe_all(self.loop_dev, self.loop_dev2)
 
+class KbdTestBcacheStatusTest(KbdBcacheTestCase):
+    @unittest.skipIf("SKIP_SLOW" in os.environ, "skipping slow tests")
+    def test_bcache_status(self):
+        succ, dev = BlockDev.kbd_bcache_create(self.loop_dev, self.loop_dev2)
+        self.assertTrue(succ)
+        self.assertTrue(dev)
+        self.bcache_dev = dev
+        time.sleep(10)
+
+        # should work with both "bcacheX" and "/dev/bcacheX"
+        status = BlockDev.kbd_bcache_status(self.bcache_dev)
+        self.assertTrue(status)
+        status = BlockDev.kbd_bcache_status("/dev/" + self.bcache_dev)
+        self.assertTrue(status)
+
+        # check some basic values (default block size is 512)
+        self.assertTrue(status.state)
+        self.assertEqual(status.state, "clean")
+        self.assertEqual(status.block_size, 512)
+        self.assertGreater(status.cache_size, 0)
+
+        succ = BlockDev.kbd_bcache_destroy(self.bcache_dev)
+        self.assertTrue(succ)
+        self.bcache_dev = None
+        time.sleep(1)
+
+        wipe_all(self.loop_dev, self.loop_dev2)
+
 class KbdUnloadTest(unittest.TestCase):
     def tearDown(self):
         # make sure the library is initialized with all plugins loaded for other

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -339,6 +339,28 @@ class KbdTestBcacheStatusTest(KbdBcacheTestCase):
 
         wipe_all(self.loop_dev, self.loop_dev2)
 
+class KbdTestBcacheBackingCacheDevTest(KbdBcacheTestCase):
+    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
+    def test_bcache_backing_cache_dev(self):
+        """Verify that is is possible to get the backing and cache devices for a Bcache"""
+
+        succ, dev = BlockDev.kbd_bcache_create(self.loop_dev, self.loop_dev2)
+        self.assertTrue(succ)
+        self.assertTrue(dev)
+        self.bcache_dev = dev
+
+        _wait_for_bcache_setup(dev)
+
+        self.assertEqual("/dev/" + BlockDev.kbd_bcache_get_backing_device(self.bcache_dev), self.loop_dev)
+        self.assertEqual("/dev/" + BlockDev.kbd_bcache_get_cache_device(self.bcache_dev), self.loop_dev2)
+
+        succ = BlockDev.kbd_bcache_destroy(self.bcache_dev)
+        self.assertTrue(succ)
+        self.bcache_dev = None
+        time.sleep(1)
+
+        wipe_all(self.loop_dev, self.loop_dev2)
+
 class KbdUnloadTest(unittest.TestCase):
     def tearDown(self):
         # make sure the library is initialized with all plugins loaded for other

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -47,12 +47,14 @@ class KbdZRAMTestCase(unittest.TestCase):
             self.assertTrue(BlockDev.kbd_zram_create_devices(2, [10 * 1024**2, 10 * 1024**2], [1, 2]))
             time.sleep(1)
             self.assertTrue(BlockDev.kbd_zram_destroy_devices())
+            time.sleep(1)
 
         # no nstreams specified
         with _track_module_load(self, "zram", "_loaded_zram_module"):
             self.assertTrue(BlockDev.kbd_zram_create_devices(2, [10 * 1024**2, 10 * 1024**2], None))
             time.sleep(1)
             self.assertTrue(BlockDev.kbd_zram_destroy_devices())
+            time.sleep(1)
 
         # with module pre-loaded, but unsed
         self.assertEqual(os.system("modprobe zram num_devices=2"), 0)
@@ -61,6 +63,7 @@ class KbdZRAMTestCase(unittest.TestCase):
             self.assertTrue(BlockDev.kbd_zram_create_devices(2, [10 * 1024**2, 10 * 1024**2], [1, 1]))
             time.sleep(1)
             self.assertTrue(BlockDev.kbd_zram_destroy_devices())
+            time.sleep(1)
 
         # with module pre-loaded, and devices used (as active swaps)
         self.assertEqual(os.system("modprobe zram num_devices=2"), 0)
@@ -81,6 +84,7 @@ class KbdZRAMTestCase(unittest.TestCase):
             self.assertTrue(BlockDev.kbd_zram_create_devices(2, [10 * 1024**2, 10 * 1024**2], [1, 1]))
             time.sleep(1)
             self.assertTrue(BlockDev.kbd_zram_destroy_devices())
+            time.sleep(1)
 
 class KbdZRAMStatsTestCase(KbdZRAMTestCase):
     @unittest.skipUnless(_can_load_zram(), "cannot load the 'zram' module")
@@ -169,7 +173,7 @@ class KbdTestBcacheCreate(KbdBcacheTestCase):
         self.assertTrue(succ)
         self.assertTrue(dev)
         self.bcache_dev = dev
-        time.sleep(5)
+        time.sleep(10)
 
         succ = BlockDev.kbd_bcache_destroy(self.bcache_dev)
         self.assertTrue(succ)
@@ -186,7 +190,7 @@ class KbdTestBcacheCreate(KbdBcacheTestCase):
         self.assertTrue(succ)
         self.assertTrue(dev)
         self.bcache_dev = dev
-        time.sleep(5)
+        time.sleep(10)
 
         succ = BlockDev.kbd_bcache_destroy("/dev/" + self.bcache_dev)
         self.assertTrue(succ)
@@ -203,7 +207,7 @@ class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
         self.assertTrue(succ)
         self.assertTrue(dev)
         self.bcache_dev = dev
-        time.sleep(5)
+        time.sleep(10)
 
         succ, c_set_uuid = BlockDev.kbd_bcache_detach(self.bcache_dev)
         self.assertTrue(succ)
@@ -227,7 +231,7 @@ class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
         self.assertTrue(succ)
         self.assertTrue(dev)
         self.bcache_dev = dev
-        time.sleep(5)
+        time.sleep(10)
 
         succ, c_set_uuid = BlockDev.kbd_bcache_detach("/dev/" + self.bcache_dev)
         self.assertTrue(succ)
@@ -252,7 +256,7 @@ class KbdTestBcacheGetSetMode(KbdBcacheTestCase):
         self.assertTrue(succ)
         self.assertTrue(dev)
         self.bcache_dev = dev
-        time.sleep(5)
+        time.sleep(10)
 
         mode = BlockDev.kbd_bcache_get_mode(self.bcache_dev)
         self.assertNotEqual(mode, BlockDev.KBDBcacheMode.UNKNOWN)

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -82,6 +82,30 @@ class KbdZRAMTestCase(unittest.TestCase):
             time.sleep(1)
             self.assertTrue(BlockDev.kbd_zram_destroy_devices())
 
+class KbdZRAMStatsTestCase(KbdZRAMTestCase):
+    @unittest.skipUnless(_can_load_zram(), "cannot load the 'zram' module")
+    def test_zram_get_stats(self):
+        """Verify that it is possible to get stats for a zram device"""
+
+        with _track_module_load(self, "zram", "_loaded_zram_module"):
+            self.assertTrue(BlockDev.kbd_zram_create_devices(1, [10 * 1024**2], [2]))
+            time.sleep(1)
+
+        # XXX: this needs to get more complex/serious
+        stats = BlockDev.kbd_zram_get_stats("zram0")
+        self.assertTrue(stats)
+
+        # /dev/zram0 should work too
+        stats = BlockDev.kbd_zram_get_stats("/dev/zram0")
+        self.assertTrue(stats)
+
+        self.assertEqual(stats.disksize, 10 * 1024**2)
+        self.assertEqual(stats.max_comp_streams, 2)
+        self.assertTrue(stats.comp_algorithm)
+
+        with _track_module_load(self, "zram", "_loaded_zram_module"):
+            self.assertTrue(BlockDev.kbd_zram_destroy_devices())
+
 class KbdBcacheTestCase(unittest.TestCase):
     def setUp(self):
         self.dev_file = create_sparse_tempfile("lvm_test", 10 * 1024**3)

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -1,0 +1,84 @@
+import unittest
+import os
+import time
+from contextlib import contextmanager
+import overrides_hack
+
+from gi.repository import BlockDev, GLib
+if not BlockDev.is_initialized():
+    BlockDev.init(None, None)
+
+def _can_load_zram():
+    """Test if we can load the zram module"""
+
+    if os.system("lsmod|grep zram >/dev/null") != 0:
+        # not loaded
+        return True
+    elif os.system("rmmod zram") == 0:
+        # successfully unloaded
+        return True
+    else:
+        # loaded and failed to unload
+        return False
+
+@contextmanager
+def _track_module_load(test_case, mod_name, loaded_attr):
+    setattr(test_case, loaded_attr, os.system("lsmod|grep %s > /dev/null" % mod_name) == 0)
+    try:
+        yield
+    finally:
+        setattr(test_case, loaded_attr, os.system("lsmod|grep %s > /dev/null" % mod_name) == 0)
+
+class KbdZRAMTestCase(unittest.TestCase):
+    def setUp(self):
+        self._loaded_zram_module = False
+
+    def tearDown(self):
+        # make sure we unload the module if we loaded it
+        if self._loaded_zram_module:
+            os.system("rmmod zram")
+
+    @unittest.skipUnless(_can_load_zram(), "cannot load the 'zram' module")
+    @unittest.skipIf("SKIP_SLOW" in os.environ, "skipping slow tests")
+    def test_create_destroy_devices(self):
+        # the easiest case
+        with _track_module_load(self, "zram", "_loaded_zram_module"):
+            self.assertTrue(BlockDev.kbd_zram_create_devices(2, [10 * 1024**2, 10 * 1024**2], [1, 2]))
+            time.sleep(1)
+            self.assertTrue(BlockDev.kbd_zram_destroy_devices())
+
+        # no nstreams specified
+        with _track_module_load(self, "zram", "_loaded_zram_module"):
+            self.assertTrue(BlockDev.kbd_zram_create_devices(2, [10 * 1024**2, 10 * 1024**2], None))
+            time.sleep(1)
+            self.assertTrue(BlockDev.kbd_zram_destroy_devices())
+
+        # with module pre-loaded, but unsed
+        self.assertEqual(os.system("modprobe zram num_devices=2"), 0)
+        time.sleep(1)
+        with _track_module_load(self, "zram", "_loaded_zram_module"):
+            self.assertTrue(BlockDev.kbd_zram_create_devices(2, [10 * 1024**2, 10 * 1024**2], [1, 1]))
+            time.sleep(1)
+            self.assertTrue(BlockDev.kbd_zram_destroy_devices())
+
+        # with module pre-loaded, and devices used (as active swaps)
+        self.assertEqual(os.system("modprobe zram num_devices=2"), 0)
+        self.assertEqual(os.system("echo 10M > /sys/class/block/zram0/disksize"), 0)
+        self.assertEqual(os.system("echo 10M > /sys/class/block/zram1/disksize"), 0)
+        time.sleep(1)
+        for zram_dev in ("/dev/zram0", "/dev/zram1"):
+            self.assertTrue(BlockDev.swap_mkswap(zram_dev, None))
+            self.assertTrue(BlockDev.swap_swapon(zram_dev, -1))
+        with _track_module_load(self, "zram", "_loaded_zram_module"):
+            with self.assertRaises(GLib.GError):
+                self.assertTrue(BlockDev.kbd_zram_create_devices(2, [10 * 1024**2, 10 * 1024**2], [1, 1]))
+            for zram_dev in ("/dev/zram0", "/dev/zram1"):
+                self.assertTrue(BlockDev.swap_swapoff(zram_dev))
+            self.assertEqual(os.system("rmmod zram"), 0)
+
+            # should work just fine now
+            self.assertTrue(BlockDev.kbd_zram_create_devices(2, [10 * 1024**2, 10 * 1024**2], [1, 1]))
+            time.sleep(1)
+            self.assertTrue(BlockDev.kbd_zram_destroy_devices())
+
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 from contextlib import contextmanager
+from itertools import chain
 
 from gi.repository import GLib
 
@@ -26,6 +27,10 @@ def create_sparse_file(path, size):
     fd = os.open(path, os.O_WRONLY|os.O_CREAT|os.O_TRUNC)
     os.ftruncate(fd, size)
     os.close(fd)
+
+def wipe_all(dev, *args):
+    for device in chain([dev], args):
+        os.system("wipefs -a %s &>/dev/null" % device)
 
 @contextmanager
 def udev_settle():


### PR DESCRIPTION
These commits implement the KernelBlockDevices plugin as it was planned before.

I'm sorry for the commit 09a61a2, but when I got to ``time.sleep(10)`` basically between every two lines of the ``bcache`` tests, I have up and just excluded the tests from normal runs. I run the myself as I know how to get the system back to the original state if some *bcache magic* happens.