### PR TITLE
Use addCleanup() instead of tearDown() in tests

### DIFF
--- a/tests/btrfs_test.py
+++ b/tests/btrfs_test.py
@@ -30,6 +30,7 @@ def umount(what):
 
 class BtrfsTestCase(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("lvm_test", 1024**3)
         self.dev_file2 = create_sparse_tempfile("lvm_test", 1024**3)
         succ, loop = BlockDev.loop_setup(self.dev_file)
@@ -41,7 +42,7 @@ class BtrfsTestCase(unittest.TestCase):
             raise RuntimeError("Failed to setup loop device for testing")
         self.loop_dev2 = "/dev/%s" % loop
 
-    def tearDown(self):
+    def _clean_up(self):
         umount(TEST_MNT)
         succ = BlockDev.loop_teardown(self.loop_dev)
         if not succ:
@@ -440,6 +441,7 @@ class BtrfsTestChangeLabel(BtrfsTestCase):
 
 class BtrfsTooSmallTestCase (unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("lvm_test", BlockDev.BTRFS_MIN_MEMBER_SIZE)
         self.dev_file2 = create_sparse_tempfile("lvm_test", BlockDev.BTRFS_MIN_MEMBER_SIZE//2)
         succ, loop = BlockDev.loop_setup(self.dev_file)
@@ -451,7 +453,7 @@ class BtrfsTooSmallTestCase (unittest.TestCase):
             raise RuntimeError("Failed to setup loop device for testing")
         self.loop_dev2 = "/dev/%s" % loop
 
-    def tearDown(self):
+    def _clean_up(self):
         succ = BlockDev.loop_teardown(self.loop_dev)
         if  not succ:
             os.unlink(self.dev_file)
@@ -475,6 +477,7 @@ class BtrfsTooSmallTestCase (unittest.TestCase):
 
 class BtrfsJustBigEnoughTestCase (unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("lvm_test", BlockDev.BTRFS_MIN_MEMBER_SIZE)
         self.dev_file2 = create_sparse_tempfile("lvm_test", BlockDev.BTRFS_MIN_MEMBER_SIZE)
         succ, loop = BlockDev.loop_setup(self.dev_file)
@@ -486,7 +489,7 @@ class BtrfsJustBigEnoughTestCase (unittest.TestCase):
             raise RuntimeError("Failed to setup loop device for testing")
         self.loop_dev2 = "/dev/%s" % loop
 
-    def tearDown(self):
+    def _clean_up(self):
         succ = BlockDev.loop_teardown(self.loop_dev)
         if  not succ:
             os.unlink(self.dev_file)
@@ -527,10 +530,10 @@ class FakeBtrfsUtilsTestCase(unittest.TestCase):
         self.assertTrue(any(subvol for subvol in subvols if subvol.path == "docker/btrfs/subvolumes/f2062b736fbabbe4da752632ac4deae87fcb916add6d7d8f5cecee4cbdc41fd9"))
 
 class BTRFSUnloadTest(unittest.TestCase):
-    def tearDown(self):
+    def setUp(self):
         # make sure the library is initialized with all plugins loaded for other
         # tests
-        self.assertTrue(BlockDev.reinit(None, True, None))
+        self.addCleanup(BlockDev.reinit, None, True, None)
 
     def test_check_low_version(self):
         """Verify that checking the minimum BTRFS version works as expected"""

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -26,6 +26,7 @@ class CryptoTestGenerateBackupPassphrase(unittest.TestCase):
 
 class CryptoTestCase(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("crypto_test", 1024**3)
         self.dev_file2 = create_sparse_tempfile("crypto_test2", 1024**3)
         succ, loop = BlockDev.loop_setup(self.dev_file)
@@ -43,7 +44,7 @@ class CryptoTestCase(unittest.TestCase):
         os.write(handle, b"nobodyknows")
         os.close(handle)
 
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.crypto_luks_close("libblockdevTestLUKS")
         except:

--- a/tests/dm_test.py
+++ b/tests/dm_test.py
@@ -9,13 +9,14 @@ if not BlockDev.is_initialized():
 
 class DevMapperTestCase(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("lvm_test", 1024**3)
         succ, loop = BlockDev.loop_setup(self.dev_file)
         if  not succ:
             raise RuntimeError("Failed to setup loop device for testing")
         self.loop_dev = "/dev/%s" % loop
 
-    def tearDown(self):
+    def _clean_up(self):
         succ = BlockDev.loop_teardown(self.loop_dev)
         if  not succ:
             os.unlink(self.dev_file)
@@ -79,10 +80,10 @@ class DevMapperNameNodeBijection(DevMapperTestCase):
         self.assertTrue(succ)
 
 class DMUnloadTest(unittest.TestCase):
-    def tearDown(self):
+    def setUp(self):
         # make sure the library is initialized with all plugins loaded for other
         # tests
-        self.assertTrue(BlockDev.reinit(None, True, None))
+        self.addCleanup(BlockDev.reinit, None, True, None)
 
     def test_check_low_version(self):
         """Verify that checking the minimum dmsetup version works as expected"""

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -42,9 +42,10 @@ def _wait_for_bcache_setup(bcache_dev):
 
 class KbdZRAMTestCase(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self._loaded_zram_module = False
 
-    def tearDown(self):
+    def _clean_up(self):
         # make sure we unload the module if we loaded it
         if self._loaded_zram_module:
             os.system("rmmod zram")
@@ -141,6 +142,7 @@ class KbdBcacheNodevTestCase(unittest.TestCase):
 
 class KbdBcacheTestCase(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("lvm_test", 10 * 1024**3)
         self.dev_file2 = create_sparse_tempfile("lvm_test", 10 * 1024**3)
         succ, loop = BlockDev.loop_setup(self.dev_file)
@@ -154,7 +156,7 @@ class KbdBcacheTestCase(unittest.TestCase):
 
         self.bcache_dev = None
 
-    def tearDown(self):
+    def _clean_up(self):
         if self.bcache_dev:
             try:
                 BlockDev.kbd_bcache_destroy(self.bcache_dev)
@@ -384,10 +386,10 @@ class KbdTestBcacheBackingCacheDevTest(KbdBcacheTestCase):
         wipe_all(self.loop_dev, self.loop_dev2)
 
 class KbdUnloadTest(unittest.TestCase):
-    def tearDown(self):
+    def setUp(self):
         # make sure the library is initialized with all plugins loaded for other
         # tests
-        self.assertTrue(BlockDev.reinit(None, True, None))
+        self.addCleanup(BlockDev.reinit, None, True, None)
 
     def test_check_no_bcache_progs(self):
         """Verify that checking the availability of make-bcache works as expected"""

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -11,7 +11,10 @@ if not BlockDev.is_initialized():
 class LibraryOpsTestCase(unittest.TestCase):
     log = ""
 
-    def tearDown(self):
+    def setUp(self):
+        self.addCleanup(self._clean_up)
+
+    def _clean_up(self):
         # change the sources back and recompile
         os.system("sed -ri 's?1024;//test-change?BD_LVM_MAX_LV_SIZE;?' src/plugins/lvm.c > /dev/null")
         os.system("make &> /dev/null")

--- a/tests/loop_test.py
+++ b/tests/loop_test.py
@@ -9,10 +9,11 @@ if not BlockDev.is_initialized():
 
 class LoopTestCase(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("loop_test", 1024**3)
         self.loop = None
 
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.loop_teardown(self.loop)
         except:
@@ -48,10 +49,10 @@ class LoopTestCase(unittest.TestCase):
         self.assertEqual(f_name, self.dev_file)
 
 class LoopUnloadTest(unittest.TestCase):
-    def tearDown(self):
+    def setUp(self):
         # make sure the library is initialized with all plugins loaded for other
         # tests
-        self.assertTrue(BlockDev.reinit(None, True, None))
+        self.addCleanup(BlockDev.reinit, None, True, None)
 
     def test_check_low_version(self):
         """Verify that checking the minimum losetup version works as expected"""

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -206,6 +206,7 @@ class LvmPVonlyTestCase(unittest.TestCase):
     #       first)
     #     * some complex test for pvs, vgs, lvs, pvinfo, vginfo and lvinfo
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("lvm_test", 1024**3)
         self.dev_file2 = create_sparse_tempfile("lvm_test", 1024**3)
         succ, loop = BlockDev.loop_setup(self.dev_file)
@@ -217,7 +218,7 @@ class LvmPVonlyTestCase(unittest.TestCase):
             raise RuntimeError("Failed to setup loop device for testing")
         self.loop_dev2 = "/dev/%s" % loop
 
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.lvm_pvremove(self.loop_dev)
         except:
@@ -337,13 +338,13 @@ class LvmTestPVs(LvmPVonlyTestCase):
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmPVVGTestCase(LvmPVonlyTestCase):
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.lvm_vgremove("testVG")
         except:
             pass
 
-        LvmPVonlyTestCase.tearDown(self)
+        LvmPVonlyTestCase._clean_up(self)
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmTestVGcreateRemove(LvmPVVGTestCase):
@@ -523,13 +524,13 @@ class LvmTestVGs(LvmPVVGTestCase):
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmPVVGLVTestCase(LvmPVVGTestCase):
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.lvm_lvremove("testVG", "testLV", True)
         except:
             pass
 
-        LvmPVVGTestCase.tearDown(self)
+        LvmPVVGTestCase._clean_up(self)
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmTestLVcreateRemove(LvmPVVGLVTestCase):
@@ -800,13 +801,13 @@ class LvmTestLVs(LvmPVVGLVTestCase):
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmPVVGthpoolTestCase(LvmPVVGTestCase):
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.lvm_lvremove("testVG", "testPool", True)
         except:
             pass
 
-        LvmPVVGTestCase.tearDown(self)
+        LvmPVVGTestCase._clean_up(self)
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmTestLVsAll(LvmPVVGthpoolTestCase):
@@ -884,13 +885,13 @@ class LvmTestDataMetadataLV(LvmPVVGthpoolTestCase):
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmPVVGLVthLVTestCase(LvmPVVGthpoolTestCase):
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.lvm_lvremove("testVG", "testThLV", True)
         except:
             pass
 
-        LvmPVVGthpoolTestCase.tearDown(self)
+        LvmPVVGthpoolTestCase._clean_up(self)
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmTestThLVcreate(LvmPVVGLVthLVTestCase):
@@ -923,13 +924,13 @@ class LvmTestThLVcreate(LvmPVVGLVthLVTestCase):
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmPVVGLVthLVsnapshotTestCase(LvmPVVGLVthLVTestCase):
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.lvm_lvremove("testVG", "testThLV_bak", True)
         except:
             pass
 
-        LvmPVVGLVthLVTestCase.tearDown(self)
+        LvmPVVGLVthLVTestCase._clean_up(self)
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmTestThSnapshotCreate(LvmPVVGLVthLVsnapshotTestCase):
@@ -966,13 +967,13 @@ class LvmTestThSnapshotCreate(LvmPVVGLVthLVsnapshotTestCase):
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmPVVGLVcachePoolTestCase(LvmPVVGLVTestCase):
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.lvm_lvremove("testVG", "testCache", True)
         except:
             pass
 
-        LvmPVVGLVTestCase.tearDown(self)
+        LvmPVVGLVTestCase._clean_up(self)
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmPVVGLVcachePoolCreateRemoveTestCase(LvmPVVGLVcachePoolTestCase):

--- a/tests/md_test.py
+++ b/tests/md_test.py
@@ -68,6 +68,7 @@ class MDNoDevTestCase(unittest.TestCase):
 
 class MDTestCase(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("md_test", 10 * 1024**2)
         self.dev_file2 = create_sparse_tempfile("md_test", 10 * 1024**2)
         self.dev_file3 = create_sparse_tempfile("md_test", 10 * 1024**2)
@@ -85,7 +86,7 @@ class MDTestCase(unittest.TestCase):
             raise RuntimeError("Failed to setup loop device for testing")
         self.loop_dev3 = "/dev/%s" % loop
 
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.md_deactivate("bd_test_md")
         except:
@@ -382,10 +383,10 @@ class FakeMDADMutilTest(unittest.TestCase):
 
 
 class MDUnloadTest(unittest.TestCase):
-    def tearDown(self):
+    def setUp(self):
         # make sure the library is initialized with all plugins loaded for other
         # tests
-        self.assertTrue(BlockDev.reinit(None, True, None))
+        self.addCleanup(BlockDev.reinit, None, True, None)
 
     def test_check_low_version(self):
         """Verify that checking the minimum mdsetup version works as expected"""

--- a/tests/mpath_test.py
+++ b/tests/mpath_test.py
@@ -9,13 +9,14 @@ if not BlockDev.is_initialized():
 
 class MpathTestCase(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("mpath_test", 1024**3)
         succ, loop = BlockDev.loop_setup(self.dev_file)
         if  not succ:
             raise RuntimeError("Failed to setup loop device for testing")
         self.loop_dev = "/dev/%s" % loop
 
-    def tearDown(self):
+    def _clean_up(self):
         succ = BlockDev.loop_teardown(self.loop_dev)
         if  not succ:
             os.unlink(self.dev_file)
@@ -31,10 +32,10 @@ class MpathTestCase(unittest.TestCase):
         self.assertFalse(BlockDev.mpath_is_mpath_member("/dev/loop0"))
 
 class MpathUnloadTest(unittest.TestCase):
-    def tearDown(self):
+    def setUp(self):
         # make sure the library is initialized with all plugins loaded for other
         # tests
-        self.assertTrue(BlockDev.reinit(None, True, None))
+        self.addCleanup(BlockDev.reinit, None, True, None)
 
     def test_check_low_version(self):
         """Verify that checking the minimum dmsetup version works as expected"""

--- a/tests/s390_test.py
+++ b/tests/s390_test.py
@@ -69,7 +69,7 @@ class S390UnloadTest(unittest.TestCase):
             self.assertNotIn("s390", BlockDev.get_available_plugin_names())
 
     @unittest.skipUnless(os.uname()[4].startswith('s390'), "s390x architecture required")
-    def tearDown(self):
+    def setUp(self):
         # make sure the library is initialized with all plugins loaded for other
         # tests
-        self.assertTrue(BlockDev.reinit(None, True, None))
+        self.addCleanup(BlockDev.reinit, None, True, None)

--- a/tests/swap_test.py
+++ b/tests/swap_test.py
@@ -9,13 +9,14 @@ if not BlockDev.is_initialized():
 
 class SwapTestCase(unittest.TestCase):
     def setUp(self):
+        self.addCleanup(self._clean_up)
         self.dev_file = create_sparse_tempfile("swap_test", 1024**3)
         succ, loop = BlockDev.loop_setup(self.dev_file)
         if  not succ:
             raise RuntimeError("Failed to setup loop device for testing")
         self.loop_dev = "/dev/%s" % loop
 
-    def tearDown(self):
+    def _clean_up(self):
         try:
             BlockDev.swap_swapoff(self.loop_dev)
         except:
@@ -81,10 +82,10 @@ class SwapTestCase(unittest.TestCase):
         os.path.exists ("/dev/disk/by-label/TestBlockDevSwap")
 
 class SwapUnloadTest(unittest.TestCase):
-    def tearDown(self):
+    def setUp(self):
         # make sure the library is initialized with all plugins loaded for other
         # tests
-        self.assertTrue(BlockDev.reinit(None, True, None))
+        self.addCleanup(BlockDev.reinit, None, True, None)
 
     def test_check_low_version(self):
         """Verify that checking the minimum swap utils versions works as expected"""


### PR DESCRIPTION
Python's unittests have a weird glitch -- the tearDown() method of a test case
is not called always. There are cases (exception in setUp(), exception in the
test?,...) when it's just skipped. However, we need to always clean after
ourselves and that's why need to use the addCleanup() method which adds
callbacks that are called ALWAYS when the test is done (succeeding, failing,
erroring, whatever).