### PR TITLE
Fix error reporting when running "make test".

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,6 @@
+SHELL = /bin/bash
+.SHELLFLAGS = -o pipefail -c
+
 ACLOCAL_AMFLAGS = -I m4
 DISTCHECK_CONFIGURE_FLAGS = --enable-introspection
 


### PR DESCRIPTION
That target pipes stuff to tee, which means the error code that gets
reported is the error code of tee.  Thus if a test fails, we will still
see success and keep going.  The fix is to simply use bash as the shell
and enable pipefail on it.