### PR TITLE
BTRFS: fix parsing empty partition label

### DIFF
--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -598,7 +598,7 @@ BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info (gchar *device, GError **error) 
     gchar *argv[5] = {"btrfs", "filesystem", "show", device, NULL};
     gchar *output = NULL;
     gboolean success = FALSE;
-    gchar const * const pattern = "Label:\\s+'(?P<label>\\S+)'\\s+" \
+    gchar const * const pattern = "Label:\\s+(none|'(?P<label>\\S+)')\\s+" \
                                   "uuid:\\s+(?P<uuid>\\S+)\\s+" \
                                   "Total\\sdevices\\s+(?P<num_devices>\\d+)\\s+" \
                                   "FS\\sbytes\\sused\\s+(?P<used>\\S+)";

--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -336,6 +336,21 @@ class BtrfsTestFilesystemInfo(BtrfsTestCase):
         self.assertEqual(info.num_devices, 1)
         self.assertTrue(info.used >= 0)
 
+class BtrfsTestFilesystemInfoNoLabel(BtrfsTestCase):
+    def test_filesystem_info(self):
+        """Verify that it is possible to get filesystem info for a volume with no label"""
+
+        succ = BlockDev.btrfs_create_volume([self.loop_dev], None, None, None)
+        self.assertTrue(succ)
+
+        mount(self.loop_dev, TEST_MNT)
+
+        info = BlockDev.btrfs_filesystem_info(TEST_MNT)
+        self.assertEqual(info.label, str())
+        self.assertTrue(info.uuid)
+        self.assertEqual(info.num_devices, 1)
+        self.assertTrue(info.used >= 0)
+
 class BtrfsTestMkfs(BtrfsTestCase):
     def test_mkfs(self):
         """Verify that it is possible to create a btrfs filesystem"""


### PR DESCRIPTION
Example of filesystem which can't be parsed by `bd_btrfs_filesystem_info()`:

```
# btrfs filesystem show /dev/sdc1
Label: none  uuid: 5dfd18e3-f676-401a-823a-9b5c6f27e08d
        Total devices 1 FS bytes used 112.00KiB
        devid    1 size 1.00GiB used 138.38MiB path /dev/sdc1

btrfs-progs v4.1
```

The patch allows the function to read **an empty** filesystem label.