### PR TITLE
Multiplugin config support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 ACLOCAL_AMFLAGS = -I m4
 DISTCHECK_CONFIGURE_FLAGS = --enable-introspection
 
-SUBDIRS = src docs dist scripts
+SUBDIRS = src docs dist scripts data
 
 dist_noinst_DATA = features.rst roadmap.rst specs.rst LICENSE
 
@@ -16,33 +16,33 @@ TEST_PYTHON ?= $(PYTHON)
 COVERAGE ?= coverage
 
 run-ipython: all
-	GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=src/python G_MESSAGES_DEBUG=all ipython
+	GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=src/python G_MESSAGES_DEBUG=all LIBBLOCKDEV_CONFIG_DIR=data/conf.d/ ipython
 
 run-root-ipython: all
-	sudo env GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=src/python G_MESSAGES_DEBUG=all ipython
+	sudo env GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=src/python G_MESSAGES_DEBUG=all LIBBLOCKDEV_CONFIG_DIR=data/conf.d/ ipython
 
 check: all
 	pylint -E src/python/gi/overrides/BlockDev.py
 
 test: all check
-	@sudo env GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
+	@sudo env GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python LIBBLOCKDEV_CONFIG_DIR=data/conf.d/ \
 		$(TEST_PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
 
 fast-test: all check
-	@sudo env SKIP_SLOW= GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
+	@sudo env SKIP_SLOW= GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python LIBBLOCKDEV_CONFIG_DIR=data/conf.d/ \
 		$(TEST_PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
 
 test-all: all check
-	@sudo env FEELINGLUCKY= GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
+	@sudo env FEELINGLUCKY= GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python LIBBLOCKDEV_CONFIG_DIR=data/conf.d/ \
 		$(TEST_PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
 
 coverage: all
-	@sudo env GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
+	@sudo env GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python LIBBLOCKDEV_CONFIG_DIR=data/conf.d/ \
 		$(COVERAGE) run --branch -m unittest discover -v -s tests/ -p '*_test.py'
 		$(COVERAGE) report --show-missing --include="src/*"
 
 coverage-all: all
-	@sudo env FEELING_LUCKY= GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
+	@sudo env FEELING_LUCKY= GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python LIBBLOCKDEV_CONFIG_DIR=data/conf.d/ \
 		$(COVERAGE) run --branch -m unittest discover -v -s tests/ -p '*_test.py'
 		$(COVERAGE) report --show-missing --include="src/*"
 

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,9 @@ AC_CONFIG_FILES([Makefile src/Makefile \
                           docs/libblockdev-docs.xml \
                           dist/Makefile \
                           dist/libblockdev.spec \
-                          scripts/Makefile])
+                          scripts/Makefile \
+                          data/Makefile \
+                          data/conf.d/Makefile])
 
 LIBBLOCKDEV_PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.42.2])
 LIBBLOCKDEV_PKG_CHECK_MODULES([CRYPTSETUP], [libcryptsetup >= 1.6.7])

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,0 +1,3 @@
+SUBDIRS = conf.d
+
+MAINTAINERCLEANFILES = Makefile.in

--- a/data/conf.d/00-default.cfg
+++ b/data/conf.d/00-default.cfg
@@ -1,0 +1,43 @@
+# This is the default configuration for the libblockdev library. For
+# each supported technology/plugin there is a separate section/group
+# with the 'sonames' key. The value of the key has to be a list of
+# sonames of shared objects that should be attempted to be loaded for
+# the plugin falling back to the next one in the list.
+#
+# So this example:
+# [lvm]
+# sonames=libbd_lvm-dbus.so.0;libbd_lvm.so.0
+#
+# would result in the libbd_lvm-dbus.so.0 shared object attempted to
+# be loaded and if that failed, the libbd_lvm.so.0 would be attempted
+# to be loaded.
+
+[btrfs]
+sonames=libbd_btrfs.so.0
+
+[crypto]
+sonames=libbd_crypto.so.0
+
+[dm]
+sonames=libbd_dm.so.0
+
+[kbd]
+sonames=libbd_kbd.so.0
+
+[loop]
+sonames=libbd_loop.so.0
+
+[lvm]
+sonames=libbd_lvm.so.0
+
+[mdraid]
+sonames=libbd_mdraid.so.0
+
+[mpath]
+sonames=libbd_mpath.so.0
+
+[swap]
+sonames=libbd_swap.so.0
+
+[s390]
+sonames=libbd_s390.so.0

--- a/data/conf.d/Makefile.am
+++ b/data/conf.d/Makefile.am
@@ -1,0 +1,4 @@
+libbdconfdir = $(sysconfdir)/libblockdev/conf.d
+dist_libbdconf_DATA = ${srcdir}/00-default.cfg
+
+MAINTAINERCLEANFILES = Makefile.in

--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -339,6 +339,7 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 %license LICENSE
 %{_libdir}/libblockdev.so.*
 %{_libdir}/girepository*/BlockDev*.typelib
+%config %{_sysconfdir}/libblockdev/conf.d/00-default.cfg
 %{python2_sitearch}/gi/overrides/*
 %{python3_sitearch}/gi/overrides/BlockDev*
 %{python3_sitearch}/gi/overrides/__pycache__/BlockDev*

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -258,7 +258,7 @@ bd_plugin_spec_copy
 bd_plugin_spec_free
 bd_is_plugin_available
 bd_get_available_plugin_names
-bd_func_available
+bd_get_plugin_soname
 <SUBSECTION Standard>
 BDPluginSpec
 BD_TYPE_PLUGIN_SPEC

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -5,7 +5,7 @@ SUBDIRS = plugin_apis
 lib_LTLIBRARIES = libblockdev.la
 libblockdev_la_CFLAGS = $(GLIB_CFLAGS)
 libblockdev_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la
-libblockdev_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0
+libblockdev_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1
 libblockdev_la_CPPFLAGS = -I${srcdir}/../utils/
 libblockdev_la_SOURCES = blockdev.c blockdev.h plugins.c plugins.h
 

--- a/src/lib/blockdev.c.in
+++ b/src/lib/blockdev.c.in
@@ -46,6 +46,8 @@ typedef struct BDPluginStatus {
     gpointer handle;
 } BDPluginStatus;
 
+typedef void* (*LoadFunc) (gchar *so_name);
+
 /* KEEP THE ORDERING OF THESE ARRAYS MATCHING THE BDPluginName ENUM! */
 static gchar * default_plugin_so[BD_PLUGIN_UNDEF] = {
     "libbd_lvm.so."@MAJOR_VER@, "libbd_btrfs.so."@MAJOR_VER@,
@@ -213,10 +215,71 @@ static void unload_plugins () {
 
 }
 
+static void load_plugin_from_sonames (LoadFunc load_fn, void **handle, GSList *sonames) {
+    while (!(*handle) && sonames) {
+        *handle = load_fn (sonames->data);
+        sonames = g_slist_next (sonames);
+    }
+}
+
+static void do_load (GSList **plugins_sonames) {
+    if (!plugins[BD_PLUGIN_LVM].handle && plugins_sonames[BD_PLUGIN_LVM])
+        load_plugin_from_sonames (load_lvm_from_plugin, &(plugins[BD_PLUGIN_LVM].handle), plugins_sonames[BD_PLUGIN_LVM]);
+    if (!plugins[BD_PLUGIN_BTRFS].handle && plugins_sonames[BD_PLUGIN_BTRFS])
+        load_plugin_from_sonames (load_btrfs_from_plugin, &(plugins[BD_PLUGIN_BTRFS].handle), plugins_sonames[BD_PLUGIN_BTRFS]);
+    if (!plugins[BD_PLUGIN_SWAP].handle && plugins_sonames[BD_PLUGIN_SWAP])
+        load_plugin_from_sonames (load_swap_from_plugin, &(plugins[BD_PLUGIN_SWAP].handle), plugins_sonames[BD_PLUGIN_SWAP]);
+    if (!plugins[BD_PLUGIN_LOOP].handle && plugins_sonames[BD_PLUGIN_LOOP])
+        load_plugin_from_sonames (load_loop_from_plugin, &(plugins[BD_PLUGIN_LOOP].handle), plugins_sonames[BD_PLUGIN_LOOP]);
+    if (!plugins[BD_PLUGIN_CRYPTO].handle && plugins_sonames[BD_PLUGIN_CRYPTO])
+        load_plugin_from_sonames (load_crypto_from_plugin, &(plugins[BD_PLUGIN_CRYPTO].handle), plugins_sonames[BD_PLUGIN_CRYPTO]);
+    if (!plugins[BD_PLUGIN_MPATH].handle && plugins_sonames[BD_PLUGIN_MPATH])
+        load_plugin_from_sonames (load_mpath_from_plugin, &(plugins[BD_PLUGIN_MPATH].handle), plugins_sonames[BD_PLUGIN_MPATH]);
+    if (!plugins[BD_PLUGIN_DM].handle && plugins_sonames[BD_PLUGIN_DM])
+        load_plugin_from_sonames (load_dm_from_plugin, &(plugins[BD_PLUGIN_DM].handle), plugins_sonames[BD_PLUGIN_DM]);
+    if (!plugins[BD_PLUGIN_MDRAID].handle && plugins_sonames[BD_PLUGIN_MDRAID])
+        load_plugin_from_sonames (load_mdraid_from_plugin, &(plugins[BD_PLUGIN_MDRAID].handle), plugins_sonames[BD_PLUGIN_MDRAID]);
+    if (!plugins[BD_PLUGIN_KBD].handle && plugins_sonames[BD_PLUGIN_KBD])
+        load_plugin_from_sonames (load_kbd_from_plugin, &(plugins[BD_PLUGIN_KBD].handle), plugins_sonames[BD_PLUGIN_KBD]);
+#if defined(__s390__) || defined(__s390x__)
+    if (!plugins[BD_PLUGIN_S390].handle && plugins_sonames[BD_PLUGIN_S390])
+        load_plugin_from_sonames (load_s390_from_plugin, &(plugins[BD_PLUGIN_S390].handle), plugins_sonames[BD_PLUGIN_S390]);
+#endif
+}
+
 static gboolean load_plugins (BDPluginSpec **require_plugins, gboolean reload, guint64 *num_loaded) {
     guint8 i = 0;
     gboolean requested_loaded = TRUE;
+    GError *error = NULL;
+    GSequence *config_files = NULL;
+    GSList *plugins_sonames[BD_PLUGIN_UNDEF] = {NULL, NULL, NULL, NULL, NULL,
+                                                NULL, NULL, NULL, NULL, NULL};
+    BDPlugin plugin_name = BD_PLUGIN_UNDEF;
+    guint64 required_plugins_mask = 0;
 
+    /* load config files first */
+    config_files = get_config_files (&error);
+    if (config_files) {
+        if (!load_config (config_files, plugins_sonames, &error))
+            g_warning ("Failed to load config files: %s. Using the built-in config", error->message);
+
+        g_sequence_free (config_files);
+    } else
+        g_warning ("Failed to load config files: %s. Using the built-in config", error->message);
+    g_clear_error (&error);
+
+    /* populate missing items with the built-in defaults */
+    for (i=0; i < BD_PLUGIN_UNDEF; i++)
+        if (!plugins_sonames[i])
+            plugins_sonames[i] = g_slist_prepend (plugins_sonames[i], g_strdup (default_plugin_so[i]));
+
+#if !defined(__s390__) && !defined(__s390x__)
+    /* do not load the s390 plugin by default if not on s390(x) */
+    g_slist_free_full (plugins_sonames[BD_PLUGIN_S390], (GDestroyNotify) g_free);
+    plugins_sonames[BD_PLUGIN_S390] = NULL;
+#endif
+
+    /* unload the previously loaded plugins if requested */
     if (reload)
         unload_plugins ();
 
@@ -224,70 +287,55 @@ static gboolean load_plugins (BDPluginSpec **require_plugins, gboolean reload, g
        defaults */
     for (i=0; i < BD_PLUGIN_UNDEF; i++)
         plugins[i].spec.so_name = NULL;
+
     if (require_plugins) {
-        /* set requested so names or defaults if so names are not specified */
+        /* set requested sonames */
         for (i=0; *(require_plugins + i); i++) {
+            plugin_name = require_plugins[i]->name;
+            required_plugins_mask |= (1 << plugin_name);
             if (require_plugins[i]->so_name) {
-                set_plugin_so_name(require_plugins[i]->name, require_plugins[i]->so_name);
-            }
-            else {
-#if !defined(__s390__) && !defined(__s390x__)
-                if (require_plugins[i]->name == BD_PLUGIN_S390) {
-                    continue;
-                }
-#endif
-
-                set_plugin_so_name(require_plugins[i]->name, default_plugin_so[require_plugins[i]->name]);
+                g_slist_free_full (plugins_sonames[plugin_name], (GDestroyNotify) g_free);
+                plugins_sonames[plugin_name] = NULL;
+                plugins_sonames[plugin_name] = g_slist_prepend(plugins_sonames[plugin_name], g_strdup (require_plugins[i]->so_name));
             }
         }
-    }
-    else {
-        /* nothing requested, just use defaults for everything */
-        for (i=0; i < BD_PLUGIN_UNDEF; i++) {
-            if (!plugins[i].spec.so_name) {
-#if !defined(__s390__) || !defined(__s390x__)
-                if (plugins[i].spec.name == BD_PLUGIN_S390) {
-                    continue;
-                }
-#endif
 
-                plugins[i].spec.so_name = default_plugin_so[i];
+        /* now remove the defaults for plugins that are not required */
+        for (i=0; (i < BD_PLUGIN_UNDEF); i++)
+            if (!(required_plugins_mask & (1 << i))) {
+                /* plugin not required */
+                g_slist_free_full (plugins_sonames[i], (GDestroyNotify) g_free);
+                plugins_sonames[i] = NULL;
             }
-        }
     }
 
-    if (!plugins[BD_PLUGIN_LVM].handle && plugins[BD_PLUGIN_LVM].spec.so_name)
-        plugins[BD_PLUGIN_LVM].handle = load_lvm_from_plugin(plugins[BD_PLUGIN_LVM].spec.so_name);
-    if (!plugins[BD_PLUGIN_BTRFS].handle && plugins[BD_PLUGIN_BTRFS].spec.so_name)
-        plugins[BD_PLUGIN_BTRFS].handle = load_btrfs_from_plugin(plugins[BD_PLUGIN_BTRFS].spec.so_name);
-    if (!plugins[BD_PLUGIN_SWAP].handle && plugins[BD_PLUGIN_SWAP].spec.so_name)
-        plugins[BD_PLUGIN_SWAP].handle = load_swap_from_plugin(plugins[BD_PLUGIN_SWAP].spec.so_name);
-    if (!plugins[BD_PLUGIN_LOOP].handle && plugins[BD_PLUGIN_LOOP].spec.so_name)
-        plugins[BD_PLUGIN_LOOP].handle = load_loop_from_plugin(plugins[BD_PLUGIN_LOOP].spec.so_name);
-    if (!plugins[BD_PLUGIN_CRYPTO].handle && plugins[BD_PLUGIN_CRYPTO].spec.so_name)
-        plugins[BD_PLUGIN_CRYPTO].handle = load_crypto_from_plugin(plugins[BD_PLUGIN_CRYPTO].spec.so_name);
-    if (!plugins[BD_PLUGIN_MPATH].handle && plugins[BD_PLUGIN_MPATH].spec.so_name)
-        plugins[BD_PLUGIN_MPATH].handle = load_mpath_from_plugin(plugins[BD_PLUGIN_MPATH].spec.so_name);
-    if (!plugins[BD_PLUGIN_DM].handle && plugins[BD_PLUGIN_DM].spec.so_name)
-        plugins[BD_PLUGIN_DM].handle = load_dm_from_plugin(plugins[BD_PLUGIN_DM].spec.so_name);
-    if (!plugins[BD_PLUGIN_MDRAID].handle && plugins[BD_PLUGIN_MDRAID].spec.so_name)
-        plugins[BD_PLUGIN_MDRAID].handle = load_mdraid_from_plugin(plugins[BD_PLUGIN_MDRAID].spec.so_name);
-    if (!plugins[BD_PLUGIN_KBD].handle && plugins[BD_PLUGIN_KBD].spec.so_name)
-        plugins[BD_PLUGIN_KBD].handle = load_kbd_from_plugin(plugins[BD_PLUGIN_KBD].spec.so_name);
-#if defined(__s390__) || defined(__s390x__)
-    if (!plugins[BD_PLUGIN_S390].handle && plugins[BD_PLUGIN_S390].spec.so_name)
-        plugins[BD_PLUGIN_S390].handle = load_s390_from_plugin(plugins[BD_PLUGIN_S390].spec.so_name);
-#endif
+    do_load (plugins_sonames);
 
     *num_loaded = 0;
-    for (i=0; (i < BD_PLUGIN_UNDEF); i++)
-        if (plugins[i].spec.so_name) {
-            if (plugins[i].handle) {
-                requested_loaded = requested_loaded && TRUE;
+    for (i=0; (i < BD_PLUGIN_UNDEF); i++) {
+        /* if this plugin was required or all plugins were required, check if it
+           was successfully loaded or not */
+        if (!require_plugins || (required_plugins_mask & (1 << i))) {
+#if !defined(__s390__) && !defined(__s390x__)
+            if (!require_plugins && (i == BD_PLUGIN_S390))
+                /* do not check the s390 plugin on different archs unless
+                   explicitly required */
+                continue;
+#endif
+            if (plugins[i].handle)
                 (*num_loaded)++;
-            } else
+            else
                 requested_loaded = FALSE;
         }
+    }
+
+    /* clear/free the config */
+    for (i=0; (i < BD_PLUGIN_UNDEF); i++) {
+        if (plugins_sonames[i]) {
+            g_slist_free_full (plugins_sonames[i], (GDestroyNotify) g_free);
+            plugins_sonames[i] = NULL;
+        }
+    }
 
     return requested_loaded;
 }

--- a/src/lib/blockdev.c.in
+++ b/src/lib/blockdev.c.in
@@ -215,35 +215,37 @@ static void unload_plugins () {
 
 }
 
-static void load_plugin_from_sonames (LoadFunc load_fn, void **handle, GSList *sonames) {
+static void load_plugin_from_sonames (BDPlugin plugin, LoadFunc load_fn, void **handle, GSList *sonames) {
     while (!(*handle) && sonames) {
         *handle = load_fn (sonames->data);
+        if (*handle)
+            set_plugin_so_name(plugin, g_strdup (sonames->data));
         sonames = g_slist_next (sonames);
     }
 }
 
 static void do_load (GSList **plugins_sonames) {
     if (!plugins[BD_PLUGIN_LVM].handle && plugins_sonames[BD_PLUGIN_LVM])
-        load_plugin_from_sonames (load_lvm_from_plugin, &(plugins[BD_PLUGIN_LVM].handle), plugins_sonames[BD_PLUGIN_LVM]);
+        load_plugin_from_sonames (BD_PLUGIN_LVM, load_lvm_from_plugin, &(plugins[BD_PLUGIN_LVM].handle), plugins_sonames[BD_PLUGIN_LVM]);
     if (!plugins[BD_PLUGIN_BTRFS].handle && plugins_sonames[BD_PLUGIN_BTRFS])
-        load_plugin_from_sonames (load_btrfs_from_plugin, &(plugins[BD_PLUGIN_BTRFS].handle), plugins_sonames[BD_PLUGIN_BTRFS]);
+        load_plugin_from_sonames (BD_PLUGIN_BTRFS, load_btrfs_from_plugin, &(plugins[BD_PLUGIN_BTRFS].handle), plugins_sonames[BD_PLUGIN_BTRFS]);
     if (!plugins[BD_PLUGIN_SWAP].handle && plugins_sonames[BD_PLUGIN_SWAP])
-        load_plugin_from_sonames (load_swap_from_plugin, &(plugins[BD_PLUGIN_SWAP].handle), plugins_sonames[BD_PLUGIN_SWAP]);
+        load_plugin_from_sonames (BD_PLUGIN_SWAP,load_swap_from_plugin, &(plugins[BD_PLUGIN_SWAP].handle), plugins_sonames[BD_PLUGIN_SWAP]);
     if (!plugins[BD_PLUGIN_LOOP].handle && plugins_sonames[BD_PLUGIN_LOOP])
-        load_plugin_from_sonames (load_loop_from_plugin, &(plugins[BD_PLUGIN_LOOP].handle), plugins_sonames[BD_PLUGIN_LOOP]);
+        load_plugin_from_sonames (BD_PLUGIN_LOOP, load_loop_from_plugin, &(plugins[BD_PLUGIN_LOOP].handle), plugins_sonames[BD_PLUGIN_LOOP]);
     if (!plugins[BD_PLUGIN_CRYPTO].handle && plugins_sonames[BD_PLUGIN_CRYPTO])
-        load_plugin_from_sonames (load_crypto_from_plugin, &(plugins[BD_PLUGIN_CRYPTO].handle), plugins_sonames[BD_PLUGIN_CRYPTO]);
+        load_plugin_from_sonames (BD_PLUGIN_CRYPTO, load_crypto_from_plugin, &(plugins[BD_PLUGIN_CRYPTO].handle), plugins_sonames[BD_PLUGIN_CRYPTO]);
     if (!plugins[BD_PLUGIN_MPATH].handle && plugins_sonames[BD_PLUGIN_MPATH])
-        load_plugin_from_sonames (load_mpath_from_plugin, &(plugins[BD_PLUGIN_MPATH].handle), plugins_sonames[BD_PLUGIN_MPATH]);
+        load_plugin_from_sonames (BD_PLUGIN_MPATH, load_mpath_from_plugin, &(plugins[BD_PLUGIN_MPATH].handle), plugins_sonames[BD_PLUGIN_MPATH]);
     if (!plugins[BD_PLUGIN_DM].handle && plugins_sonames[BD_PLUGIN_DM])
-        load_plugin_from_sonames (load_dm_from_plugin, &(plugins[BD_PLUGIN_DM].handle), plugins_sonames[BD_PLUGIN_DM]);
+        load_plugin_from_sonames (BD_PLUGIN_DM, load_dm_from_plugin, &(plugins[BD_PLUGIN_DM].handle), plugins_sonames[BD_PLUGIN_DM]);
     if (!plugins[BD_PLUGIN_MDRAID].handle && plugins_sonames[BD_PLUGIN_MDRAID])
-        load_plugin_from_sonames (load_mdraid_from_plugin, &(plugins[BD_PLUGIN_MDRAID].handle), plugins_sonames[BD_PLUGIN_MDRAID]);
+        load_plugin_from_sonames (BD_PLUGIN_MDRAID, load_mdraid_from_plugin, &(plugins[BD_PLUGIN_MDRAID].handle), plugins_sonames[BD_PLUGIN_MDRAID]);
     if (!plugins[BD_PLUGIN_KBD].handle && plugins_sonames[BD_PLUGIN_KBD])
-        load_plugin_from_sonames (load_kbd_from_plugin, &(plugins[BD_PLUGIN_KBD].handle), plugins_sonames[BD_PLUGIN_KBD]);
+        load_plugin_from_sonames (BD_PLUGIN_KBD, load_kbd_from_plugin, &(plugins[BD_PLUGIN_KBD].handle), plugins_sonames[BD_PLUGIN_KBD]);
 #if defined(__s390__) || defined(__s390x__)
     if (!plugins[BD_PLUGIN_S390].handle && plugins_sonames[BD_PLUGIN_S390])
-        load_plugin_from_sonames (load_s390_from_plugin, &(plugins[BD_PLUGIN_S390].handle), plugins_sonames[BD_PLUGIN_S390]);
+        load_plugin_from_sonames (BD_PLUGIN_S390, load_s390_from_plugin, &(plugins[BD_PLUGIN_S390].handle), plugins_sonames[BD_PLUGIN_S390]);
 #endif
 }
 
@@ -687,4 +689,18 @@ gboolean bd_is_plugin_available (BDPlugin plugin) {
         return plugins[plugin].handle != NULL;
     else
         return FALSE;
+}
+
+/**
+ * bd_get_plugin_soname:
+ * @plugin: the queried plugin
+ *
+ * Returns: (transfer full): name of the shared object loaded for the plugin or
+ * %NULL if none is loaded
+ */
+gchar* bd_get_plugin_soname (BDPlugin plugin) {
+    if (plugins[plugin].handle)
+        return g_strdup (plugins[plugin].spec.so_name);
+
+    return NULL;
 }

--- a/src/lib/blockdev.c.in
+++ b/src/lib/blockdev.c.in
@@ -36,6 +36,8 @@
  *
  */
 
+#define DEFAULT_CONF_DIR_PATH "/etc/libblockdev/conf.d/"
+
 static GMutex init_lock;
 static gboolean initialized = FALSE;
 
@@ -70,6 +72,100 @@ static gchar* plugin_names[BD_PLUGIN_UNDEF] = {
 
 static void set_plugin_so_name (BDPlugin name, gchar *so_name) {
     plugins[name].spec.so_name = so_name;
+}
+
+static gint config_file_cmp (gconstpointer a, gconstpointer b, gpointer user_data __attribute__((unused))) {
+    const gchar *name1 = (const gchar *) a;
+    const gchar *name2 = (const gchar *) b;
+
+    return g_strcmp0 (a, b);
+}
+
+static GSequence* get_config_files (GError **error) {
+    GDir *dir = NULL;
+    GSequence *ret = NULL;
+    gchar *conf_dir_path = NULL;
+    const gchar *dirent = NULL;
+
+    conf_dir_path = g_strdup (g_getenv("LIBBLOCKDEV_CONFIG_DIR"));
+    if (!conf_dir_path)
+        conf_dir_path = g_strdup (DEFAULT_CONF_DIR_PATH);
+
+    dir = g_dir_open (conf_dir_path, 0, error);
+    if (!dir) {
+        g_prefix_error (error, "Failed to get contents of the config dir (%s)", conf_dir_path);
+        g_free (conf_dir_path);
+        return NULL;
+    }
+
+    ret = g_sequence_new ((GDestroyNotify) g_free);
+
+    dirent = g_dir_read_name(dir);
+    while (dirent) {
+        /* only process .cfg files from the directory */
+        if (g_str_has_suffix (dirent, ".cfg")) {
+            dirent = g_build_filename (conf_dir_path, dirent, NULL);
+            g_sequence_insert_sorted (ret, (gpointer) dirent, config_file_cmp, NULL);
+        }
+        dirent = g_dir_read_name(dir);
+    }
+
+    g_free (conf_dir_path);
+    g_dir_close (dir);
+    return ret;
+}
+
+static gboolean process_config_file (gchar *config_file, GSList **plugins_sonames, GError **error) {
+    GKeyFile *config = NULL;
+    BDPlugin i = 0;
+    gchar **sonames = NULL;
+    gsize n_sonames = 0;
+
+    config = g_key_file_new ();
+    if (!g_key_file_load_from_file (config, config_file, G_KEY_FILE_NONE, error))
+        return FALSE;
+
+    /* get sonames for each plugin (if specified) */
+    for (i=0; (i < BD_PLUGIN_UNDEF); i++) {
+        sonames = g_key_file_get_string_list (config, plugin_names[i], "sonames", &n_sonames, error);
+        if (!sonames) {
+            /* no sonames specified or an error occurred */
+            if (*error)
+                g_clear_error (error);
+        } else {
+            /* go through the sonames in the reversed order (because we prepend
+               them to the list) */
+            for (; n_sonames > 0; n_sonames--) {
+                plugins_sonames[i] = g_slist_prepend (plugins_sonames[i], sonames[n_sonames-1]);
+            }
+            /* we need to free only the array here not its items because those
+               were put into the list above as pointers */
+            g_free (sonames);
+        }
+    }
+
+    g_key_file_free (config);
+
+    return TRUE;
+}
+
+static gboolean load_config (GSequence *config_files, GSList **plugins_sonames, GError **error) {
+    GSequenceIter *config_file_iter = NULL;
+    gchar *config_file = NULL;
+    BDPlugin i = 0;
+
+    /* process config files one after another in order */
+    config_file_iter = g_sequence_get_begin_iter (config_files);
+    while (!g_sequence_iter_is_end (config_file_iter)) {
+        config_file = (gchar *) g_sequence_get (config_file_iter);
+        if (!process_config_file (config_file, plugins_sonames, error)) {
+            g_warning ("Cannot process the config file '%s': %s. Skipping.", config_file, (*error)->message);
+            g_clear_error (error);
+        }
+        config_file_iter = g_sequence_iter_next (config_file_iter);
+    }
+
+    return TRUE;
 }
 
 static void unload_plugins () {

--- a/src/lib/plugins.h
+++ b/src/lib/plugins.h
@@ -31,6 +31,6 @@ void bd_plugin_spec_free (BDPluginSpec *spec);
 
 gboolean bd_is_plugin_available (BDPlugin plugin);
 gchar** bd_get_available_plugin_names ();
-gboolean bd_func_available (BDPlugin plugin, gchar *func_name);
+gchar* bd_get_plugin_soname (BDPlugin plugin);
 
 #endif  /* BD_PLUGINS */

--- a/tests/plugin_multi_conf.d/00-default.cfg
+++ b/tests/plugin_multi_conf.d/00-default.cfg
@@ -1,0 +1,43 @@
+# This is the default configuration for the libblockdev library. For
+# each supported technology/plugin there is a separate section/group
+# with the 'sonames' key. The value of the key has to be a list of
+# sonames of shared objects that should be attempted to be loaded for
+# the plugin falling back to the next one in the list.
+#
+# So this example:
+# [lvm]
+# sonames=libbd_lvm-dbus.so.0;libbd_lvm.so.0
+#
+# would result in the libbd_lvm-dbus.so.0 shared object attempted to
+# be loaded and if that failed, the libbd_lvm.so.0 would be attempted
+# to be loaded.
+
+[btrfs]
+sonames=libbd_btrfs.so.0
+
+[crypto]
+sonames=libbd_crypto.so.0
+
+[dm]
+sonames=libbd_dm.so.0
+
+[kbd]
+sonames=libbd_kbd.so.0
+
+[loop]
+sonames=libbd_loop.so.0
+
+[lvm]
+sonames=libbd_lvm.so.0
+
+[mdraid]
+sonames=libbd_mdraid.so.0
+
+[mpath]
+sonames=libbd_mpath.so.0
+
+[swap]
+sonames=libbd_swap.so.0
+
+[s390]
+sonames=libbd_s390.so.0

--- a/tests/plugin_multi_conf.d/10-lvm2.cfg
+++ b/tests/plugin_multi_conf.d/10-lvm2.cfg
@@ -1,0 +1,2 @@
+[lvm]
+sonames=libbd_lvm2.so.0

--- a/tests/plugin_prio_conf.d/00-default.cfg
+++ b/tests/plugin_prio_conf.d/00-default.cfg
@@ -1,0 +1,43 @@
+# This is the default configuration for the libblockdev library. For
+# each supported technology/plugin there is a separate section/group
+# with the 'sonames' key. The value of the key has to be a list of
+# sonames of shared objects that should be attempted to be loaded for
+# the plugin falling back to the next one in the list.
+#
+# So this example:
+# [lvm]
+# sonames=libbd_lvm-dbus.so.0;libbd_lvm.so.0
+#
+# would result in the libbd_lvm-dbus.so.0 shared object attempted to
+# be loaded and if that failed, the libbd_lvm.so.0 would be attempted
+# to be loaded.
+
+[btrfs]
+sonames=libbd_btrfs.so.0
+
+[crypto]
+sonames=libbd_crypto.so.0
+
+[dm]
+sonames=libbd_dm.so.0
+
+[kbd]
+sonames=libbd_kbd.so.0
+
+[loop]
+sonames=libbd_loop.so.0
+
+[lvm]
+sonames=libbd_lvm2.so.0;libbd_lvm.so.0
+
+[mdraid]
+sonames=libbd_mdraid.so.0
+
+[mpath]
+sonames=libbd_mpath.so.0
+
+[swap]
+sonames=libbd_swap.so.0
+
+[s390]
+sonames=libbd_s390.so.0


### PR DESCRIPTION
These commits add support for having multiple implementations for plugins and configuration files specifying which plugins should be preferred and which should be fallbacks. For the rationale please read the [Design Draft for this feature] (https://gist.github.com/vpodzime/008bf30c7d78079e0036).