### PR TITLE
Make invocation of tests configurable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-introspection
 
 SUBDIRS = src docs dist scripts data
 
-dist_noinst_DATA = features.rst roadmap.rst specs.rst LICENSE
+dist_noinst_DATA = features.rst roadmap.rst specs.rst LICENSE tests
 
 MAINTAINERCLEANFILES = Makefile.in aclocal.m4 config.guess config.sub \
     configure depcomp install-sh ltmain.sh missing py-compile compile ar-lib \
@@ -34,6 +34,7 @@ check: all pylint
 pylint:
 	pylint -E src/python/gi/overrides/BlockDev.py
 
+if TESTS_ENABLED
 test: all check
 	@rm -f $(TEST_SUITE_LOG)
 	@touch $(TEST_SUITE_LOG)
@@ -53,6 +54,7 @@ test-all: all check
 		$(TEST_PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
 	sudo env FEELINGLUCKY= GI_TYPELIB_PATH=${GIDIR} LD_LIBRARY_PATH=${LIBDIRS} PYTHONPATH=.:tests/:src/python \
 		$(TEST_PYTHON) -m unittest discover -v -s tests/ -p 'lvm_dbus_tests.py'
+endif # TESTS_ENABLED
 
 coverage: all
 	@rm -f $(TEST_SUITE_LOG)

--- a/configure.ac
+++ b/configure.ac
@@ -67,7 +67,10 @@ PYTHON3_EXECDIR=`$PYTHON3 -c "import distutils.sysconfig; \
 AC_SUBST(py3execdir, $PYTHON3_EXECDIR)
 AM_CONDITIONAL(USE_PYTHON3, test ${use_python3} = "yes")
 
-
+# Run tests on build?
+AC_ARG_ENABLE([tests], AS_HELP_STRING([--enable-tests], [Run tests at compile time (default=yes)]))
+test "x$enable_tests" = "x" && enable_tests="yes"
+AM_CONDITIONAL([TESTS_ENABLED], [test "x$enable_tests" = "xyes"])
 
 AC_CHECK_HEADERS([dlfcn.h string.h unistd.h sys/fcntl.h sys/ioctl.h linux/random.h glob.h syslog.h math.h],
                  [],


### PR DESCRIPTION
Sometimes, it's not desired to fire up the tests when the build is about to complete.

**Usage:**
`./configure --disable-tests && make`