### PR TITLE
Add a new makefile target that does everything needed for jenkins.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -83,3 +83,5 @@ rpm: local
 
 release: tag
 	$(MAKE) archive
+
+ci: test-all distcheck


### PR DESCRIPTION
We should have as much of the logic of how the CI tests are run in source
control as possible, so that's what this target is for.  Besides this, jenkins
just runs a "git clean" first.