### PR TITLE
Fix lvcreate calls for striped LVs

### DIFF
--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -1037,16 +1037,25 @@ gboolean bd_lvm_lvcreate (gchar *vg_name, gchar *lv_name, guint64 size, gchar *t
     gboolean success = FALSE;
     guint64 i = 0;
     guint64 j = 0;
+    gchar *size_str = NULL;
+    gchar *type_str = NULL;
 
     args[i++] = "lvcreate";
     args[i++] = "-n";
     args[i++] = lv_name;
     args[i++] = "-L";
-    args[i++] = g_strdup_printf ("%"G_GUINT64_FORMAT"K", size/1024);
+    size_str = g_strdup_printf ("%"G_GUINT64_FORMAT"K", size/1024);
+    args[i++] = size_str;
     args[i++] = "-y";
     if (type) {
-        args[i++] = "--type";
-        args[i++] = type;
+        if (g_strcmp0 (type, "striped") == 0) {
+            args[i++] = "--stripes";
+            type_str = g_strdup_printf ("%d", pv_list_len);
+            args[i++] = type_str;
+        } else {
+            args[i++] = "--type";
+            args[i++] = type;
+        }
     }
     args[i++] = vg_name;
 
@@ -1056,7 +1065,8 @@ gboolean bd_lvm_lvcreate (gchar *vg_name, gchar *lv_name, guint64 size, gchar *t
     args[i] = NULL;
 
     success = call_lvm_and_report_error (args, error);
-    g_free (args[4]);
+    g_free (size_str);
+    g_free (type_str);
     g_free (args);
 
     return success;

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -544,6 +544,10 @@ class LvmTestLVcreateType(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvcreate("testVG", "testLV", 512 * 1024**2, "striped", [self.loop_dev, self.loop_dev2])
         self.assertTrue(succ)
 
+        # verify that the LV has the requested segtype
+        info = BlockDev.lvm_lvinfo("testVG", "testLV")
+        self.assertEqual(info.segtype, "striped")
+
         succ = BlockDev.lvm_lvremove("testVG", "testLV", True)
         self.assertTrue(succ)
 
@@ -551,12 +555,20 @@ class LvmTestLVcreateType(LvmPVVGLVTestCase):
         succ = BlockDev.lvm_lvcreate("testVG", "testLV", 512 * 1024**2, "mirror", [self.loop_dev, self.loop_dev2])
         self.assertTrue(succ)
 
+        # verify that the LV has the requested segtype
+        info = BlockDev.lvm_lvinfo("testVG", "testLV")
+        self.assertEqual(info.segtype, "mirror")
+
         succ = BlockDev.lvm_lvremove("testVG", "testLV", True)
         self.assertTrue(succ)
 
         # try to create a raid1 LV
         succ = BlockDev.lvm_lvcreate("testVG", "testLV", 512 * 1024**2, "raid1", [self.loop_dev, self.loop_dev2])
         self.assertTrue(succ)
+
+        # verify that the LV has the requested segtype
+        info = BlockDev.lvm_lvinfo("testVG", "testLV")
+        self.assertEqual(info.segtype, "raid1")
 
         succ = BlockDev.lvm_lvremove("testVG", "testLV", True)
         self.assertTrue(succ)


### PR DESCRIPTION
Striped LVs are not created like other non-linear LV types. Instead of 'lvcreate
--type striped...' we need to specify the number of stripes.

Also improve the test for creating LVs with specified types.