### PR TITLE
Round size in thpoolcreate() to KiB

### DIFF
--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -1364,7 +1364,7 @@ gboolean bd_lvm_thpoolcreate (gchar *vg_name, gchar *lv_name, guint64 size, guin
     guint8 next_arg = 4;
     gboolean success = FALSE;
 
-    args[3] = g_strdup_printf ("%"G_GUINT64_FORMAT"b", size);
+    args[3] = g_strdup_printf ("%"G_GUINT64_FORMAT"K", size/1024);
 
     if (md_size != 0) {
         args[next_arg] = g_strdup_printf("--poolmetadatasize=%"G_GUINT64_FORMAT"b", md_size);


### PR DESCRIPTION
Otherwise LVM may complain about the size not being a multiple of 512. See
https://bugzilla.redhat.com/show_bug.cgi?id=1224638 for more details.