### PR TITLE
Check bcache device's state before trying to detach the cache in dest…

### DIFF
--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -262,6 +262,28 @@ class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
 
         wipe_all(self.loop_dev, self.loop_dev2)
 
+    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
+    def test_bcache_detach_destroy(self):
+        """Verify that it's possible to destroy a bcache device with no cache attached"""
+
+        succ, dev = BlockDev.kbd_bcache_create(self.loop_dev, self.loop_dev2)
+        self.assertTrue(succ)
+        self.assertTrue(dev)
+        self.bcache_dev = dev
+
+        _wait_for_bcache_setup(dev)
+
+        succ, c_set_uuid = BlockDev.kbd_bcache_detach(self.bcache_dev)
+        self.assertTrue(succ)
+        self.assertTrue(c_set_uuid)
+
+        succ = BlockDev.kbd_bcache_destroy(self.bcache_dev)
+        self.assertTrue(succ)
+        self.bcache_dev = None
+        time.sleep(1)
+
+        wipe_all(self.loop_dev, self.loop_dev2)
+
 class KbdTestBcacheGetSetMode(KbdBcacheTestCase):
     @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     def test_bcache_get_set_mode(self):


### PR DESCRIPTION
…roy()

If the bcache device doesn't have any cache attached, we shouldn't fail to
destroy it just because we blindly try to detach the cache. We should check the
state and only do the detach if there's some cache attached instead.

(this fixes the issue #45)