### PR TITLE
Make the init functions better usable

### DIFF
--- a/src/lib/blockdev.c
+++ b/src/lib/blockdev.c
@@ -216,9 +216,11 @@ gboolean bd_init (BDPluginSpec **require_plugins, BDUtilsLogFunc log_func, GErro
         return FALSE;
     }
 
-    if (log_func && !bd_utils_init_logging (log_func, error))
+    if (log_func && !bd_utils_init_logging (log_func, error)) {
         /* the error is already populated */
-        success = FALSE;
+        g_mutex_unlock (&init_lock);
+        return FALSE;
+    }
 
     if (!load_plugins (require_plugins, FALSE, &num_loaded)) {
         g_set_error (error, BD_INIT_ERROR, BD_INIT_ERROR_PLUGINS_FAILED,
@@ -290,9 +292,11 @@ gboolean bd_ensure_init (BDPluginSpec **require_plugins, BDUtilsLogFunc log_func
         }
     }
 
-    if (log_func && !bd_utils_init_logging (log_func, error))
+    if (log_func && !bd_utils_init_logging (log_func, error)) {
         /* the error is already populated */
-        success = FALSE;
+        g_mutex_unlock (&init_lock);
+        return FALSE;
+    }
 
     if (!load_plugins (require_plugins, FALSE, &num_loaded)) {
         g_set_error (error, BD_INIT_ERROR, BD_INIT_ERROR_PLUGINS_FAILED,
@@ -345,9 +349,11 @@ gboolean bd_try_init(BDPluginSpec **request_plugins, BDUtilsLogFunc log_func,
         return FALSE;
     }
 
-    if (log_func && !bd_utils_init_logging (log_func, error))
+    if (log_func && !bd_utils_init_logging (log_func, error)) {
         /* the error is already populated */
-        success = FALSE;
+        g_mutex_unlock (&init_lock);
+        return FALSE;
+    }
 
     success = load_plugins (request_plugins, FALSE, &num_loaded);
 
@@ -390,9 +396,11 @@ gboolean bd_reinit (BDPluginSpec **require_plugins, gboolean reload, BDUtilsLogF
     guint64 num_loaded = 0;
 
     g_mutex_lock (&init_lock);
-    if (log_func && !bd_utils_init_logging (log_func, error))
+    if (log_func && !bd_utils_init_logging (log_func, error)) {
         /* the error is already populated */
-        success = FALSE;
+        g_mutex_unlock (&init_lock);
+        return FALSE;
+    }
 
     if (!load_plugins (require_plugins, reload, &num_loaded)) {
         g_set_error (error, BD_INIT_ERROR, BD_INIT_ERROR_PLUGINS_FAILED,
@@ -444,9 +452,11 @@ gboolean bd_try_reinit (BDPluginSpec **require_plugins, gboolean reload, BDUtils
     guint64 num_loaded = 0;
 
     g_mutex_lock (&init_lock);
-    if (log_func && !bd_utils_init_logging (log_func, error))
+    if (log_func && !bd_utils_init_logging (log_func, error)) {
         /* the error is already populated */
-        success = FALSE;
+        g_mutex_unlock (&init_lock);
+        return FALSE;
+    }
 
     success = load_plugins (require_plugins, reload, &num_loaded);
     if (success && require_plugins && (*require_plugins == NULL) && reload)

--- a/src/lib/blockdev.c
+++ b/src/lib/blockdev.c
@@ -272,12 +272,18 @@ gboolean bd_ensure_init (BDPluginSpec **require_plugins, BDUtilsLogFunc log_func
     BDPluginSpec **check_plugin = NULL;
     gboolean missing = FALSE;
     guint64 num_loaded = 0;
+    BDPlugin plugin = BD_PLUGIN_UNDEF;
 
     g_mutex_lock (&init_lock);
     if (initialized) {
         if (require_plugins)
             for (check_plugin=require_plugins; !missing && *check_plugin; check_plugin++)
                 missing = !bd_is_plugin_available((*check_plugin)->name);
+        else
+            /* all plugins requested */
+            for (plugin=BD_PLUGIN_LVM; plugin != BD_PLUGIN_UNDEF; plugin++)
+                missing = !bd_is_plugin_available(plugin);
+
         if (!missing) {
             g_mutex_unlock (&init_lock);
             return TRUE;

--- a/src/lib/blockdev.c
+++ b/src/lib/blockdev.c
@@ -340,7 +340,7 @@ gboolean bd_reinit (BDPluginSpec **require_plugins, gboolean reload, BDUtilsLogF
         /* the error is already populated */
         success = FALSE;
 
-    if (!load_plugins (require_plugins, FALSE, &num_loaded)) {
+    if (!load_plugins (require_plugins, reload, &num_loaded)) {
         g_set_error (error, BD_INIT_ERROR, BD_INIT_ERROR_PLUGINS_FAILED,
                      "Failed to load plugins");
         success = FALSE;

--- a/src/lib/blockdev.h
+++ b/src/lib/blockdev.h
@@ -19,6 +19,10 @@ typedef enum {
 gboolean bd_init (BDPluginSpec **require_plugins, BDUtilsLogFunc log_func, GError **error);
 gboolean bd_ensure_init (BDPluginSpec **require_plugins, BDUtilsLogFunc log_func, GError **error);
 gboolean bd_reinit (BDPluginSpec **require_plugins, gboolean reload, BDUtilsLogFunc log_func, GError **error);
+gboolean bd_try_init(BDPluginSpec **request_plugins, BDUtilsLogFunc log_func,
+                     gchar ***loaded_plugin_names, GError **error);
+gboolean bd_try_reinit (BDPluginSpec **require_plugins, gboolean reload, BDUtilsLogFunc log_func,
+                        gchar ***loaded_plugin_names, GError **error);
 gboolean bd_is_initialized ();
 
 #endif  /* BD_LIB */

--- a/src/lib/blockdev.h
+++ b/src/lib/blockdev.h
@@ -17,7 +17,7 @@ typedef enum {
 } BDInitError;
 
 gboolean bd_init (BDPluginSpec **require_plugins, BDUtilsLogFunc log_func, GError **error);
-gboolean bd_try_init (BDPluginSpec **require_plugins, BDUtilsLogFunc log_func, GError **error);
+gboolean bd_ensure_init (BDPluginSpec **require_plugins, BDUtilsLogFunc log_func, GError **error);
 gboolean bd_reinit (BDPluginSpec **require_plugins, gboolean reload, BDUtilsLogFunc log_func, GError **error);
 gboolean bd_is_initialized ();
 

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -61,6 +61,17 @@ def reinit(require_plugins=None, reload=False, log_func=None):
     return _reinit(require_plugins, reload, log_func)
 __all__.append("reinit")
 
+_try_init = BlockDev.try_init
+@override(BlockDev.try_init)
+def try_init(require_plugins=None, log_func=None):
+    return _try_init(require_plugins, log_func)
+__all__.append("try_init")
+
+_try_reinit = BlockDev.try_reinit
+@override(BlockDev.try_reinit)
+def try_reinit(require_plugins=None, reload=True, log_func=None):
+    return _try_reinit(require_plugins, reload, log_func)
+__all__.append("try_reinit")
 
 _btrfs_create_volume = BlockDev.btrfs_create_volume
 @override(BlockDev.btrfs_create_volume)


### PR DESCRIPTION
This tries to address the issue #15 by renaming the ``try_init()`` function to ``ensure_init()`` which is a better name for what it does and by adding new ``try_init()`` and ``try_reinit()`` functions that do "best-effort" plugin loading and report back the list of loaded plugins.