### PR TITLE
Make the tests run faster and a bit better

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ run-root-ipython: all
 check: all pylint
 
 pylint:
-	pylint -E src/python/gi/overrides/BlockDev.py
+	python3-pylint -E src/python/gi/overrides/BlockDev.py
 
 if TESTS_ENABLED
 test: all check
@@ -113,5 +113,4 @@ release: tag
 
 ci: distcheck
 	$(MAKE) pylint > $(PYLINT_LOG)
-	TEST_PYTHON=python2 $(MAKE) test
 	TEST_PYTHON=python3 COVERAGE=coverage3 $(MAKE) coverage

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -17,7 +17,7 @@ class LibraryOpsTestCase(unittest.TestCase):
     def _clean_up(self):
         # change the sources back and recompile
         os.system("sed -ri 's?1024;//test-change?BD_LVM_MAX_LV_SIZE;?' src/plugins/lvm.c > /dev/null")
-        os.system("make &> /dev/null")
+        os.system("make -C src/plugins/ libbd_lvm.la &> /dev/null")
 
         # try to get everything back to normal by (re)loading all plugins
         BlockDev.reinit(None, True, None)
@@ -33,7 +33,7 @@ class LibraryOpsTestCase(unittest.TestCase):
 
         # change the sources and recompile
         os.system("sed -ri 's?BD_LVM_MAX_LV_SIZE;?1024;//test-change?' src/plugins/lvm.c > /dev/null")
-        os.system("make &> /dev/null")
+        os.system("make -C src/plugins/ libbd_lvm.la &> /dev/null")
 
         # library should successfully reinitialize without reloading plugins
         self.assertTrue(BlockDev.reinit(None, False, None))
@@ -49,7 +49,7 @@ class LibraryOpsTestCase(unittest.TestCase):
 
         # change the sources back and recompile
         os.system("sed -ri 's?1024;//test-change?BD_LVM_MAX_LV_SIZE;?' src/plugins/lvm.c > /dev/null")
-        os.system("make &> /dev/null")
+        os.system("make -C src/plugins/ libbd_lvm.la &> /dev/null")
 
         # library should successfully reinitialize reloading original plugins
         self.assertTrue(BlockDev.reinit(None, True, None))
@@ -71,14 +71,14 @@ class LibraryOpsTestCase(unittest.TestCase):
 
         # change the sources and recompile
         os.system("sed -ri 's?BD_LVM_MAX_LV_SIZE;?1024;//test-change?' src/plugins/lvm.c > /dev/null")
-        os.system("make &>/dev/null")
+        os.system("make -C src/plugins/ libbd_lvm.la &>/dev/null")
 
         # proclaim the new build a different plugin
         os.system("cp src/plugins/.libs/libbd_lvm.so src/plugins/.libs/libbd_lvm2.so")
 
         # change the sources back and recompile
         os.system("sed -ri 's?1024;//test-change?BD_LVM_MAX_LV_SIZE;?' src/plugins/lvm.c > /dev/null")
-        os.system("make &>/dev/null")
+        os.system("make -C src/plugins/ libbd_lvm.la &>/dev/null")
 
         # force the new plugin to be used
         ps = BlockDev.PluginSpec()
@@ -114,14 +114,14 @@ class LibraryOpsTestCase(unittest.TestCase):
 
         # change the sources and recompile
         os.system("sed -ri 's?BD_LVM_MAX_LV_SIZE;?1024;//test-change?' src/plugins/lvm.c > /dev/null")
-        os.system("make &>/dev/null")
+        os.system("make -C src/plugins/ libbd_lvm.la &>/dev/null")
 
         # proclaim the new build a different plugin
         os.system("cp src/plugins/.libs/libbd_lvm.so src/plugins/.libs/libbd_lvm2.so.0")
 
         # change the sources back and recompile
         os.system("sed -ri 's?1024;//test-change?BD_LVM_MAX_LV_SIZE;?' src/plugins/lvm.c > /dev/null")
-        os.system("make &>/dev/null")
+        os.system("make -C src/plugins/ libbd_lvm.la &>/dev/null")
 
         # now reinit the library with the config preferring the new build
         orig_conf_dir = os.environ.get("LIBBLOCKDEV_CONFIG_DIR")
@@ -177,14 +177,14 @@ class LibraryOpsTestCase(unittest.TestCase):
 
         # change the sources and recompile
         os.system("sed -ri 's?gboolean check\(\) \{?gboolean check() { return FALSE;//test-change?' src/plugins/lvm.c > /dev/null")
-        os.system("make &>/dev/null")
+        os.system("make -C src/plugins/ libbd_lvm.la &>/dev/null")
 
         # proclaim the new build a different plugin
         os.system("cp src/plugins/.libs/libbd_lvm.so src/plugins/.libs/libbd_lvm2.so.0")
 
         # change the sources back and recompile
         os.system("sed -ri 's?gboolean check\(\) \{ return FALSE;//test-change?gboolean check() {?' src/plugins/lvm.c > /dev/null")
-        os.system("make &>/dev/null")
+        os.system("make -C src/plugins/ libbd_lvm.la &>/dev/null")
 
         # now reinit the library with the config preferring the new build
         orig_conf_dir = os.environ.get("LIBBLOCKDEV_CONFIG_DIR")

--- a/tests/md_test.py
+++ b/tests/md_test.py
@@ -111,6 +111,10 @@ class MDTestCase(unittest.TestCase):
             BlockDev.md_deactivate("bd_test_md")
         except:
             pass
+        try:
+            BlockDev.md_deactivate(BlockDev.md_node_from_name("bd_test_md"))
+        except:
+            pass
 
         succ = BlockDev.loop_teardown(self.loop_dev)
         if  not succ:
@@ -240,6 +244,10 @@ class MDTestNominateDenominate(MDTestCase):
 
         with wait_for_resync():
             succ = BlockDev.md_nominate(self.loop_dev)
+            self.assertTrue(succ)
+
+        with wait_for_resync():
+            succ = BlockDev.md_deactivate(BlockDev.md_node_from_name("bd_test_md"))
             self.assertTrue(succ)
 
 class MDTestNominateDenominateActive(MDTestCase):


### PR DESCRIPTION
We don't really need to run the tests with both Python 2 and Python 3. Also, we don't need to run gtk-doc just to recompile a plugin. And we can try harder to clean after ``mdadm``.