### PR TITLE
tests: use LANG=C in test_backup_passphrase()

### DIFF
--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -364,7 +364,11 @@ class CryptoTestEscrow(CryptoTestCase):
             self.assertTrue(os.path.isfile(escrow_backup_passphrase))
 
             # Check that the encrypted file contains what we put in
-            passphrase = subprocess.check_output(['volume_key', '--secrets', '-d', self.nss_dir, escrow_backup_passphrase])
+            env = os.environ
+            env.update({"LC_ALL": "C"})
+            passphrase = subprocess.check_output(
+                    ['volume_key', '--secrets', '-d', self.nss_dir, escrow_backup_passphrase],
+                    env=env)
             passphrase = passphrase.strip().split()[1]
             self.assertEquals(passphrase, backup_passphrase)
 


### PR DESCRIPTION
Otherwise I get this failure:

```
======================================================================
FAIL: test_backup_passphrase (crypto_test.CryptoTestEscrow)
Verify that a backup passphrase can be created for a device
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/www/html/libblockdev/tests/crypto_test.py", line 369, in test_backup_passphrase
    self.assertEquals(passphrase, backup_passphrase)
AssertionError: '\xd1\x84\xd1\x80\xd0\xb0\xd0\xb7\xd0\xb0:' != '0j/l5-bvVJ5-2Nj8R-1QH3x'
```

My terminal uses LANG=bg_BG.utf8 by default