### PR TITLE
Fix the calculation of physical space taken by an LV

### DIFF
--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -456,12 +456,10 @@ guint64 bd_lvm_round_size_to_pe (guint64 size, guint64 pe_size, gboolean roundup
  * using given @pe_size.
  */
 guint64 bd_lvm_get_lv_physical_size (guint64 lv_size, guint64 pe_size, GError **error) {
-    /* TODO: should take into account mirroring and RAID in general? */
-
-    /* add one PE for metadata */
     pe_size = RESOLVE_PE_SIZE(pe_size);
 
-    return bd_lvm_round_size_to_pe (lv_size, pe_size, TRUE, error) + pe_size;
+    /* the LV just takes space rounded up the the a multiple of extent size */
+    return bd_lvm_round_size_to_pe (lv_size, pe_size, TRUE, error);
 }
 
 /**

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -76,14 +76,14 @@ class LvmNoDevTestCase(unittest.TestCase):
         """Verify that get_lv_physical_size works as expected"""
 
         self.assertEqual(BlockDev.lvm_get_lv_physical_size(25 * 1024**3, 4 * 1024**2),
-                         25 * 1024**3 + 4 * 1024**2)
+                         25 * 1024**3)
 
         # default PE size is 4 MiB
         self.assertEqual(BlockDev.lvm_get_lv_physical_size(25 * 1024**3, 0),
-                         25 * 1024**3 + 4 * 1024**2)
+                         25 * 1024**3)
 
         self.assertEqual(BlockDev.lvm_get_lv_physical_size(11 * 1024**2, 4 * 1024**2),
-                         16 * 1024**2)
+                         12 * 1024**2)
 
     def test_get_thpool_padding(self):
         """Verify that get_thpool_padding works as expected"""


### PR DESCRIPTION
If an LV is added to a VG, no extra meta data is allocated and it doesn't matter
at all if one or more of the VG's PVs are MD RAID devices or whatever, they are
just block devices. In the end we just need to make sure the LV size is rounded
up to the PE size.

Also update the tests accordingly.