### PR TITLE
Don't expect to always get introspection data from DBus

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -264,6 +264,9 @@ static gchar** get_existing_objects (gchar *obj_prefix, GError **error) {
     intro_v = g_dbus_connection_call_sync (bus, LVM_BUS_NAME, obj_prefix, DBUS_INTRO_IFACE,
                                            "Introspect", NULL, NULL, G_DBUS_CALL_FLAGS_NONE,
                                            -1, NULL, error);
+    if (!intro_v)
+        /* no introspection data, something went wrong (error must be set) */
+        return NULL;
 
     g_variant_get (intro_v, "(s)", &intro_data);
     info = g_dbus_node_info_new_for_xml (intro_data, error);


### PR DESCRIPTION
For example if we are not running as root, we may not get introspection data
from services running on the SystemBus or just because the policy says so.