### PR TITLE
Filter the python files from automatic rpm requires

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -25,6 +25,13 @@ BuildRequires: kmod-devel
 BuildRequires: s390utils-devel
 %endif
 
+# Do not check the python directories for automatic Requires
+# The python gi.overrides files automatically add python(abi) entries to
+# the rpm Requires, but this is backwards. Anything using libblockdev from
+# python will require python, but libblockdev will work just fine without
+# python.
+%global __requires_exclude_from ^(%{python2_sitearch}|%{python3_sitearch})/gi/overrides/.*$
+
 
 %description
 The libblockdev is a C library with GObject introspection support that can be


### PR DESCRIPTION
The libblockdev python bindings don't really require python. Programs
using libblockdev via the python bindings require python. Remove the
gi.overrides files from autorequires so that the main libblockdev
package can contain all it needs for gobject-introspection bindings
without adding python-abi dependencies.