### PR TITLE
Makefile updates

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,26 +12,39 @@ MAINTAINERCLEANFILES = Makefile.in aclocal.m4 config.guess config.sub \
 LIBDIRS = src/utils/.libs:src/plugins/.libs:src/lib/.libs
 GIDIR = src/lib
 
+PYTHON ?= python2
+COVERAGE ?= coverage
+
 run-ipython: all
 	GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=src/python G_MESSAGES_DEBUG=all ipython
 
 run-root-ipython: all
 	sudo GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=src/python G_MESSAGES_DEBUG=all ipython
 
-test: all
+check: all
 	pylint -E src/python/gi/overrides/BlockDev.py
+
+test: all check
 	@sudo GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
-		python -m unittest discover -v -s tests/ -p '*_test.py'
+		$(PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
 
-fast-test: all
-	pylint -E src/python/gi/overrides/BlockDev.py
+fast-test: all check
 	@sudo SKIP_SLOW= GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
-		python -m unittest discover -v -s tests/ -p '*_test.py'
+		$(PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
 
-test-all: all
-	pylint -E src/python/gi/overrides/BlockDev.py
+test-all: all check
 	@sudo FEELINGLUCKY= GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
-		python -m unittest discover -v -s tests/ -p '*_test.py'
+		$(PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
+
+coverage: all
+	@sudo GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
+		$(COVERAGE) run --branch -m unittest discover -v -s tests/ -p '*_test.py'
+		$(COVERAGE) report --show-missing --include="src/*"
+
+coverage-all: all
+	@sudo FEELING_LUCKY= GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
+		$(COVERAGE) run --branch -m unittest discover -v -s tests/ -p '*_test.py'
+		$(COVERAGE) report --show-missing --include="src/*"
 
 tag:
 	@TAG="$(PACKAGE_NAME)-$(PACKAGE_VERSION)-1" ; \

--- a/docs/libblockdev-docs.xml.in
+++ b/docs/libblockdev-docs.xml.in
@@ -83,6 +83,15 @@ cat dist/libblockdev.spec.in | grep BuildRequires: | cut -f2 -d: | cut -f2 -d' '
     </para>
 
     <para>
+      To execute the Pylint code analysis tool run:
+
+      <screen><userinput>make check</userinput></screen>
+
+      The check target is a dependency of all test targets and you don't have to
+      execute it explicitly when testing.
+    </para>
+
+    <para>
       To execute the test suite from inside the source directory run one of these
       commands:
 
@@ -98,6 +107,28 @@ cat dist/libblockdev.spec.in | grep BuildRequires: | cut -f2 -d: | cut -f2 -d' '
 
       executes all tests, including ones which may result in kernel panic or
       take more time to complete.
+    </para>
+
+    <para>
+      It is also possible to generate test coverage reports using the Python coverage
+      tool:
+
+      <screen><userinput>make coverage</userinput></screen>
+
+      is equivalent to `make test'.
+
+      <screen><userinput>make coverage-all</userinput></screen>
+
+      is equivalent to `make test-all'.
+    </para>
+
+    <para>
+      libblockdev also supports running the test and coverage targets using Python3.
+      To do this define the PYTHON or COVERAGE variables respectively. For example:
+
+      <screen><userinput>make PYTHON=python3 test</userinput></screen>
+
+      <screen><userinput>make COVERAGE=coverage3 coverage</userinput></screen>
     </para>
   </chapter>
 


### PR DESCRIPTION
Makefile.am:
  - add separate check target - previously this was repeated in all the test targets
  - add coverage targets - makes it possible to use the Python coverage tool to generate reports
  - make it possible to test with Python3 - just use variables instead of binary names so it is possible to override them on the command line.

Add description of these new Makefile targets to the docs as well.