### PR TITLE
Better document how MD RAID superblock size should be calculated

### DIFF
--- a/src/lib/plugin_apis/mdraid.api
+++ b/src/lib/plugin_apis/mdraid.api
@@ -157,14 +157,14 @@ GType bd_md_detail_data_get_type () {
 
 /**
  * bd_md_get_superblock_size:
- * @size: size of the array
+ * @member_size: size of an array member
  * @version: (allow-none): metadata version or %NULL to use the current default version
  * @error: (out): place to store error (if any)
  *
- * Returns: Calculated superblock size for given array @size and metadata @version
- * or default if unsupported @version is used.
+ * Returns: Calculated superblock size for an array with a given @member_size
+ * and metadata @version or default if unsupported @version is used.
  */
-guint64 bd_md_get_superblock_size (guint64 size, gchar *version, GError **error);
+guint64 bd_md_get_superblock_size (guint64 member_size, gchar *version, GError **error);
 
 /**
  * bd_md_create:

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -301,14 +301,14 @@ static BDMDDetailData* get_detail_data_from_table (GHashTable *table, gboolean f
 
 /**
  * bd_md_get_superblock_size:
- * @size: size of the array
+ * @member_size: size of an array member
  * @version: (allow-none): metadata version or %NULL to use the current default version
  * @error: (out): place to store error (if any)
  *
- * Returns: Calculated superblock size for given array @size and metadata @version
- * or default if unsupported @version is used.
+ * Returns: Calculated superblock size for an array with a given @member_size
+ * and metadata @version or default if unsupported @version is used.
  */
-guint64 bd_md_get_superblock_size (guint64 size, gchar *version, GError **error __attribute__((unused))) {
+guint64 bd_md_get_superblock_size (guint64 member_size, gchar *version, GError **error __attribute__((unused))) {
     guint64 headroom = BD_MD_SUPERBLOCK_SIZE;
     guint64 min_headroom = (1 MiB);
 
@@ -322,7 +322,7 @@ guint64 bd_md_get_superblock_size (guint64 size, gchar *version, GError **error 
          * MDADM: which is plenty for efficient reshapes
          * NOTE: In the mdadm code this is in 512b sectors. Converted to use MiB */
         headroom = (128 MiB);
-        while (((headroom << 10) > size) && (headroom > min_headroom))
+        while (((headroom << 10) > member_size) && (headroom > min_headroom))
             headroom >>= 1;
     }
 

--- a/src/plugins/mdraid.h
+++ b/src/plugins/mdraid.h
@@ -55,7 +55,7 @@ typedef struct BDMDDetailData {
 void bd_md_detail_data_free (BDMDDetailData *data);
 BDMDDetailData* bd_md_detail_data_copy (BDMDDetailData *data);
 
-guint64 bd_md_get_superblock_size (guint64 size, gchar *version, GError **error);
+guint64 bd_md_get_superblock_size (guint64 member_size, gchar *version, GError **error);
 gboolean bd_md_create (gchar *device_name, gchar *level, gchar **disks, guint64 spares, gchar *version, gboolean bitmap, GError **error);
 gboolean bd_md_destroy (gchar *device, GError **error);
 gboolean bd_md_deactivate (gchar *device_name, GError **error);


### PR DESCRIPTION
The superblock size should be calculated from an MD RAID member size not from
the size of the whole array. Make this clear in the bd_md_get_superblock_size()
function's documentation and size parameter name.