### PR TITLE
BTRFS: allow an arbitrary label to be set for a btrfs volume

### DIFF
--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -598,7 +598,7 @@ BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info (gchar *device, GError **error) 
     gchar *argv[5] = {"btrfs", "filesystem", "show", device, NULL};
     gchar *output = NULL;
     gboolean success = FALSE;
-    gchar const * const pattern = "Label:\\s+(none|'(?P<label>\\S+)')\\s+" \
+    gchar const * const pattern = "Label:\\s+(none|'(?P<label>.+)')\\s+" \
                                   "uuid:\\s+(?P<uuid>\\S+)\\s+" \
                                   "Total\\sdevices\\s+(?P<num_devices>\\d+)\\s+" \
                                   "FS\\sbytes\\sused\\s+(?P<used>\\S+)";

--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -326,13 +326,15 @@ class BtrfsTestFilesystemInfo(BtrfsTestCase):
     def test_filesystem_info(self):
         """Verify that it is possible to get filesystem info"""
 
-        succ = BlockDev.btrfs_create_volume([self.loop_dev], "myShinyBtrfs", None, None)
+        label = "My 'Shiny' Btrfs"
+        succ = BlockDev.btrfs_create_volume([self.loop_dev], label, None, None)
         self.assertTrue(succ)
 
         mount(self.loop_dev, TEST_MNT)
 
         info = BlockDev.btrfs_filesystem_info(TEST_MNT)
-        self.assertEqual(info.label, "myShinyBtrfs")
+        self.assertTrue(info)
+        self.assertEqual(info.label, label)
         self.assertTrue(info.uuid)
         self.assertEqual(info.num_devices, 1)
         self.assertTrue(info.used >= 0)


### PR DESCRIPTION
Allow libblockdev to read info about filesystems with more complex labels.

This suggestion can't read multi-line labels, though; but is sufficient for any arbitrary one-line label.