### PR TITLE
Mark pointer parameters we don't change as const

### DIFF
--- a/scripts/boilerplate_generator.py
+++ b/scripts/boilerplate_generator.py
@@ -207,7 +207,7 @@ def get_funcs_info(fn_infos, module_name):
 def get_loading_func(fn_infos, module_name):
     # TODO: only error on functions provided by the plugin that fail to load
     # TODO: implement the 'gchar **errors' argument
-    ret =  'gpointer load_{0}_from_plugin(gchar *so_name) {{\n'.format(module_name)
+    ret =  'gpointer load_{0}_from_plugin(const gchar *so_name) {{\n'.format(module_name)
     ret += '    void *handle = NULL;\n'
     ret += '    char *error = NULL;\n'
     ret += '    gboolean (*check_fn) (void) = NULL;\n'

--- a/src/lib/blockdev.c.in
+++ b/src/lib/blockdev.c.in
@@ -49,7 +49,7 @@ typedef struct BDPluginStatus {
     gpointer handle;
 } BDPluginStatus;
 
-typedef void* (*LoadFunc) (gchar *so_name);
+typedef void* (*LoadFunc) (const gchar *so_name);
 
 /* KEEP THE ORDERING OF THESE ARRAYS MATCHING THE BDPluginName ENUM! */
 static gchar * default_plugin_so[BD_PLUGIN_UNDEF] = {
@@ -78,7 +78,7 @@ static gchar* plugin_names[BD_PLUGIN_UNDEF] = {
     "lvm", "btrfs", "swap", "loop", "crypto", "mpath", "dm", "mdraid", "kbd", "s390", "part", "fs"
 };
 
-static void set_plugin_so_name (BDPlugin name, gchar *so_name) {
+static void set_plugin_so_name (BDPlugin name, const gchar *so_name) {
     plugins[name].spec.so_name = so_name;
 }
 
@@ -123,7 +123,7 @@ static GSequence* get_config_files (GError **error) {
     return ret;
 }
 
-static gboolean process_config_file (gchar *config_file, GSList **plugins_sonames, GError **error) {
+static gboolean process_config_file (const gchar *config_file, GSList **plugins_sonames, GError **error) {
     GKeyFile *config = NULL;
     BDPlugin i = 0;
     gchar **sonames = NULL;
@@ -165,7 +165,7 @@ static gboolean load_config (GSequence *config_files, GSList **plugins_sonames, 
     /* process config files one after another in order */
     config_file_iter = g_sequence_get_begin_iter (config_files);
     while (!g_sequence_iter_is_end (config_file_iter)) {
-        config_file = (gchar *) g_sequence_get (config_file_iter);
+        config_file = (const gchar *) g_sequence_get (config_file_iter);
         if (!process_config_file (config_file, plugins_sonames, error)) {
             g_warning ("Cannot process the config file '%s': %s. Skipping.", config_file, (*error)->message);
             g_clear_error (error);

--- a/src/lib/plugin_apis/btrfs.api
+++ b/src/lib/plugin_apis/btrfs.api
@@ -170,7 +170,7 @@ GType bd_btrfs_filesystem_info_get_type () {
  *
  * See mkfs.btrfs(8) for details about @data_level, @md_level and btrfs in general.
  */
-gboolean bd_btrfs_create_volume (gchar **devices, gchar *label, gchar *data_level, gchar *md_level, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_create_volume (const gchar **devices, const gchar *label, const gchar *data_level, const gchar *md_level, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_add_device:
@@ -182,7 +182,7 @@ gboolean bd_btrfs_create_volume (gchar **devices, gchar *label, gchar *data_leve
  *
  * Returns: whether the @device was successfully added to the @mountpoint btrfs volume or not
  */
-gboolean bd_btrfs_add_device (gchar *mountpoint, gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_add_device (const gchar *mountpoint, const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_remove_device:
@@ -194,7 +194,7 @@ gboolean bd_btrfs_add_device (gchar *mountpoint, gchar *device, BDExtraArg **ext
  *
  * Returns: whether the @device was successfully removed from the @mountpoint btrfs volume or not
  */
-gboolean bd_btrfs_remove_device (gchar *mountpoint, gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_remove_device (const gchar *mountpoint, const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_create_subvolume:
@@ -206,7 +206,7 @@ gboolean bd_btrfs_remove_device (gchar *mountpoint, gchar *device, BDExtraArg **
  *
  * Returns: whether the @mountpoint/@name subvolume was successfully created or not
  */
-gboolean bd_btrfs_create_subvolume (gchar *mountpoint, gchar *name, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_create_subvolume (const gchar *mountpoint, const gchar *name, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_delete_subvolume:
@@ -218,7 +218,7 @@ gboolean bd_btrfs_create_subvolume (gchar *mountpoint, gchar *name, BDExtraArg *
  *
  * Returns: whether the @mountpoint/@name subvolume was successfully deleted or not
  */
-gboolean bd_btrfs_delete_subvolume (gchar *mountpoint, gchar *name, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_delete_subvolume (const gchar *mountpoint, const gchar *name, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_get_default_subvolume_id:
@@ -228,7 +228,7 @@ gboolean bd_btrfs_delete_subvolume (gchar *mountpoint, gchar *name, BDExtraArg *
  * Returns: ID of the @mountpoint volume's default subvolume. If 0,
  * @error) may be set to indicate error
  */
-guint64 bd_btrfs_get_default_subvolume_id (gchar *mountpoint, GError **error);
+guint64 bd_btrfs_get_default_subvolume_id (const gchar *mountpoint, GError **error);
 
 /**
  * bd_btrfs_set_default_subvolume:
@@ -241,7 +241,7 @@ guint64 bd_btrfs_get_default_subvolume_id (gchar *mountpoint, GError **error);
  * Returns: whether the @mountpoint volume's default subvolume was correctly set
  * to @subvol_id or not
  */
-gboolean bd_btrfs_set_default_subvolume (gchar *mountpoint, guint64 subvol_id, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_set_default_subvolume (const gchar *mountpoint, guint64 subvol_id, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_create_snapshot:
@@ -254,7 +254,7 @@ gboolean bd_btrfs_set_default_subvolume (gchar *mountpoint, guint64 subvol_id, B
  *
  * Returns: whether the @dest snapshot of @source was successfully created or not
  */
-gboolean bd_btrfs_create_snapshot (gchar *source, gchar *dest, gboolean ro, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_create_snapshot (const gchar *source, const gchar *dest, gboolean ro, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_list_devices:
@@ -264,7 +264,7 @@ gboolean bd_btrfs_create_snapshot (gchar *source, gchar *dest, gboolean ro, BDEx
  * Returns: (array zero-terminated=1): information about the devices that are part of the btrfs volume
  * containing @device or %NULL in case of error
  */
-BDBtrfsDeviceInfo** bd_btrfs_list_devices (gchar *device, GError **error);
+BDBtrfsDeviceInfo** bd_btrfs_list_devices (const gchar *device, GError **error);
 
 /**
  * bd_btrfs_list_subvolumes:
@@ -278,7 +278,7 @@ BDBtrfsDeviceInfo** bd_btrfs_list_devices (gchar *device, GError **error);
  * The subvolumes are sorted in a way that no child subvolume appears in the
  * list before its parent (sub)volume.
  */
-BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (gchar *mountpoint, gboolean snapshots_only, GError **error);
+BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (const gchar *mountpoint, gboolean snapshots_only, GError **error);
 
 /**
  * bd_btrfs_filesystem_info:
@@ -287,7 +287,7 @@ BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (gchar *mountpoint, gboolean sna
  *
  * Returns: information about the @device's volume's filesystem or %NULL in case of error
  */
-BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info (gchar *device, GError **error);
+BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info (const gchar *device, GError **error);
 
 /**
  * bd_btrfs_mkfs:
@@ -303,7 +303,7 @@ BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info (gchar *device, GError **error);
  *
  * See mkfs.btrfs(8) for details about @data_level, @md_level and btrfs in general.
  */
-gboolean bd_btrfs_mkfs (gchar **devices, gchar *label, gchar *data_level, gchar *md_level, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_mkfs (const gchar **devices, const gchar *label, const gchar *data_level, const gchar *md_level, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_resize:
@@ -316,7 +316,7 @@ gboolean bd_btrfs_mkfs (gchar **devices, gchar *label, gchar *data_level, gchar 
  * Returns: whether the @mountpoint filesystem was successfully resized to @size
  * or not
  */
-gboolean bd_btrfs_resize (gchar *mountpoint, guint64 size, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_resize (const gchar *mountpoint, guint64 size, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_check:
@@ -327,7 +327,7 @@ gboolean bd_btrfs_resize (gchar *mountpoint, guint64 size, BDExtraArg **extra, G
  *
  * Returns: whether the filesystem was successfully checked or not
  */
-gboolean bd_btrfs_check (gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_check (const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_repair:
@@ -338,7 +338,7 @@ gboolean bd_btrfs_check (gchar *device, BDExtraArg **extra, GError **error);
  *
  * Returns: whether the filesystem was successfully checked and repaired or not
  */
-gboolean bd_btrfs_repair (gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_btrfs_change_label:
@@ -351,4 +351,4 @@ gboolean bd_btrfs_repair (gchar *device, BDExtraArg **extra, GError **error);
  * Returns: whether the label of the @mountpoint filesystem was successfully set
  * to @label or not
  */
-gboolean bd_btrfs_change_label (gchar *mountpoint, gchar *label, BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_change_label (const gchar *mountpoint, const gchar *label, const BDExtraArg **extra, GError **error);

--- a/src/lib/plugin_apis/dm.api
+++ b/src/lib/plugin_apis/dm.api
@@ -21,7 +21,7 @@ typedef enum {
  * Returns: whether the new linear mapping @map_name was successfully created
  * for the @device or not
  */
-gboolean bd_dm_create_linear (gchar *map_name, gchar *device, guint64 length, gchar *uuid, GError **error);
+gboolean bd_dm_create_linear (const gchar *map_name, const gchar *device, guint64 length, const gchar *uuid, GError **error);
 
 /**
  * bd_dm_remove:
@@ -30,7 +30,7 @@ gboolean bd_dm_create_linear (gchar *map_name, gchar *device, guint64 length, gc
  *
  * Returns: whether the @map_name map was successfully removed or not
  */
-gboolean bd_dm_remove (gchar *map_name, GError **error);
+gboolean bd_dm_remove (const gchar *map_name, GError **error);
 
 /**
  * bd_dm_name_from_node:
@@ -40,7 +40,7 @@ gboolean bd_dm_remove (gchar *map_name, GError **error);
  * Returns: map name of the map providing the @dm_node device or %NULL
  * (@error) contains the error in such cases)
  */
-gchar* bd_dm_name_from_node (gchar *dm_node, GError **error);
+gchar* bd_dm_name_from_node (const gchar *dm_node, GError **error);
 
 /**
  * bd_dm_node_from_name:
@@ -50,7 +50,7 @@ gchar* bd_dm_name_from_node (gchar *dm_node, GError **error);
  * Returns: DM node name for the @map_name map or %NULL (@error) contains
  * the error in such cases)
  */
-gchar* bd_dm_node_from_name (gchar *map_name, GError **error);
+gchar* bd_dm_node_from_name (const gchar *map_name, GError **error);
 
 /**
  * bd_dm_map_exists:
@@ -62,7 +62,7 @@ gchar* bd_dm_node_from_name (gchar *map_name, GError **error);
  * Returns: whether the given @map_name exists (and is live if @live_only is
  * %TRUE (and is active if @active_only is %TRUE)).
  */
-gboolean bd_dm_map_exists (gchar *map_name, gboolean live_only, gboolean active_only, GError **error);
+gboolean bd_dm_map_exists (const gchar *map_name, gboolean live_only, gboolean active_only, GError **error);
 
 /**
  * bd_dm_get_member_raid_sets:
@@ -77,7 +77,7 @@ gboolean bd_dm_map_exists (gchar *map_name, gboolean live_only, gboolean active_
  *
  * One of @name, @uuid or @major:@minor has to be given.
  */
-gchar** bd_dm_get_member_raid_sets (gchar *name, gchar *uuid, gint major, gint minor, GError **error);
+gchar** bd_dm_get_member_raid_sets (const gchar *name, const gchar *uuid, gint major, gint minor, GError **error);
 
 /**
  * bd_dm_activate_raid_set:
@@ -86,7 +86,7 @@ gchar** bd_dm_get_member_raid_sets (gchar *name, gchar *uuid, gint major, gint m
  *
  * Returns: whether the RAID set @name was successfully activate or not
  */
-gboolean bd_dm_activate_raid_set (gchar *name, GError **error);
+gboolean bd_dm_activate_raid_set (const gchar *name, GError **error);
 
 /**
  * bd_dm_deactivate_raid_set:
@@ -95,7 +95,7 @@ gboolean bd_dm_activate_raid_set (gchar *name, GError **error);
  *
  * Returns: whether the RAID set @name was successfully deactivate or not
  */
-gboolean bd_dm_deactivate_raid_set (gchar *name, GError **error);
+gboolean bd_dm_deactivate_raid_set (const gchar *name, GError **error);
 
 /**
  * bd_dm_get_raid_set_type:
@@ -104,4 +104,4 @@ gboolean bd_dm_deactivate_raid_set (gchar *name, GError **error);
  *
  * Returns: string representation of the @name RAID set's type
  */
-gchar* bd_dm_get_raid_set_type (gchar *name, GError **error);
+gchar* bd_dm_get_raid_set_type (const gchar *name, GError **error);

--- a/src/lib/plugin_apis/fs.api
+++ b/src/lib/plugin_apis/fs.api
@@ -123,7 +123,7 @@ GType bd_fs_xfs_info_get_type () {
  *
  * Returns: whether signagures were successfully wiped on @device or not
  */
-gboolean bd_fs_wipe (gchar *device, gboolean all, GError **error);
+gboolean bd_fs_wipe (const gchar *device, gboolean all, GError **error);
 
 
 /**
@@ -135,7 +135,7 @@ gboolean bd_fs_wipe (gchar *device, gboolean all, GError **error);
  *
  * Returns: whether a new ext4 fs was successfully created on @device or not
  */
-gboolean bd_fs_ext4_mkfs (gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_fs_ext4_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_fs_ext4_wipe:
@@ -145,7 +145,7 @@ gboolean bd_fs_ext4_mkfs (gchar *device, BDExtraArg **extra, GError **error);
  * Returns: whether an ext4 signature was successfully wiped from the @device or
  *          not
  */
-gboolean bd_fs_ext4_wipe (gchar *device, GError **error);
+gboolean bd_fs_ext4_wipe (const gchar *device, GError **error);
 
 /**
  * bd_fs_ext4_check:
@@ -156,7 +156,7 @@ gboolean bd_fs_ext4_wipe (gchar *device, GError **error);
  *
  * Returns: whether an ext4 file system on the @device is clean or not
  */
-gboolean bd_fs_ext4_check (gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_fs_ext4_check (const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_fs_ext4_repair:
@@ -169,7 +169,7 @@ gboolean bd_fs_ext4_check (gchar *device, BDExtraArg **extra, GError **error);
  * Returns: whether an ext4 file system on the @device was successfully repaired
  *          (if needed) or not (error is set in that case)
  */
-gboolean bd_fs_ext4_repair (gchar *device, gboolean unsafe, BDExtraArg **extra, GError **error);
+gboolean bd_fs_ext4_repair (const gchar *device, gboolean unsafe, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_fs_ext4_set_label:
@@ -180,7 +180,7 @@ gboolean bd_fs_ext4_repair (gchar *device, gboolean unsafe, BDExtraArg **extra, 
  * Returns: whether the label of ext4 file system on the @device was
  *          successfully set or not
  */
-gboolean bd_fs_ext4_set_label (gchar *device, gchar *label, GError **error);
+gboolean bd_fs_ext4_set_label (const gchar *device, const gchar *label, GError **error);
 
 /**
  * bd_fs_ext4_get_info:
@@ -190,7 +190,7 @@ gboolean bd_fs_ext4_set_label (gchar *device, gchar *label, GError **error);
  * Returns: (transfer full): information about the file system on @device or
  *                           %NULL in case of error
  */
-BDFSExt4Info* bd_fs_ext4_get_info (gchar *device, GError **error);
+BDFSExt4Info* bd_fs_ext4_get_info (const gchar *device, GError **error);
 
 /**
  * bd_fs_ext4_resize:
@@ -203,7 +203,7 @@ BDFSExt4Info* bd_fs_ext4_get_info (gchar *device, GError **error);
  *
  * Returns: whether the file system on @device was successfully resized or not
  */
-gboolean bd_fs_ext4_resize (gchar *device, guint64 new_size, BDExtraArg **extra, GError **error);
+gboolean bd_fs_ext4_resize (const gchar *device, guint64 new_size, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_fs_xfs_mkfs:
@@ -214,7 +214,7 @@ gboolean bd_fs_ext4_resize (gchar *device, guint64 new_size, BDExtraArg **extra,
  *
  * Returns: whether a new xfs fs was successfully created on @device or not
  */
-gboolean bd_fs_xfs_mkfs (gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_fs_xfs_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_fs_xfs_wipe:
@@ -224,7 +224,7 @@ gboolean bd_fs_xfs_mkfs (gchar *device, BDExtraArg **extra, GError **error);
  * Returns: whether an xfs signature was successfully wiped from the @device or
  *          not
  */
-gboolean bd_fs_xfs_wipe (gchar *device, GError **error);
+gboolean bd_fs_xfs_wipe (const gchar *device, GError **error);
 
 /**
  * bd_fs_xfs_check:
@@ -236,7 +236,7 @@ gboolean bd_fs_xfs_wipe (gchar *device, GError **error);
  * Note: if the file system is mounted it may be reported as unclean even if
  *       everything is okay and there are just some pending/in-progress writes
  */
-gboolean bd_fs_xfs_check (gchar *device, GError **error);
+gboolean bd_fs_xfs_check (const gchar *device, GError **error);
 
 /**
  * bd_fs_xfs_repair:
@@ -248,7 +248,7 @@ gboolean bd_fs_xfs_check (gchar *device, GError **error);
  * Returns: whether an xfs file system on the @device was successfully repaired
  *          (if needed) or not (error is set in that case)
  */
-gboolean bd_fs_xfs_repair (gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_fs_xfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_fs_xfs_set_label:
@@ -259,7 +259,7 @@ gboolean bd_fs_xfs_repair (gchar *device, BDExtraArg **extra, GError **error);
  * Returns: whether the label of xfs file system on the @device was
  *          successfully set or not
  */
-gboolean bd_fs_xfs_set_label (gchar *device, gchar *label, GError **error);
+gboolean bd_fs_xfs_set_label (const gchar *device, const gchar *label, GError **error);
 
 /**
  * bd_fs_xfs_get_info:
@@ -269,7 +269,7 @@ gboolean bd_fs_xfs_set_label (gchar *device, gchar *label, GError **error);
  * Returns: (transfer full): information about the file system on @device or
  *                           %NULL in case of error
  */
-BDFSXfsInfo* bd_fs_xfs_get_info (gchar *device, GError **error);
+BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error);
 
 /**
  * bd_fs_xfs_resize:
@@ -282,6 +282,6 @@ BDFSXfsInfo* bd_fs_xfs_get_info (gchar *device, GError **error);
  *
  * Returns: whether the file system mounted on @mpoint was successfully resized or not
  */
-gboolean bd_fs_xfs_resize (gchar *mpoint, guint64 new_size, BDExtraArg **extra, GError **error);
+gboolean bd_fs_xfs_resize (const gchar *mpoint, guint64 new_size, const BDExtraArg **extra, GError **error);
 
 #endif  /* BD_FS_API */

--- a/src/lib/plugin_apis/kbd.api
+++ b/src/lib/plugin_apis/kbd.api
@@ -159,7 +159,7 @@ GType bd_kbd_bcache_stats_get_type () {
  *
  * **Lengths of @size and @nstreams (if given) have to be >= @num_devices!**
  */
-gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error);
+gboolean bd_kbd_zram_create_devices (guint64 num_devices, const guint64 *sizes, const guint64 *nstreams, GError **error);
 
 /**
  * bd_kbd_zram_destroy_devices:
@@ -180,7 +180,7 @@ gboolean bd_kbd_zram_destroy_devices (GError **error);
  *
  * Returns: (transfer full): statistics for the zRAM device
  */
-BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error);
+BDKBDZramStats* bd_kbd_zram_get_stats (const gchar *device, GError **error);
 
 /**
  * bd_kbd_bcache_create:
@@ -193,7 +193,7 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error);
  *
  * Returns: whether the bcache device was successfully created or not
  */
-gboolean bd_kbd_bcache_create (gchar *backing_device, gchar *cache_device, BDExtraArg **extra, gchar **bcache_device, GError **error);
+gboolean bd_kbd_bcache_create (const gchar *backing_device, const gchar *cache_device, const BDExtraArg **extra, const gchar **bcache_device, GError **error);
 
 /**
  * bd_kbd_bcache_attach:
@@ -203,7 +203,7 @@ gboolean bd_kbd_bcache_create (gchar *backing_device, gchar *cache_device, BDExt
  *
  * Returns: whether the @c_set_uuid cache was successfully attached to @bcache_device or not
  */
-gboolean bd_kbd_bcache_attach (gchar *c_set_uuid, gchar *bcache_device, GError **error);
+gboolean bd_kbd_bcache_attach (const gchar *c_set_uuid, const gchar *bcache_device, GError **error);
 
 /**
  * bd_kbd_bcache_detach:
@@ -214,7 +214,7 @@ gboolean bd_kbd_bcache_attach (gchar *c_set_uuid, gchar *bcache_device, GError *
  *
  * Note: Flushes the cache first.
  */
-gboolean bd_kbd_bcache_detach (gchar *bcache_device, gchar **c_set_uuid, GError **error);
+gboolean bd_kbd_bcache_detach (const gchar *bcache_device, gchar **c_set_uuid, GError **error);
 
 /**
  * bd_kbd_bcache_destroy:
@@ -223,7 +223,7 @@ gboolean bd_kbd_bcache_detach (gchar *bcache_device, gchar **c_set_uuid, GError 
  *
  * Returns: whether the bcache device @bcache_device was successfully destroyed or not
  */
-gboolean bd_kbd_bcache_destroy (gchar *bcache_device, GError **error);
+gboolean bd_kbd_bcache_destroy (const gchar *bcache_device, GError **error);
 
 /**
  * bd_kbd_bcache_get_mode:
@@ -232,7 +232,7 @@ gboolean bd_kbd_bcache_destroy (gchar *bcache_device, GError **error);
  *
  * Returns: current mode of the @bcache_device
  */
-BDKBDBcacheMode bd_kbd_bcache_get_mode (gchar *bcache_device, GError **error);
+BDKBDBcacheMode bd_kbd_bcache_get_mode (const gchar *bcache_device, GError **error);
 
 /**
  * bd_kbd_bcache_get_mode_str:
@@ -250,7 +250,7 @@ const gchar* bd_kbd_bcache_get_mode_str (BDKBDBcacheMode mode, GError **error);
  *
  * Returns: mode matching the @mode_str given or %BD_KBD_MODE_UNKNOWN in case of no match
  */
-BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (gchar *mode_str, GError **error);
+BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (const gchar *mode_str, GError **error);
 
 /**
  * bd_kbd_bcache_set_mode:
@@ -260,7 +260,7 @@ BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (gchar *mode_str, GError **error
  *
  * Returns: whether the mode was successfully set or not
  */
-gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GError **error);
+gboolean bd_kbd_bcache_set_mode (const gchar *bcache_device, BDKBDBcacheMode mode, GError **error);
 
 /**
  * bd_kbd_bcache_status:
@@ -270,7 +270,7 @@ gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GEr
  * Returns: (transfer full): status of the @bcache_device or %NULL in case of
  *                           error (@error is set)
  */
-BDKBDBcacheStats* bd_kbd_bcache_status (gchar *bcache_device, GError **error);
+BDKBDBcacheStats* bd_kbd_bcache_status (const gchar *bcache_device, GError **error);
 
 /**
  * bd_kbd_bcache_get_backing_device:
@@ -280,7 +280,7 @@ BDKBDBcacheStats* bd_kbd_bcache_status (gchar *bcache_device, GError **error);
  * Returns: (transfer full): name of the backing device of the @bcache_device
  *                           or %NULL if failed to determine (@error is populated)
  */
-gchar* bd_kbd_bcache_get_backing_device (gchar *bcache_device, GError **error);
+gchar* bd_kbd_bcache_get_backing_device (const gchar *bcache_device, GError **error);
 
 /**
  * bd_kbd_bcache_get_cache_device:
@@ -293,6 +293,6 @@ gchar* bd_kbd_bcache_get_backing_device (gchar *bcache_device, GError **error);
  * Note: returns the name of the first cache device of @bcache_device (in case
  *       there are more)
  */
-gchar* bd_kbd_bcache_get_cache_device (gchar *bcache_device, GError **error);
+gchar* bd_kbd_bcache_get_cache_device (const gchar *bcache_device, GError **error);
 
 #endif  /* BD_KBD_API */

--- a/src/lib/plugin_apis/loop.api
+++ b/src/lib/plugin_apis/loop.api
@@ -15,7 +15,7 @@ typedef enum {
  * Returns: (transfer full): path of the device's backing file or %NULL if none
  *                           is found
  */
-gchar* bd_loop_get_backing_file (gchar *dev_name, GError **error);
+gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
 
 /**
  * bd_loop_get_loop_name:
@@ -24,7 +24,7 @@ gchar* bd_loop_get_backing_file (gchar *dev_name, GError **error);
  *
  * Returns: (transfer full): name of the loop device associated with the given @file
  */
-gchar* bd_loop_get_loop_name (gchar *file, GError **error);
+gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
 
 /**
  * bd_loop_setup:
@@ -34,7 +34,7 @@ gchar* bd_loop_get_loop_name (gchar *file, GError **error);
  *
  * Returns: whether the @file was successfully setup as a loop device or not
  */
-gboolean bd_loop_setup (gchar *file, gchar **loop_name, GError **error);
+gboolean bd_loop_setup (const gchar *file, const gchar **loop_name, GError **error);
 
 /**
  * bd_loop_teardown:
@@ -43,4 +43,4 @@ gboolean bd_loop_setup (gchar *file, gchar **loop_name, GError **error);
  *
  * Returns: whether the @loop device was successfully torn down or not
  */
-gboolean bd_loop_teardown (gchar *loop, GError **error);
+gboolean bd_loop_teardown (const gchar *loop, GError **error);

--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -391,7 +391,7 @@ gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard, GErr
  *
  * Returns: whether the PV was successfully created or not
  */
-gboolean bd_lvm_pvcreate (gchar *device, guint64 data_alignment, guint64 metadata_size, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_pvcreate (const gchar *device, guint64 data_alignment, guint64 metadata_size, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_pvresize:
@@ -407,7 +407,7 @@ gboolean bd_lvm_pvcreate (gchar *device, guint64 data_alignment, guint64 metadat
  * pvresize(8)). If given @size 0, adjusts the PV's size to the underlaying
  * block device's size.
  */
-gboolean bd_lvm_pvresize (gchar *device, guint64 size, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_pvresize (const gchar *device, guint64 size, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_pvremove:
@@ -418,7 +418,7 @@ gboolean bd_lvm_pvresize (gchar *device, guint64 size, BDExtraArg **extra, GErro
  *
  * Returns: whether the PV was successfully removed/destroyed or not
  */
-gboolean bd_lvm_pvremove (gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_pvremove (const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_pvmove:
@@ -433,7 +433,7 @@ gboolean bd_lvm_pvremove (gchar *device, BDExtraArg **extra, GError **error);
  * If @dest is %NULL, VG allocation rules are used for the extents from the @src
  * PV (see pvmove(8)).
  */
-gboolean bd_lvm_pvmove (gchar *src, gchar *dest, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_pvmove (const gchar *src, const gchar *dest, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_pvscan:
@@ -448,7 +448,7 @@ gboolean bd_lvm_pvmove (gchar *src, gchar *dest, BDExtraArg **extra, GError **er
  * The @device argument is used only if @update_cache is %TRUE. Otherwise the
  * whole system is scanned for PVs.
  */
-gboolean bd_lvm_pvscan (gchar *device, gboolean update_cache, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_pvscan (const gchar *device, gboolean update_cache, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_pvinfo:
@@ -458,7 +458,7 @@ gboolean bd_lvm_pvscan (gchar *device, gboolean update_cache, BDExtraArg **extra
  * Returns: (transfer full): information about the PV on the given @device or
  * %NULL in case of error (the @error) gets populated in those cases)
  */
-BDLVMPVdata* bd_lvm_pvinfo (gchar *device, GError **error);
+BDLVMPVdata* bd_lvm_pvinfo (const gchar *device, GError **error);
 
 /**
  * bd_lvm_pvs:
@@ -479,7 +479,7 @@ BDLVMPVdata** bd_lvm_pvs (GError **error);
  *
  * Returns: whether the VG @name was successfully created or not
  */
-gboolean bd_lvm_vgcreate (gchar *name, gchar **pv_list, guint64 pe_size, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgcreate (const gchar *name, const gchar **pv_list, guint64 pe_size, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_vgremove:
@@ -490,7 +490,7 @@ gboolean bd_lvm_vgcreate (gchar *name, gchar **pv_list, guint64 pe_size, BDExtra
  *
  * Returns: whether the VG was successfully removed or not
  */
-gboolean bd_lvm_vgremove (gchar *vg_name, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgremove (const gchar *vg_name, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_vgrename:
@@ -502,7 +502,7 @@ gboolean bd_lvm_vgremove (gchar *vg_name, BDExtraArg **extra, GError **error);
  *
  * Returns: whether the VG was successfully renamed or not
  */
-gboolean bd_lvm_vgrename (gchar *old_vg_name, gchar *new_vg_name, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgrename (const gchar *old_vg_name, const gchar *new_vg_name, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_vgactivate:
@@ -513,7 +513,7 @@ gboolean bd_lvm_vgrename (gchar *old_vg_name, gchar *new_vg_name, BDExtraArg **e
  *
  * Returns: whether the VG was successfully activated or not
  */
-gboolean bd_lvm_vgactivate (gchar *vg_name, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgactivate (const gchar *vg_name, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_vgdeactivate:
@@ -524,7 +524,7 @@ gboolean bd_lvm_vgactivate (gchar *vg_name, BDExtraArg **extra, GError **error);
  *
  * Returns: whether the VG was successfully deactivated or not
  */
-gboolean bd_lvm_vgdeactivate (gchar *vg_name, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgdeactivate (const gchar *vg_name, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_vgextend:
@@ -536,7 +536,7 @@ gboolean bd_lvm_vgdeactivate (gchar *vg_name, BDExtraArg **extra, GError **error
  *
  * Returns: whether the VG @vg_name was successfully extended with the given @device or not.
  */
-gboolean bd_lvm_vgextend (gchar *vg_name, gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgextend (const gchar *vg_name, const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_vgreduce:
@@ -552,7 +552,7 @@ gboolean bd_lvm_vgextend (gchar *vg_name, gchar *device, BDExtraArg **extra, GEr
  * Note: This function does not move extents off of the PV before removing
  *       it from the VG. You must do that first by calling #bd_lvm_pvmove.
  */
-gboolean bd_lvm_vgreduce (gchar *vg_name, gchar *device, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgreduce (const gchar *vg_name, const gchar *device, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_vginfo:
@@ -562,7 +562,7 @@ gboolean bd_lvm_vgreduce (gchar *vg_name, gchar *device, BDExtraArg **extra, GEr
  * Returns: (transfer full): information about the @vg_name VG or %NULL in case
  * of error (the @error) gets populated in those cases)
  */
-BDLVMVGdata* bd_lvm_vginfo (gchar *vg_name, GError **error);
+BDLVMVGdata* bd_lvm_vginfo (const gchar *vg_name, GError **error);
 
 /**
  * bd_lvm_vgs:
@@ -581,7 +581,7 @@ BDLVMVGdata** bd_lvm_vgs (GError **error);
  * Returns: (transfer full): the origin volume for the @vg_name/@lv_name LV or
  * %NULL if failed to determine (@error) is set in those cases)
  */
-gchar* bd_lvm_lvorigin (gchar *vg_name, gchar *lv_name, GError **error);
+gchar* bd_lvm_lvorigin (const gchar *vg_name, const gchar *lv_name, GError **error);
 
 /**
  * bd_lvm_lvcreate:
@@ -597,7 +597,7 @@ gchar* bd_lvm_lvorigin (gchar *vg_name, gchar *lv_name, GError **error);
  *
  * Returns: whether the given @vg_name/@lv_name LV was successfully created or not
  */
-gboolean bd_lvm_lvcreate (gchar *vg_name, gchar *lv_name, guint64 size, gchar *type, gchar **pv_list, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvcreate (const gchar *vg_name, const gchar *lv_name, guint64 size, const gchar *type, const gchar **pv_list, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_lvremove:
@@ -610,7 +610,7 @@ gboolean bd_lvm_lvcreate (gchar *vg_name, gchar *lv_name, guint64 size, gchar *t
  *
  * Returns: whether the @vg_name/@lv_name LV was successfully removed or not
  */
-gboolean bd_lvm_lvremove (gchar *vg_name, gchar *lv_name, gboolean force, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvremove (const gchar *vg_name, const gchar *lv_name, gboolean force, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_lvrename:
@@ -624,7 +624,7 @@ gboolean bd_lvm_lvremove (gchar *vg_name, gchar *lv_name, gboolean force, BDExtr
  * Returns: whether the @vg_name/@lv_name LV was successfully renamed to
  * @vg_name/@new_name or not
  */
-gboolean bd_lvm_lvrename (gchar *vg_name, gchar *lv_name, gchar *new_name, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvrename (const gchar *vg_name, const gchar *lv_name, const gchar *new_name, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_lvresize:
@@ -637,7 +637,7 @@ gboolean bd_lvm_lvrename (gchar *vg_name, gchar *lv_name, gchar *new_name, BDExt
  *
  * Returns: whether the @vg_name/@lv_name LV was successfully resized or not
  */
-gboolean bd_lvm_lvresize (gchar *vg_name, gchar *lv_name, guint64 size, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvresize (const gchar *vg_name, const gchar *lv_name, guint64 size, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_lvactivate:
@@ -650,7 +650,7 @@ gboolean bd_lvm_lvresize (gchar *vg_name, gchar *lv_name, guint64 size, BDExtraA
  *
  * Returns: whether the @vg_name/@lv_name LV was successfully activated or not
  */
-gboolean bd_lvm_lvactivate (gchar *vg_name, gchar *lv_name, gboolean ignore_skip, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_lvdeactivate:
@@ -662,7 +662,7 @@ gboolean bd_lvm_lvactivate (gchar *vg_name, gchar *lv_name, gboolean ignore_skip
  *
  * Returns: whether the @vg_name/@lv_name LV was successfully deactivated or not
  */
-gboolean bd_lvm_lvdeactivate (gchar *vg_name, gchar *lv_name, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvdeactivate (const gchar *vg_name, const gchar *lv_name, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_lvsnapshotcreate:
@@ -677,7 +677,7 @@ gboolean bd_lvm_lvdeactivate (gchar *vg_name, gchar *lv_name, BDExtraArg **extra
  * Returns: whether the @snapshot_name snapshot of the @vg_name/@origin_name LV
  * was successfully created or not.
  */
-gboolean bd_lvm_lvsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *snapshot_name, guint64 size, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvsnapshotcreate (const gchar *vg_name, const gchar *origin_name, const gchar *snapshot_name, guint64 size, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_lvsnapshotmerge:
@@ -689,7 +689,7 @@ gboolean bd_lvm_lvsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *sna
  *
  * Returns: whether the @vg_name/@snapshot_name LV snapshot was successfully merged or not
  */
-gboolean bd_lvm_lvsnapshotmerge (gchar *vg_name, gchar *snapshot_name, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvsnapshotmerge (const gchar *vg_name, const gchar *snapshot_name, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_lvinfo:
@@ -700,7 +700,7 @@ gboolean bd_lvm_lvsnapshotmerge (gchar *vg_name, gchar *snapshot_name, BDExtraAr
  * Returns: (transfer full): information about the @vg_name/@lv_name LV or %NULL in case
  * of error (the @error) gets populated in those cases)
  */
-BDLVMLVdata* bd_lvm_lvinfo (gchar *vg_name, gchar *lv_name, GError **error);
+BDLVMLVdata* bd_lvm_lvinfo (const gchar *vg_name, const gchar *lv_name, GError **error);
 
 /**
  * bd_lvm_lvs:
@@ -710,7 +710,7 @@ BDLVMLVdata* bd_lvm_lvinfo (gchar *vg_name, gchar *lv_name, GError **error);
  * Returns: (array zero-terminated=1): information about LVs found in the given
  * @vg_name VG or in system if @vg_name is %NULL
  */
-BDLVMLVdata** bd_lvm_lvs (gchar *vg_name, GError **error);
+BDLVMLVdata** bd_lvm_lvs (const gchar *vg_name, GError **error);
 
 /**
  * bd_lvm_thpoolcreate:
@@ -727,7 +727,7 @@ BDLVMLVdata** bd_lvm_lvs (gchar *vg_name, GError **error);
  *
  * Returns: whether the @vg_name/@lv_name thin pool was successfully created or not
  */
-gboolean bd_lvm_thpoolcreate (gchar *vg_name, gchar *lv_name, guint64 size, guint64 md_size, guint64 chunk_size, gchar *profile, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_thpoolcreate (const gchar *vg_name, const gchar *lv_name, guint64 size, guint64 md_size, guint64 chunk_size, const gchar *profile, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_thlvcreate:
@@ -741,7 +741,7 @@ gboolean bd_lvm_thpoolcreate (gchar *vg_name, gchar *lv_name, guint64 size, guin
  *
  * Returns: whether the @vg_name/@lv_name thin LV was successfully created or not
  */
-gboolean bd_lvm_thlvcreate (gchar *vg_name, gchar *pool_name, gchar *lv_name, guint64 size, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_thlvcreate (const gchar *vg_name, const gchar *pool_name, const gchar *lv_name, guint64 size, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_thlvpoolname:
@@ -752,7 +752,7 @@ gboolean bd_lvm_thlvcreate (gchar *vg_name, gchar *pool_name, gchar *lv_name, gu
  * Returns: (transfer full): the name of the pool volume for the @vg_name/@lv_name
  * thin LV or %NULL if failed to determine (@error) is set in those cases)
  */
-gchar* bd_lvm_thlvpoolname (gchar *vg_name, gchar *lv_name, GError **error);
+gchar* bd_lvm_thlvpoolname (const gchar *vg_name, const gchar *lv_name, GError **error);
 
 /**
  * bd_lvm_thsnapshotcreate:
@@ -767,7 +767,7 @@ gchar* bd_lvm_thlvpoolname (gchar *vg_name, gchar *lv_name, GError **error);
  * Returns: whether the @snapshot_name snapshot of the @vg_name/@origin_name
  * thin LV was successfully created or not.
  */
-gboolean bd_lvm_thsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *snapshot_name, gchar *pool_name, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_thsnapshotcreate (const gchar *vg_name, const gchar *origin_name, const gchar *snapshot_name, const gchar *pool_name, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_set_global_config:
@@ -778,7 +778,7 @@ gboolean bd_lvm_thsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *sna
  * Returns: whether the new requested global config @new_config was successfully
  *          set or not
  */
-gboolean bd_lvm_set_global_config (gchar *new_config, GError **error);
+gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error);
 
 /**
  * bd_lvm_get_global_config:
@@ -815,7 +815,7 @@ const gchar* bd_lvm_cache_get_mode_str (BDLVMCacheMode mode, GError **error);
  * Returns: cache mode for the @mode_str or %BD_LVM_CACHE_MODE_UNKNOWN if
  *          failed to determine
  */
-BDLVMCacheMode bd_lvm_cache_get_mode_from_str (gchar *mode_str, GError **error);
+BDLVMCacheMode bd_lvm_cache_get_mode_from_str (const gchar *mode_str, GError **error);
 
 /**
  * bd_lvm_cache_create_pool:
@@ -832,7 +832,7 @@ BDLVMCacheMode bd_lvm_cache_get_mode_from_str (gchar *mode_str, GError **error);
  *
  * Returns: whether the cache pool @vg_name/@pool_name was successfully created or not
  */
-gboolean bd_lvm_cache_create_pool (gchar *vg_name, gchar *pool_name, guint64 pool_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags, gchar **fast_pvs, GError **error);
+gboolean bd_lvm_cache_create_pool (const gchar *vg_name, const gchar *pool_name, guint64 pool_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags, const gchar **fast_pvs, GError **error);
 
 /**
  * bd_lvm_cache_attach:
@@ -845,7 +845,7 @@ gboolean bd_lvm_cache_create_pool (gchar *vg_name, gchar *pool_name, guint64 poo
  *
  * Returns: whether the @cache_pool_lv was successfully attached to the @data_lv or not
  */
-gboolean bd_lvm_cache_attach (gchar *vg_name, gchar *data_lv, gchar *cache_pool_lv, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_cache_attach (const gchar *vg_name, const gchar *data_lv, const gchar *cache_pool_lv, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_cache_detach:
@@ -860,7 +860,7 @@ gboolean bd_lvm_cache_attach (gchar *vg_name, gchar *data_lv, gchar *cache_pool_
  *
  * Note: synces the cache first
  */
-gboolean bd_lvm_cache_detach (gchar *vg_name, gchar *cached_lv, gboolean destroy, BDExtraArg **extra, GError **error);
+gboolean bd_lvm_cache_detach (const gchar *vg_name, const gchar *cached_lv, gboolean destroy, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_lvm_cache_create_cached_lv:
@@ -877,7 +877,7 @@ gboolean bd_lvm_cache_detach (gchar *vg_name, gchar *cached_lv, gboolean destroy
  *
  * Returns: whether the cached LV @lv_name was successfully created or not
  */
-gboolean bd_lvm_cache_create_cached_lv (gchar *vg_name, gchar *lv_name, guint64 data_size, guint64 cache_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags, gchar **slow_pvs, gchar **fast_pvs, GError **error);
+gboolean bd_lvm_cache_create_cached_lv (const gchar *vg_name, const gchar *lv_name, guint64 data_size, guint64 cache_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags, const gchar **slow_pvs, const gchar **fast_pvs, GError **error);
 
 /**
  * bd_lvm_cache_pool_name:
@@ -887,7 +887,7 @@ gboolean bd_lvm_cache_create_cached_lv (gchar *vg_name, gchar *lv_name, guint64 
  *
  * Returns: name of the cache pool LV used by the @cached_lv or %NULL in case of error
  */
-gchar* bd_lvm_cache_pool_name (gchar *vg_name, gchar *cached_lv, GError **error);
+gchar* bd_lvm_cache_pool_name (const gchar *vg_name, const gchar *cached_lv, GError **error);
 
 /**
  * bd_lvm_cache_stats:
@@ -897,7 +897,7 @@ gchar* bd_lvm_cache_pool_name (gchar *vg_name, gchar *cached_lv, GError **error)
  *
  * Returns: stats for the @cached_lv or %NULL in case of error
  */
-BDLVMCacheStats* bd_lvm_cache_stats (gchar *vg_name, gchar *cached_lv, GError **error);
+BDLVMCacheStats* bd_lvm_cache_stats (const gchar *vg_name, const gchar *cached_lv, GError **error);
 
 /**
  * bd_lvm_data_lv_name:
@@ -908,7 +908,7 @@ BDLVMCacheStats* bd_lvm_cache_stats (gchar *vg_name, gchar *cached_lv, GError **
  * Returns: (transfer full): the name of the (internal) data LV of the
  * @vg_name/@lv_name LV
  */
-gchar* bd_lvm_data_lv_name (gchar *vg_name, gchar *lv_name, GError **error);
+gchar* bd_lvm_data_lv_name (const gchar *vg_name, const gchar *lv_name, GError **error);
 
 /**
  * bd_lvm_metadata_lv_name:
@@ -919,6 +919,6 @@ gchar* bd_lvm_data_lv_name (gchar *vg_name, gchar *lv_name, GError **error);
  * Returns: (transfer full): the name of the (internal) metadata LV of the
  * @vg_name/@lv_name LV
  */
-gchar* bd_lvm_metadata_lv_name (gchar *vg_name, gchar *lv_name, GError **error);
+gchar* bd_lvm_metadata_lv_name (const gchar *vg_name, const gchar *lv_name, GError **error);
 
 #endif  /* BD_LVM_API */

--- a/src/lib/plugin_apis/mdraid.api
+++ b/src/lib/plugin_apis/mdraid.api
@@ -167,7 +167,7 @@ GType bd_md_detail_data_get_type () {
  * Returns: Calculated superblock size for an array with a given @member_size
  * and metadata @version or default if unsupported @version is used.
  */
-guint64 bd_md_get_superblock_size (guint64 member_size, gchar *version, GError **error);
+guint64 bd_md_get_superblock_size (guint64 member_size, const gchar *version, GError **error);
 
 /**
  * bd_md_create:
@@ -183,7 +183,7 @@ guint64 bd_md_get_superblock_size (guint64 member_size, gchar *version, GError *
  *
  * Returns: whether the new MD RAID device @device_name was successfully created or not
  */
-gboolean bd_md_create (gchar *device_name, gchar *level, gchar **disks, guint64 spares, gchar *version, gboolean bitmap, BDExtraArg **extra, GError **error);
+gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_md_create_with_chunk_size:
@@ -200,7 +200,7 @@ gboolean bd_md_create (gchar *device_name, gchar *level, gchar **disks, guint64 
  *
  * Returns: whether the new MD RAID device @device_name was successfully created or not
  */
-gboolean bd_md_create_with_chunk_size (gchar *device_name, gchar *level, gchar **disks, guint64 spares, gchar *version, gboolean bitmap, guint64 chunk_size, BDExtraArg **extra, GError **error);
+gboolean bd_md_create_with_chunk_size (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_md_destroy:
@@ -209,7 +209,7 @@ gboolean bd_md_create_with_chunk_size (gchar *device_name, gchar *level, gchar *
  *
  * Returns: whether the MD RAID metadata was successfully destroyed on @device or not
  */
-gboolean bd_md_destroy (gchar *device, GError **error);
+gboolean bd_md_destroy (const gchar *device, GError **error);
 
 /**
  * bd_md_deactivate:
@@ -218,7 +218,7 @@ gboolean bd_md_destroy (gchar *device, GError **error);
  *
  * Returns: whether the RAID device @device_name was successfully deactivated or not
  */
-gboolean bd_md_deactivate (gchar *device_name, GError **error);
+gboolean bd_md_deactivate (const gchar *device_name, GError **error);
 
 /**
  * bd_md_activate:
@@ -233,7 +233,7 @@ gboolean bd_md_deactivate (gchar *device_name, GError **error);
  *
  * Note: either @members or @uuid (or both) have to be specified.
  */
-gboolean bd_md_activate (gchar *device_name, gchar **members, gchar *uuid, BDExtraArg **extra, GError **error);
+gboolean bd_md_activate (const gchar *device_name, const gchar **members, const gchar *uuid, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_md_run:
@@ -242,7 +242,7 @@ gboolean bd_md_activate (gchar *device_name, gchar **members, gchar *uuid, BDExt
  *
  * Returns: whether the @raid_name was successfully started or not
  */
-gboolean bd_md_run (gchar *raid_name, GError **error);
+gboolean bd_md_run (const gchar *raid_name, GError **error);
 
 /**
  * bd_md_nominate:
@@ -254,7 +254,7 @@ gboolean bd_md_run (gchar *raid_name, GError **error);
  *
  * Note: may start the MD RAID if it becomes ready by adding @device.
  */
-gboolean bd_md_nominate (gchar *device, GError **error);
+gboolean bd_md_nominate (const gchar *device, GError **error);
 
 /**
  * bd_md_denominate:
@@ -266,7 +266,7 @@ gboolean bd_md_nominate (gchar *device, GError **error);
  *
  * Note: may start the MD RAID if it becomes ready by adding @device.
  */
-gboolean bd_md_denominate (gchar *device, GError **error);
+gboolean bd_md_denominate (const gchar *device, GError **error);
 
 /**
  * bd_md_add:
@@ -288,7 +288,7 @@ gboolean bd_md_denominate (gchar *device, GError **error);
  * Whether the new device will be added as a spare or an active member is
  * decided by mdadm.
  */
-gboolean bd_md_add (gchar *raid_name, gchar *device, guint64 raid_devs, BDExtraArg **extra, GError **error);
+gboolean bd_md_add (const gchar *raid_name, const gchar *device, guint64 raid_devs, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_md_remove:
@@ -302,7 +302,7 @@ gboolean bd_md_add (gchar *raid_name, gchar *device, guint64 raid_devs, BDExtraA
  * Returns: whether the @device was successfully removed from the @raid_name
  * RAID or not.
  */
-gboolean bd_md_remove (gchar *raid_name, gchar *device, gboolean fail, BDExtraArg **extra, GError **error);
+gboolean bd_md_remove (const gchar *raid_name, const gchar *device, gboolean fail, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_md_examine:
@@ -311,7 +311,7 @@ gboolean bd_md_remove (gchar *raid_name, gchar *device, gboolean fail, BDExtraAr
  *
  * Returns: information about the MD RAID extracted from the @device
  */
-BDMDExamineData* bd_md_examine (gchar *device, GError **error);
+BDMDExamineData* bd_md_examine (const gchar *device, GError **error);
 
 /**
  * bd_md_detail:
@@ -320,7 +320,7 @@ BDMDExamineData* bd_md_examine (gchar *device, GError **error);
  *
  * Returns: information about the MD RAID @raid_name
  */
-BDMDDetailData* bd_md_detail (gchar *raid_name, GError **error);
+BDMDDetailData* bd_md_detail (const gchar *raid_name, GError **error);
 
 /**
  * bd_md_canonicalize_uuid:
@@ -332,7 +332,7 @@ BDMDDetailData* bd_md_detail (gchar *raid_name, GError **error);
  * This function expects a UUID in the form that mdadm returns. The change is as
  * follows: 3386ff85:f5012621:4a435f06:1eb47236 -> 3386ff85-f501-2621-4a43-5f061eb47236
  */
-gchar* bd_md_canonicalize_uuid (gchar *uuid, GError **error);
+gchar* bd_md_canonicalize_uuid (const gchar *uuid, GError **error);
 
 /**
  * bd_md_get_md_uuid:
@@ -346,7 +346,7 @@ gchar* bd_md_canonicalize_uuid (gchar *uuid, GError **error);
  * bd_md_canonicalize_uuid(). The change is as follows:
  * 3386ff85-f501-2621-4a43-5f061eb47236 -> 3386ff85:f5012621:4a435f06:1eb47236
  */
-gchar* bd_md_get_md_uuid (gchar *uuid, GError **error);
+gchar* bd_md_get_md_uuid (const gchar *uuid, GError **error);
 
 /**
  * bd_md_node_from_name:
@@ -355,7 +355,7 @@ gchar* bd_md_get_md_uuid (gchar *uuid, GError **error);
  *
  * Returns: path to the @name MD RAID's device node or %NULL in case of error
  */
-gchar* bd_md_node_from_name (gchar *name, GError **error);
+gchar* bd_md_node_from_name (const gchar *name, GError **error);
 
 /**
  * bd_md_name_from_node:
@@ -364,6 +364,6 @@ gchar* bd_md_node_from_name (gchar *name, GError **error);
  *
  * Returns: @name of the MD RAID the device node belongs to or %NULL in case of error
  */
-gchar* bd_md_name_from_node (gchar *node, GError **error);
+gchar* bd_md_name_from_node (const gchar *node, GError **error);
 
 #endif  /* BD_MD_API */

--- a/src/lib/plugin_apis/mpath.api
+++ b/src/lib/plugin_apis/mpath.api
@@ -27,7 +27,7 @@ gboolean bd_mpath_flush_mpaths (GError **error);
  * Returns: %TRUE if the device is a multipath member, %FALSE if not or an error
  * appeared when queried (@error is set in those cases)
  */
-gboolean bd_mpath_is_mpath_member (gchar *device, GError **error);
+gboolean bd_mpath_is_mpath_member (const gchar *device, GError **error);
 
 /**
  * bd_mpath_set_friendly_names:

--- a/src/lib/plugin_apis/part.api
+++ b/src/lib/plugin_apis/part.api
@@ -110,7 +110,7 @@ GType bd_part_spec_get_type () {
  *
  * Returns: whether the partition table was successfully created or not
  */
-gboolean bd_part_create_table (gchar *disk, BDPartTableType type, gboolean ignore_existing, GError **error);
+gboolean bd_part_create_table (const gchar *disk, BDPartTableType type, gboolean ignore_existing, GError **error);
 
 /**
  * bd_part_get_part_spec:
@@ -120,7 +120,7 @@ gboolean bd_part_create_table (gchar *disk, BDPartTableType type, gboolean ignor
  *
  * Returns: spec of the @part partition from @disk or %NULL in case of error
  */
-BDPartSpec* bd_part_get_part_spec (gchar *disk, gchar *part, GError **error);
+BDPartSpec* bd_part_get_part_spec (const gchar *disk, const gchar *part, GError **error);
 
 /**
  * bd_part_get_disk_parts:
@@ -129,7 +129,7 @@ BDPartSpec* bd_part_get_part_spec (gchar *disk, gchar *part, GError **error);
  *
  * Returns: (transfer full) (array zero-terminated=1): specs of the partitions from @disk or %NULL in case of error
  */
-BDPartSpec** bd_part_get_disk_parts (gchar *disk, GError **error);
+BDPartSpec** bd_part_get_disk_parts (const gchar *disk, GError **error);
 
 /**
  * bd_part_create_part:
@@ -147,7 +147,7 @@ BDPartSpec** bd_part_get_disk_parts (gchar *disk, GError **error);
  * NOTE: The resulting partition may start at a different position than given by
  *       @start and can have different size than @size due to alignment.
  */
-BDPartSpec* bd_part_create_part (gchar *disk, BDPartTypeReq type, guint64 start, guint64 size, BDPartAlign align, GError **error);
+BDPartSpec* bd_part_create_part (const gchar *disk, BDPartTypeReq type, guint64 start, guint64 size, BDPartAlign align, GError **error);
 
 /**
  * bd_part_delete_part:
@@ -157,7 +157,7 @@ BDPartSpec* bd_part_create_part (gchar *disk, BDPartTypeReq type, guint64 start,
  *
  * Returns: whether the @part partition was successfully deleted from @disk
  */
-gboolean bd_part_delete_part (gchar *disk, gchar *part, GError **error);
+gboolean bd_part_delete_part (const gchar *disk, const gchar *part, GError **error);
 
 /**
  * bd_part_set_part_flag:
@@ -170,7 +170,7 @@ gboolean bd_part_delete_part (gchar *disk, gchar *part, GError **error);
  * Returns: whether the flag @flag was successfully set on the @part partition
  * or not.
  */
-gboolean bd_part_set_part_flag (gchar *disk, gchar *part, BDPartFlag flag, gboolean state, GError **error);
+gboolean bd_part_set_part_flag (const gchar *disk, const gchar *part, BDPartFlag flag, gboolean state, GError **error);
 
 /**
  * bd_part_get_part_table_type_str:

--- a/src/lib/plugin_apis/s390.api
+++ b/src/lib/plugin_apis/s390.api
@@ -23,7 +23,7 @@ typedef enum {
  *
  * Returns: whether dasdfmt was successful or not
  */
-gboolean bd_s390_dasd_format (const gchar *dasd, BDExtraArg **extra, GError **error);
+gboolean bd_s390_dasd_format (const gchar *dasd, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_s390_dasd_needs_format:
@@ -41,7 +41,7 @@ gboolean bd_s390_dasd_needs_format (const gchar *dasd, GError **error);
  *
  * Returns: whether a dasd was successfully switched online
  */
-gboolean bd_s390_dasd_online (gchar *dasd, GError **error);
+gboolean bd_s390_dasd_online (const gchar *dasd, GError **error);
 
 /**
  * bd_s390_dasd_is_Ldl:

--- a/src/lib/plugin_apis/swap.api
+++ b/src/lib/plugin_apis/swap.api
@@ -17,7 +17,7 @@ typedef enum {
  *
  * Returns: whether the swap space was successfully created or not
  */
-gboolean bd_swap_mkswap (gchar *device, gchar *label, BDExtraArg **extra, GError **error);
+gboolean bd_swap_mkswap (const gchar *device, const gchar *label, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_swap_swapon:
@@ -27,7 +27,7 @@ gboolean bd_swap_mkswap (gchar *device, gchar *label, BDExtraArg **extra, GError
  *
  * Returns: whether the swap device was successfully activated or not
  */
-gboolean bd_swap_swapon (gchar *device, gint priority, GError **error);
+gboolean bd_swap_swapon (const gchar *device, gint priority, GError **error);
 
 /**
  * bd_swap_swapoff:
@@ -36,7 +36,7 @@ gboolean bd_swap_swapon (gchar *device, gint priority, GError **error);
  *
  * Returns: whether the swap device was successfully deactivated or not
  */
-gboolean bd_swap_swapoff (gchar *device, GError **error);
+gboolean bd_swap_swapoff (const gchar *device, GError **error);
 
 /**
  * bd_swap_swapstatus:
@@ -46,4 +46,4 @@ gboolean bd_swap_swapoff (gchar *device, GError **error);
  * Returns: %TRUE if the swap device is active, %FALSE if not active or failed
  * to determine (@error) is set not a non-NULL value in such case)
  */
-gboolean bd_swap_swapstatus (gchar *device, GError **error);
+gboolean bd_swap_swapstatus (const gchar *device, GError **error);

--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -184,14 +184,14 @@ static BDBtrfsFilesystemInfo* get_filesystem_info_from_match (GMatchInfo *match_
  *
  * See mkfs.btrfs(8) for details about @data_level, @md_level and btrfs in general.
  */
-gboolean bd_btrfs_create_volume (gchar **devices, gchar *label, gchar *data_level, gchar *md_level, BDExtraArg **extra, GError **error) {
-    gchar **device_p = NULL;
+gboolean bd_btrfs_create_volume (const gchar **devices, const gchar *label, const gchar *data_level, const gchar *md_level, const BDExtraArg **extra, GError **error) {
+    const gchar **device_p = NULL;
     guint8 num_args = 0;
-    gchar **argv = NULL;
+    const gchar **argv = NULL;
     guint8 next_arg = 1;
     gboolean success = FALSE;
 
-    if (!devices || (g_strv_length (devices) < 1)) {
+    if (!devices || (g_strv_length ((gchar **) devices) < 1)) {
         g_set_error (error, BD_BTRFS_ERROR, BD_BTRFS_ERROR_DEVICE, "No devices given");
         return FALSE;
     }
@@ -211,7 +211,7 @@ gboolean bd_btrfs_create_volume (gchar **devices, gchar *label, gchar *data_leve
     if (md_level)
         num_args += 2;
 
-    argv = g_new0 (gchar*, num_args + 2);
+    argv = g_new0 (const gchar*, num_args + 2);
     argv[0] = "mkfs.btrfs";
     if (label) {
         argv[next_arg] = "--label";
@@ -251,8 +251,8 @@ gboolean bd_btrfs_create_volume (gchar **devices, gchar *label, gchar *data_leve
  *
  * Returns: whether the @device was successfully added to the @mountpoint btrfs volume or not
  */
-gboolean bd_btrfs_add_device (gchar *mountpoint, gchar *device, BDExtraArg **extra, GError **error) {
-    gchar *argv[6] = {"btrfs", "device", "add", device, mountpoint, NULL};
+gboolean bd_btrfs_add_device (const gchar *mountpoint, const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[6] = {"btrfs", "device", "add", device, mountpoint, NULL};
     return bd_utils_exec_and_report_error (argv, extra, error);
 }
 
@@ -266,8 +266,8 @@ gboolean bd_btrfs_add_device (gchar *mountpoint, gchar *device, BDExtraArg **ext
  *
  * Returns: whether the @device was successfully removed from the @mountpoint btrfs volume or not
  */
-gboolean bd_btrfs_remove_device (gchar *mountpoint, gchar *device, BDExtraArg **extra, GError **error) {
-    gchar *argv[6] = {"btrfs", "device", "delete", device, mountpoint, NULL};
+gboolean bd_btrfs_remove_device (const gchar *mountpoint, const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[6] = {"btrfs", "device", "delete", device, mountpoint, NULL};
     return bd_utils_exec_and_report_error (argv, extra, error);
 }
 
@@ -281,10 +281,10 @@ gboolean bd_btrfs_remove_device (gchar *mountpoint, gchar *device, BDExtraArg **
  *
  * Returns: whether the @mountpoint/@name subvolume was successfully created or not
  */
-gboolean bd_btrfs_create_subvolume (gchar *mountpoint, gchar *name, BDExtraArg **extra, GError **error) {
+gboolean bd_btrfs_create_subvolume (const gchar *mountpoint, const gchar *name, const BDExtraArg **extra, GError **error) {
     gchar *path = NULL;
     gboolean success = FALSE;
-    gchar *argv[5] = {"btrfs", "subvol", "create", NULL, NULL};
+    const gchar *argv[5] = {"btrfs", "subvol", "create", NULL, NULL};
 
     if (g_str_has_suffix (mountpoint, "/"))
         path = g_strdup_printf ("%s%s", mountpoint, name);
@@ -308,10 +308,10 @@ gboolean bd_btrfs_create_subvolume (gchar *mountpoint, gchar *name, BDExtraArg *
  *
  * Returns: whether the @mountpoint/@name subvolume was successfully deleted or not
  */
-gboolean bd_btrfs_delete_subvolume (gchar *mountpoint, gchar *name, BDExtraArg **extra, GError **error) {
+gboolean bd_btrfs_delete_subvolume (const gchar *mountpoint, const gchar *name, const BDExtraArg **extra, GError **error) {
     gchar *path = NULL;
     gboolean success = FALSE;
-    gchar *argv[5] = {"btrfs", "subvol", "delete", NULL, NULL};
+    const gchar *argv[5] = {"btrfs", "subvol", "delete", NULL, NULL};
 
     if (g_str_has_suffix (mountpoint, "/"))
         path = g_strdup_printf ("%s%s", mountpoint, name);
@@ -333,14 +333,14 @@ gboolean bd_btrfs_delete_subvolume (gchar *mountpoint, gchar *name, BDExtraArg *
  * Returns: ID of the @mountpoint volume's default subvolume. If 0,
  * @error) may be set to indicate error
  */
-guint64 bd_btrfs_get_default_subvolume_id (gchar *mountpoint, GError **error) {
+guint64 bd_btrfs_get_default_subvolume_id (const gchar *mountpoint, GError **error) {
     GRegex *regex = NULL;
     GMatchInfo *match_info = NULL;
     gboolean success = FALSE;
     gchar *output = NULL;
     gchar *match = NULL;
     guint64 ret = 0;
-    gchar *argv[5] = {"btrfs", "subvol", "get-default", mountpoint, NULL};
+    const gchar *argv[5] = {"btrfs", "subvol", "get-default", mountpoint, NULL};
 
     regex = g_regex_new ("ID (\\d+) .*", 0, 0, error);
     if (!regex) {
@@ -386,13 +386,13 @@ guint64 bd_btrfs_get_default_subvolume_id (gchar *mountpoint, GError **error) {
  * Returns: whether the @mountpoint volume's default subvolume was correctly set
  * to @subvol_id or not
  */
-gboolean bd_btrfs_set_default_subvolume (gchar *mountpoint, guint64 subvol_id, BDExtraArg **extra, GError **error) {
-    gchar *argv[6] = {"btrfs", "subvol", "set-default", NULL, mountpoint, NULL};
+gboolean bd_btrfs_set_default_subvolume (const gchar *mountpoint, guint64 subvol_id, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[6] = {"btrfs", "subvol", "set-default", NULL, mountpoint, NULL};
     gboolean ret = FALSE;
 
     argv[3] = g_strdup_printf ("%"G_GUINT64_FORMAT, subvol_id);
     ret = bd_utils_exec_and_report_error (argv, extra, error);
-    g_free (argv[3]);
+    g_free ((gchar *) argv[3]);
 
     return ret;
 }
@@ -408,8 +408,8 @@ gboolean bd_btrfs_set_default_subvolume (gchar *mountpoint, guint64 subvol_id, B
  *
  * Returns: whether the @dest snapshot of @source was successfully created or not
  */
-gboolean bd_btrfs_create_snapshot (gchar *source, gchar *dest, gboolean ro, BDExtraArg **extra, GError **error) {
-    gchar *argv[7] = {"btrfs", "subvol", "snapshot", NULL, NULL, NULL, NULL};
+gboolean bd_btrfs_create_snapshot (const gchar *source, const gchar *dest, gboolean ro, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[7] = {"btrfs", "subvol", "snapshot", NULL, NULL, NULL, NULL};
     guint next_arg = 3;
 
     if (ro) {
@@ -431,8 +431,8 @@ gboolean bd_btrfs_create_snapshot (gchar *source, gchar *dest, gboolean ro, BDEx
  * Returns: (array zero-terminated=1): information about the devices that are part of the btrfs volume
  * containing @device or %NULL in case of error
  */
-BDBtrfsDeviceInfo** bd_btrfs_list_devices (gchar *device, GError **error) {
-    gchar *argv[5] = {"btrfs", "filesystem", "show", device, NULL};
+BDBtrfsDeviceInfo** bd_btrfs_list_devices (const gchar *device, GError **error) {
+    const gchar *argv[5] = {"btrfs", "filesystem", "show", device, NULL};
     gchar *output = NULL;
     gboolean success = FALSE;
     gchar **lines = NULL;
@@ -503,8 +503,8 @@ BDBtrfsDeviceInfo** bd_btrfs_list_devices (gchar *device, GError **error) {
  * The subvolumes are sorted in a way that no child subvolume appears in the
  * list before its parent (sub)volume.
  */
-BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (gchar *mountpoint, gboolean snapshots_only, GError **error) {
-    gchar *argv[7] = {"btrfs", "subvol", "list", "-p", NULL, NULL, NULL};
+BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (const gchar *mountpoint, gboolean snapshots_only, GError **error) {
+    const gchar *argv[7] = {"btrfs", "subvol", "list", "-p", NULL, NULL, NULL};
     gchar *output = NULL;
     gboolean success = FALSE;
     gchar **lines = NULL;
@@ -608,8 +608,8 @@ BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (gchar *mountpoint, gboolean sna
  *
  * Returns: information about the @device's volume's filesystem or %NULL in case of error
  */
-BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info (gchar *device, GError **error) {
-    gchar *argv[5] = {"btrfs", "filesystem", "show", device, NULL};
+BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info (const gchar *device, GError **error) {
+    const gchar *argv[5] = {"btrfs", "filesystem", "show", device, NULL};
     gchar *output = NULL;
     gboolean success = FALSE;
     gchar const * const pattern = "Label:\\s+(none|'(?P<label>.+)')\\s+" \
@@ -661,7 +661,7 @@ BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info (gchar *device, GError **error) 
  *
  * See mkfs.btrfs(8) for details about @data_level, @md_level and btrfs in general.
  */
-gboolean bd_btrfs_mkfs (gchar **devices, gchar *label, gchar *data_level, gchar *md_level, BDExtraArg **extra, GError **error) {
+gboolean bd_btrfs_mkfs (const gchar **devices, const gchar *label, const gchar *data_level, const gchar *md_level, const BDExtraArg **extra, GError **error) {
     return bd_btrfs_create_volume (devices, label, data_level, md_level, extra, error);
 }
 
@@ -676,13 +676,13 @@ gboolean bd_btrfs_mkfs (gchar **devices, gchar *label, gchar *data_level, gchar 
  * Returns: whether the @mountpoint filesystem was successfully resized to @size
  * or not
  */
-gboolean bd_btrfs_resize (gchar *mountpoint, guint64 size, BDExtraArg **extra, GError **error) {
-    gchar *argv[6] = {"btrfs", "filesystem", "resize", NULL, mountpoint, NULL};
+gboolean bd_btrfs_resize (const gchar *mountpoint, guint64 size, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[6] = {"btrfs", "filesystem", "resize", NULL, mountpoint, NULL};
     gboolean ret = FALSE;
 
     argv[3] = g_strdup_printf ("%"G_GUINT64_FORMAT, size);
     ret = bd_utils_exec_and_report_error (argv, extra, error);
-    g_free (argv[3]);
+    g_free ((gchar *) argv[3]);
 
     return ret;
 }
@@ -696,8 +696,8 @@ gboolean bd_btrfs_resize (gchar *mountpoint, guint64 size, BDExtraArg **extra, G
  *
  * Returns: whether the filesystem was successfully checked or not
  */
-gboolean bd_btrfs_check (gchar *device, BDExtraArg **extra, GError **error) {
-    gchar *argv[4] = {"btrfs", "check", device, NULL};
+gboolean bd_btrfs_check (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[4] = {"btrfs", "check", device, NULL};
 
     return bd_utils_exec_and_report_error (argv, extra, error);
 }
@@ -711,8 +711,8 @@ gboolean bd_btrfs_check (gchar *device, BDExtraArg **extra, GError **error) {
  *
  * Returns: whether the filesystem was successfully checked and repaired or not
  */
-gboolean bd_btrfs_repair (gchar *device, BDExtraArg **extra, GError **error) {
-    gchar *argv[5] = {"btrfs", "check", "--repair", device, NULL};
+gboolean bd_btrfs_repair (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[5] = {"btrfs", "check", "--repair", device, NULL};
 
     return bd_utils_exec_and_report_error (argv, extra, error);
 }
@@ -726,8 +726,8 @@ gboolean bd_btrfs_repair (gchar *device, BDExtraArg **extra, GError **error) {
  * Returns: whether the label of the @mountpoint filesystem was successfully set
  * to @label or not
  */
-gboolean bd_btrfs_change_label (gchar *mountpoint, gchar *label, GError **error) {
-    gchar *argv[6] = {"btrfs", "filesystem", "label", mountpoint, label, NULL};
+gboolean bd_btrfs_change_label (const gchar *mountpoint, const gchar *label, GError **error) {
+    const gchar *argv[6] = {"btrfs", "filesystem", "label", mountpoint, label, NULL};
 
     return bd_utils_exec_and_report_error (argv, NULL, error);
 }

--- a/src/plugins/btrfs.h
+++ b/src/plugins/btrfs.h
@@ -46,22 +46,22 @@ typedef struct BDBtrfsFilesystemInfo {
 void bd_btrfs_filesystem_info_free (BDBtrfsFilesystemInfo *info);
 BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info_copy (BDBtrfsFilesystemInfo *info);
 
-gboolean bd_btrfs_create_volume (gchar **devices, gchar *label, gchar *data_level, gchar *md_level, BDExtraArg **extra, GError **error);
-gboolean bd_btrfs_add_device (gchar *mountpoint, gchar *device, BDExtraArg **extra, GError **error);
-gboolean bd_btrfs_remove_device (gchar *mountpoint, gchar *device, BDExtraArg **extra, GError **error);
-gboolean bd_btrfs_create_subvolume (gchar *mountpoint, gchar *name, BDExtraArg **extra, GError **error);
-gboolean bd_btrfs_delete_subvolume (gchar *mountpoint, gchar *name, BDExtraArg **extra, GError **error);
-guint64 bd_btrfs_get_default_subvolume_id (gchar *mountpoint, GError **error);
-gboolean bd_btrfs_set_default_subvolume (gchar *mountpoint, guint64 subvol_id, BDExtraArg **extra, GError **error);
-gboolean bd_btrfs_create_snapshot (gchar *source, gchar *dest, gboolean ro, BDExtraArg **extra, GError **error);
-BDBtrfsDeviceInfo** bd_btrfs_list_devices (gchar *device, GError **error);
-BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (gchar *mountpoint, gboolean snapshots_only, GError **error);
-BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info (gchar *device, GError **error);
+gboolean bd_btrfs_create_volume (const gchar **devices, const gchar *label, const gchar *data_level, const gchar *md_level, const BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_add_device (const gchar *mountpoint, const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_remove_device (const gchar *mountpoint, const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_create_subvolume (const gchar *mountpoint, const gchar *name, const BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_delete_subvolume (const gchar *mountpoint, const gchar *name, const BDExtraArg **extra, GError **error);
+guint64 bd_btrfs_get_default_subvolume_id (const gchar *mountpoint, GError **error);
+gboolean bd_btrfs_set_default_subvolume (const gchar *mountpoint, guint64 subvol_id, const BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_create_snapshot (const gchar *source, const gchar *dest, gboolean ro, const BDExtraArg **extra, GError **error);
+BDBtrfsDeviceInfo** bd_btrfs_list_devices (const gchar *device, GError **error);
+BDBtrfsSubvolumeInfo** bd_btrfs_list_subvolumes (const gchar *mountpoint, gboolean snapshots_only, GError **error);
+BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info (const gchar *device, GError **error);
 
-gboolean bd_btrfs_mkfs (gchar **devices, gchar *label, gchar *data_level, gchar *md_level, BDExtraArg **extra, GError **error);
-gboolean bd_btrfs_resize (gchar *mountpoint, guint64 size, BDExtraArg **extra, GError **error);
-gboolean bd_btrfs_check (gchar *device, BDExtraArg **extra, GError **error);
-gboolean bd_btrfs_repair (gchar *device, BDExtraArg **extra, GError **error);
-gboolean bd_btrfs_change_label (gchar *mountpoint, gchar *label, GError **error);
+gboolean bd_btrfs_mkfs (const gchar **devices, const gchar *label, const gchar *data_level, const gchar *md_level, const BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_resize (const gchar *mountpoint, guint64 size, const BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_check (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_btrfs_change_label (const gchar *mountpoint, const gchar *label, GError **error);
 
 #endif  /* BD_BTRFS */

--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -683,7 +683,7 @@ static gboolean write_escrow_data_file (struct libvk_volume *volume, struct libv
         return FALSE;
     }
 
-    status = g_io_channel_write_chars (out_file, (gchar *) packet_data, (gssize) packet_data_size,
+    status = g_io_channel_write_chars (out_file, (const gchar *) packet_data, (gssize) packet_data_size,
                                        &bytes_written, error);
     g_free (packet_data);
     if (status != G_IO_STATUS_NORMAL) {

--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -93,9 +93,9 @@ gboolean check() {
  * Returns: whether the new linear mapping @map_name was successfully created
  * for the @device or not
  */
-gboolean bd_dm_create_linear (gchar *map_name, gchar *device, guint64 length, gchar *uuid, GError **error) {
+gboolean bd_dm_create_linear (const gchar *map_name, const gchar *device, guint64 length, const gchar *uuid, GError **error) {
     gboolean success = FALSE;
-    gchar *argv[9] = {"dmsetup", "create", map_name, "--table", NULL, NULL, NULL, NULL, NULL};
+    const gchar *argv[9] = {"dmsetup", "create", map_name, "--table", NULL, NULL, NULL, NULL, NULL};
 
     gchar *table = g_strdup_printf ("0 %"G_GUINT64_FORMAT" linear %s 0", length, device);
     argv[4] = table;
@@ -120,8 +120,8 @@ gboolean bd_dm_create_linear (gchar *map_name, gchar *device, guint64 length, gc
  *
  * Returns: whether the @map_name map was successfully removed or not
  */
-gboolean bd_dm_remove (gchar *map_name, GError **error) {
-    gchar *argv[4] = {"dmsetup", "remove", map_name, NULL};
+gboolean bd_dm_remove (const gchar *map_name, GError **error) {
+    const gchar *argv[4] = {"dmsetup", "remove", map_name, NULL};
 
     return bd_utils_exec_and_report_error (argv, NULL, error);
 }
@@ -134,7 +134,7 @@ gboolean bd_dm_remove (gchar *map_name, GError **error) {
  * Returns: map name of the map providing the @dm_node device or %NULL
  * (@error) contains the error in such cases)
  */
-gchar* bd_dm_name_from_node (gchar *dm_node, GError **error) {
+gchar* bd_dm_name_from_node (const gchar *dm_node, GError **error) {
     gchar *ret = NULL;
     gboolean success = FALSE;
 
@@ -166,7 +166,7 @@ gchar* bd_dm_name_from_node (gchar *dm_node, GError **error) {
  * Returns: DM node name for the @map_name map or %NULL (@error) contains
  * the error in such cases)
  */
-gchar* bd_dm_node_from_name (gchar *map_name, GError **error) {
+gchar* bd_dm_node_from_name (const gchar *map_name, GError **error) {
     gchar *symlink = NULL;
     gchar *ret = NULL;
     gchar *dev_mapper_path = g_strdup_printf ("/dev/mapper/%s", map_name);
@@ -198,7 +198,7 @@ gchar* bd_dm_node_from_name (gchar *map_name, GError **error) {
  * %TRUE (and is active if @active_only is %TRUE)). If %FALSE is returned,
  * @error) indicates whether error appeared (non-%NULL) or not (%NULL).
  */
-gboolean bd_dm_map_exists (gchar *map_name, gboolean live_only, gboolean active_only, GError **error) {
+gboolean bd_dm_map_exists (const gchar *map_name, gboolean live_only, gboolean active_only, GError **error) {
     struct dm_task *task_list = NULL;
     struct dm_task *task_info = NULL;
 	struct dm_names *names = NULL;
@@ -320,7 +320,7 @@ static struct lib_context* init_dmraid_stack (GError **error) {
  * Returns: whether the device specified by @sysname matches the spec given by @name,
  *          @uuid, @major and @minor
  */
-static gboolean raid_dev_matches_spec (struct raid_dev *raid_dev, gchar *name, gchar *uuid, gint major, gint minor) {
+static gboolean raid_dev_matches_spec (struct raid_dev *raid_dev, const gchar *name, const gchar *uuid, gint major, gint minor) {
     gchar const *dev_name = NULL;
     gchar const *dev_uuid;
     gchar const *major_str;
@@ -372,7 +372,7 @@ static gboolean raid_dev_matches_spec (struct raid_dev *raid_dev, gchar *name, g
 /**
  * find_raid_sets_for_dev: (skip)
  */
-static void find_raid_sets_for_dev (gchar *name, gchar *uuid, gint major, gint minor, struct lib_context *lc, struct raid_set *rs, GPtrArray *ret_sets) {
+static void find_raid_sets_for_dev (const gchar *name, const gchar *uuid, gint major, gint minor, struct lib_context *lc, struct raid_set *rs, GPtrArray *ret_sets) {
     struct raid_set *subset;
     struct raid_dev *dev;
 
@@ -400,7 +400,7 @@ static void find_raid_sets_for_dev (gchar *name, gchar *uuid, gint major, gint m
  *
  * One of @name, @uuid or @major:@minor has to be given.
  */
-gchar** bd_dm_get_member_raid_sets (gchar *name, gchar *uuid, gint major, gint minor, GError **error) {
+gchar** bd_dm_get_member_raid_sets (const gchar *name, const gchar *uuid, gint major, gint minor, GError **error) {
     guint64 i = 0;
     struct lib_context *lc = NULL;
     struct raid_set *rs = NULL;
@@ -463,7 +463,7 @@ static struct raid_set* rs_matches_name (struct raid_set *rs, gpointer *name_dat
         return NULL;
 }
 
-static gboolean change_set_by_name (gchar *name, enum activate_type action, GError **error) {
+static gboolean change_set_by_name (const gchar *name, enum activate_type action, GError **error) {
     gint rc = 0;
     struct lib_context *lc;
     struct raid_set *iter_rs;
@@ -475,7 +475,7 @@ static gboolean change_set_by_name (gchar *name, enum activate_type action, GErr
         return FALSE;
 
     for_each_raidset (lc, iter_rs) {
-        match_rs = find_in_raid_sets (iter_rs, (RSEvalFunc)rs_matches_name, name);
+        match_rs = find_in_raid_sets (iter_rs, (RSEvalFunc)rs_matches_name, (gchar *)name);
         if (match_rs)
             break;
     }
@@ -506,7 +506,7 @@ static gboolean change_set_by_name (gchar *name, enum activate_type action, GErr
  *
  * Returns: whether the RAID set @name was successfully activate or not
  */
-gboolean bd_dm_activate_raid_set (gchar *name, GError **error) {
+gboolean bd_dm_activate_raid_set (const gchar *name, GError **error) {
     return change_set_by_name (name, A_ACTIVATE, error);
 }
 
@@ -517,7 +517,7 @@ gboolean bd_dm_activate_raid_set (gchar *name, GError **error) {
  *
  * Returns: whether the RAID set @name was successfully deactivate or not
  */
-gboolean bd_dm_deactivate_raid_set (gchar *name, GError **error) {
+gboolean bd_dm_deactivate_raid_set (const gchar *name, GError **error) {
     return change_set_by_name (name, A_DEACTIVATE, error);
 }
 
@@ -528,7 +528,7 @@ gboolean bd_dm_deactivate_raid_set (gchar *name, GError **error) {
  *
  * Returns: string representation of the @name RAID set's type
  */
-gchar* bd_dm_get_raid_set_type (gchar *name, GError **error) {
+gchar* bd_dm_get_raid_set_type (const gchar *name, GError **error) {
     struct lib_context *lc;
     struct raid_set *iter_rs;
     struct raid_set *match_rs = NULL;
@@ -540,7 +540,7 @@ gchar* bd_dm_get_raid_set_type (gchar *name, GError **error) {
         return NULL;
 
     for_each_raidset (lc, iter_rs) {
-        match_rs = find_in_raid_sets (iter_rs, (RSEvalFunc)rs_matches_name, name);
+        match_rs = find_in_raid_sets (iter_rs, (RSEvalFunc)rs_matches_name, (gchar *)name);
         if (match_rs)
             break;
     }

--- a/src/plugins/dm.h
+++ b/src/plugins/dm.h
@@ -17,14 +17,14 @@ typedef enum {
     BD_DM_ERROR_RAID_NO_EXIST,
 } BDDMError;
 
-gboolean bd_dm_create_linear (gchar *map_name, gchar *device, guint64 length, gchar *uuid, GError **error);
-gboolean bd_dm_remove (gchar *map_name, GError **error);
-gchar* bd_dm_name_from_node (gchar *dm_node, GError **error);
-gchar* bd_dm_node_from_name (gchar *map_name, GError **error);
-gboolean bd_dm_map_exists (gchar *map_name, gboolean live_only, gboolean active_only, GError **error);
-gchar** bd_dm_get_member_raid_sets (gchar *name, gchar *uuid, gint major, gint minor, GError **error);
-gboolean bd_dm_activate_raid_set (gchar *name, GError **error);
-gboolean bd_dm_deactivate_raid_set (gchar *name, GError **error);
-gchar* bd_dm_get_raid_set_type (gchar *name, GError **error);
+gboolean bd_dm_create_linear (const gchar *map_name, const gchar *device, guint64 length, const gchar *uuid, GError **error);
+gboolean bd_dm_remove (const gchar *map_name, GError **error);
+gchar* bd_dm_name_from_node (const gchar *dm_node, GError **error);
+gchar* bd_dm_node_from_name (const gchar *map_name, GError **error);
+gboolean bd_dm_map_exists (const gchar *map_name, gboolean live_only, gboolean active_only, GError **error);
+gchar** bd_dm_get_member_raid_sets (const gchar *name, const gchar *uuid, gint major, gint minor, GError **error);
+gboolean bd_dm_activate_raid_set (const gchar *name, GError **error);
+gboolean bd_dm_deactivate_raid_set (const gchar *name, GError **error);
+gchar* bd_dm_get_raid_set_type (const gchar *name, GError **error);
 
 #endif  /* BD_DM */

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -130,7 +130,7 @@ static gint synced_close (gint fd) {
  *
  * Returns: whether signagures were successfully wiped on @device or not
  */
-gboolean bd_fs_wipe (gchar *device, gboolean all, GError **error) {
+gboolean bd_fs_wipe (const gchar *device, gboolean all, GError **error) {
     blkid_probe probe = NULL;
     gint fd = 0;
     gint status = 0;
@@ -198,7 +198,7 @@ gboolean bd_fs_wipe (gchar *device, gboolean all, GError **error) {
     return TRUE;
 }
 
-static gboolean wipe_fs (gchar *device, gchar *fs_type, GError **error) {
+static gboolean wipe_fs (const gchar *device, const gchar *fs_type, GError **error) {
     blkid_probe probe = NULL;
     gint fd = 0;
     gint status = 0;
@@ -303,8 +303,8 @@ static gboolean wipe_fs (gchar *device, gchar *fs_type, GError **error) {
  *
  * Returns: whether a new ext4 fs was successfully created on @device or not
  */
-gboolean bd_fs_ext4_mkfs (gchar *device, BDExtraArg **extra, GError **error) {
-    gchar *args[3] = {"mkfs.ext4", device, NULL};
+gboolean bd_fs_ext4_mkfs (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *args[3] = {"mkfs.ext4", device, NULL};
 
     return bd_utils_exec_and_report_error (args, extra, error);
 }
@@ -317,7 +317,7 @@ gboolean bd_fs_ext4_mkfs (gchar *device, BDExtraArg **extra, GError **error) {
  * Returns: whether an ext4 signature was successfully wiped from the @device or
  *          not
  */
-gboolean bd_fs_ext4_wipe (gchar *device, GError **error) {
+gboolean bd_fs_ext4_wipe (const gchar *device, GError **error) {
     return wipe_fs (device, "ext4", error);
 }
 
@@ -330,11 +330,11 @@ gboolean bd_fs_ext4_wipe (gchar *device, GError **error) {
  *
  * Returns: whether an ext4 file system on the @device is clean or not
  */
-gboolean bd_fs_ext4_check (gchar *device, BDExtraArg **extra, GError **error) {
+gboolean bd_fs_ext4_check (const gchar *device, const BDExtraArg **extra, GError **error) {
     /* Force checking even if the file system seems clean. AND
      * Open the filesystem read-only, and assume an answer of no to all
      * questions. */
-    gchar *args[5] = {"e2fsck", "-f", "-n", device, NULL};
+    const gchar *args[5] = {"e2fsck", "-f", "-n", device, NULL};
     gint status = 0;
     gboolean ret = FALSE;
 
@@ -357,11 +357,11 @@ gboolean bd_fs_ext4_check (gchar *device, BDExtraArg **extra, GError **error) {
  * Returns: whether an ext4 file system on the @device was successfully repaired
  *          (if needed) or not (error is set in that case)
  */
-gboolean bd_fs_ext4_repair (gchar *device, gboolean unsafe, BDExtraArg **extra, GError **error) {
+gboolean bd_fs_ext4_repair (const gchar *device, gboolean unsafe, const BDExtraArg **extra, GError **error) {
     /* Force checking even if the file system seems clean. AND
      *     Automatically repair what can be safely repaired. OR
      *     Assume an answer of `yes' to all questions. */
-    gchar *args[5] = {"e2fsck", "-f", unsafe ? "-y" : "-p", device, NULL};
+    const gchar *args[5] = {"e2fsck", "-f", unsafe ? "-y" : "-p", device, NULL};
 
     return bd_utils_exec_and_report_error (args, extra, error);
 }
@@ -375,8 +375,8 @@ gboolean bd_fs_ext4_repair (gchar *device, gboolean unsafe, BDExtraArg **extra, 
  * Returns: whether the label of ext4 file system on the @device was
  *          successfully set or not
  */
-gboolean bd_fs_ext4_set_label (gchar *device, gchar *label, GError **error) {
-    gchar *args[5] = {"tune2fs", "-L", label, device, NULL};
+gboolean bd_fs_ext4_set_label (const gchar *device, const gchar *label, GError **error) {
+    const gchar *args[5] = {"tune2fs", "-L", label, device, NULL};
 
     return bd_utils_exec_and_report_error (args, NULL, error);
 }
@@ -391,7 +391,7 @@ gboolean bd_fs_ext4_set_label (gchar *device, gchar *label, GError **error) {
  * Returns: (transfer full): GHashTable containing the key-value pairs parsed
  * from the @str.
  */
-static GHashTable* parse_output_vars (gchar *str, gchar *item_sep, gchar *key_val_sep, guint *num_items) {
+static GHashTable* parse_output_vars (const gchar *str, const gchar *item_sep, const gchar *key_val_sep, guint *num_items) {
     GHashTable *table = NULL;
     gchar **items = NULL;
     gchar **item_p = NULL;
@@ -456,8 +456,8 @@ static BDFSExt4Info* get_ext4_info_from_table (GHashTable *table, gboolean free_
  * Returns: (transfer full): information about the file system on @device or
  *                           %NULL in case of error
  */
-BDFSExt4Info* bd_fs_ext4_get_info (gchar *device, GError **error) {
-    gchar *args[4] = {"dumpe2fs", "-h", device, NULL};
+BDFSExt4Info* bd_fs_ext4_get_info (const gchar *device, GError **error) {
+    const gchar *args[4] = {"dumpe2fs", "-h", device, NULL};
     gboolean success = FALSE;
     gchar *output = NULL;
     GHashTable *table = NULL;
@@ -500,8 +500,8 @@ BDFSExt4Info* bd_fs_ext4_get_info (gchar *device, GError **error) {
  *
  * Returns: whether the file system on @device was successfully resized or not
  */
-gboolean bd_fs_ext4_resize (gchar *device, guint64 new_size, BDExtraArg **extra, GError **error) {
-    gchar *args[4] = {"resize2fs", device, NULL, NULL};
+gboolean bd_fs_ext4_resize (const gchar *device, guint64 new_size, const BDExtraArg **extra, GError **error) {
+    const gchar *args[4] = {"resize2fs", device, NULL, NULL};
     gboolean ret = FALSE;
 
     if (new_size != 0)
@@ -509,7 +509,7 @@ gboolean bd_fs_ext4_resize (gchar *device, guint64 new_size, BDExtraArg **extra,
         args[2] = g_strdup_printf ("%"G_GUINT64_FORMAT"s", new_size / 512);
     ret = bd_utils_exec_and_report_error (args, extra, error);
 
-    g_free (args[2]);
+    g_free ((gchar *) args[2]);
     return ret;
 }
 
@@ -522,8 +522,8 @@ gboolean bd_fs_ext4_resize (gchar *device, guint64 new_size, BDExtraArg **extra,
  *
  * Returns: whether a new xfs fs was successfully created on @device or not
  */
-gboolean bd_fs_xfs_mkfs (gchar *device, BDExtraArg **extra, GError **error) {
-    gchar *args[3] = {"mkfs.xfs", device, NULL};
+gboolean bd_fs_xfs_mkfs (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *args[3] = {"mkfs.xfs", device, NULL};
 
     return bd_utils_exec_and_report_error (args, extra, error);
 }
@@ -536,7 +536,7 @@ gboolean bd_fs_xfs_mkfs (gchar *device, BDExtraArg **extra, GError **error) {
  * Returns: whether an xfs signature was successfully wiped from the @device or
  *          not
  */
-gboolean bd_fs_xfs_wipe (gchar *device, GError **error) {
+gboolean bd_fs_xfs_wipe (const gchar *device, GError **error) {
     return wipe_fs (device, "xfs", error);
 }
 
@@ -550,8 +550,8 @@ gboolean bd_fs_xfs_wipe (gchar *device, GError **error) {
  * Note: if the file system is mounted it may be reported as unclean even if
  *       everything is okay and there are just some pending/in-progress writes
  */
-gboolean bd_fs_xfs_check (gchar *device, GError **error) {
-    gchar *args[6] = {"xfs_db", "-r", "-c", "check", device, NULL};
+gboolean bd_fs_xfs_check (const gchar *device, GError **error) {
+    const gchar *args[6] = {"xfs_db", "-r", "-c", "check", device, NULL};
     gboolean ret = FALSE;
 
     ret = bd_utils_exec_and_report_error (args, NULL, error);
@@ -572,8 +572,8 @@ gboolean bd_fs_xfs_check (gchar *device, GError **error) {
  * Returns: whether an xfs file system on the @device was successfully repaired
  *          (if needed) or not (error is set in that case)
  */
-gboolean bd_fs_xfs_repair (gchar *device, BDExtraArg **extra, GError **error) {
-    gchar *args[3] = {"xfs_repair", device, NULL};
+gboolean bd_fs_xfs_repair (const gchar *device, const BDExtraArg **extra, GError **error) {
+    const gchar *args[3] = {"xfs_repair", device, NULL};
 
     return bd_utils_exec_and_report_error (args, extra, error);
 }
@@ -587,8 +587,8 @@ gboolean bd_fs_xfs_repair (gchar *device, BDExtraArg **extra, GError **error) {
  * Returns: whether the label of xfs file system on the @device was
  *          successfully set or not
  */
-gboolean bd_fs_xfs_set_label (gchar *device, gchar *label, GError **error) {
-    gchar *args[5] = {"xfs_admin", "-L", label, device, NULL};
+gboolean bd_fs_xfs_set_label (const gchar *device, const gchar *label, GError **error) {
+    const gchar *args[5] = {"xfs_admin", "-L", label, device, NULL};
     if (!label || (strncmp (label, "", 1) == 0))
         args[2] = "--";
 
@@ -603,8 +603,8 @@ gboolean bd_fs_xfs_set_label (gchar *device, gchar *label, GError **error) {
  * Returns: (transfer full): information about the file system on @device or
  *                           %NULL in case of error
  */
-BDFSXfsInfo* bd_fs_xfs_get_info (gchar *device, GError **error) {
-    gchar *args[4] = {"xfs_admin", "-lu", device, NULL};
+BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error) {
+    const gchar *args[4] = {"xfs_admin", "-lu", device, NULL};
     gboolean success = FALSE;
     gchar *output = NULL;
     BDFSXfsInfo *ret = NULL;
@@ -711,8 +711,8 @@ BDFSXfsInfo* bd_fs_xfs_get_info (gchar *device, GError **error) {
  *
  * Returns: whether the file system mounted on @mpoint was successfully resized or not
  */
-gboolean bd_fs_xfs_resize (gchar *mpoint, guint64 new_size, BDExtraArg **extra, GError **error) {
-    gchar *args[5] = {"xfs_growfs", NULL, NULL, NULL, NULL};
+gboolean bd_fs_xfs_resize (const gchar *mpoint, guint64 new_size, const BDExtraArg **extra, GError **error) {
+    const gchar *args[5] = {"xfs_growfs", NULL, NULL, NULL, NULL};
     gchar *size_str = NULL;
     gboolean ret = FALSE;
 

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -34,22 +34,22 @@ BDFSXfsInfo* bd_fs_xfs_info_copy (BDFSXfsInfo *data);
 void bd_fs_xfs_info_free (BDFSXfsInfo *data);
 
 
-gboolean bd_fs_wipe (gchar *device, gboolean all, GError **error);
+gboolean bd_fs_wipe (const gchar *device, gboolean all, GError **error);
 
-gboolean bd_fs_ext4_mkfs (gchar *device, BDExtraArg **extra, GError **error);
-gboolean bd_fs_ext4_wipe (gchar *device, GError **error);
-gboolean bd_fs_ext4_check (gchar *device, BDExtraArg **extra, GError **error);
-gboolean bd_fs_ext4_repair (gchar *device, gboolean unsafe, BDExtraArg **extra, GError **error);
-gboolean bd_fs_ext4_set_label (gchar *device, gchar *label, GError **error);
-BDFSExt4Info* bd_fs_ext4_get_info (gchar *device, GError **error);
-gboolean bd_fs_ext4_resize (gchar *device, guint64 new_size, BDExtraArg **extra, GError **error);
+gboolean bd_fs_ext4_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_ext4_wipe (const gchar *device, GError **error);
+gboolean bd_fs_ext4_check (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_ext4_repair (const gchar *device, gboolean unsafe, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_ext4_set_label (const gchar *device, const gchar *label, GError **error);
+BDFSExt4Info* bd_fs_ext4_get_info (const gchar *device, GError **error);
+gboolean bd_fs_ext4_resize (const gchar *device, guint64 new_size, const BDExtraArg **extra, GError **error);
 
-gboolean bd_fs_xfs_mkfs (gchar *device, BDExtraArg **extra, GError **error);
-gboolean bd_fs_xfs_wipe (gchar *device, GError **error);
-gboolean bd_fs_xfs_check (gchar *device, GError **error);
-gboolean bd_fs_xfs_repair (gchar *device, BDExtraArg **extra, GError **error);
-gboolean bd_fs_xfs_set_label (gchar *device, gchar *label, GError **error);
-BDFSXfsInfo* bd_fs_xfs_get_info (gchar *device, GError **error);
-gboolean bd_fs_xfs_resize (gchar *mpoint, guint64 new_size, BDExtraArg **extra, GError **error);
+gboolean bd_fs_xfs_mkfs (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_xfs_wipe (const gchar *device, GError **error);
+gboolean bd_fs_xfs_check (const gchar *device, GError **error);
+gboolean bd_fs_xfs_repair (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_fs_xfs_set_label (const gchar *device, const gchar *label, GError **error);
+BDFSXfsInfo* bd_fs_xfs_get_info (const gchar *device, GError **error);
+gboolean bd_fs_xfs_resize (const gchar *mpoint, guint64 new_size, const BDExtraArg **extra, GError **error);
 
 #endif  /* BD_PART */

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -100,7 +100,7 @@ void bd_kbd_bcache_stats_free (BDKBDBcacheStats *data) {
     g_free (data);
 }
 
-static gboolean have_kernel_module (gchar *module_name, GError **error);
+static gboolean have_kernel_module (const gchar *module_name, GError **error);
 
 /**
  * check: (skip)
@@ -130,7 +130,7 @@ gboolean check() {
     return ret;
 }
 
-static gboolean have_kernel_module (gchar *module_name, GError **error) {
+static gboolean have_kernel_module (const gchar *module_name, GError **error) {
     gint ret = 0;
     struct kmod_ctx *ctx = NULL;
     struct kmod_module *mod = NULL;
@@ -163,7 +163,7 @@ static gboolean have_kernel_module (gchar *module_name, GError **error) {
     return have_path;
 }
 
-static gboolean load_kernel_module (gchar *module_name, gchar *options, GError **error) {
+static gboolean load_kernel_module (const gchar *module_name, const gchar *options, GError **error) {
     gint ret = 0;
     struct kmod_ctx *ctx = NULL;
     struct kmod_module *mod = NULL;
@@ -210,7 +210,7 @@ static gboolean load_kernel_module (gchar *module_name, gchar *options, GError *
     return TRUE;
 }
 
-static gboolean unload_kernel_module (gchar *module_name, GError **error) {
+static gboolean unload_kernel_module (const gchar *module_name, GError **error) {
     gint ret = 0;
     struct kmod_ctx *ctx = NULL;
     struct kmod_module *mod = NULL;
@@ -267,7 +267,7 @@ static gboolean unload_kernel_module (gchar *module_name, GError **error) {
     return TRUE;
 }
 
-static gboolean echo_str_to_file (gchar *str, gchar *file_path, GError **error) {
+static gboolean echo_str_to_file (const gchar *str, const gchar *file_path, GError **error) {
     GIOChannel *out_file = NULL;
     gsize bytes_written = 0;
 
@@ -299,7 +299,7 @@ static gboolean echo_str_to_file (gchar *str, gchar *file_path, GError **error) 
  *
  * **Lengths of @size and @nstreams (if given) have to be >= @num_devices!**
  */
-gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error) {
+gboolean bd_kbd_zram_create_devices (guint64 num_devices, const guint64 *sizes, const guint64 *nstreams, GError **error) {
     gchar *opts = NULL;
     gboolean success = FALSE;
     guint64 i = 0;
@@ -377,7 +377,7 @@ gboolean bd_kbd_zram_destroy_devices (GError **error) {
     return unload_kernel_module ("zram", error);
 }
 
-static guint64 get_number_from_file (gchar *path, GError **error) {
+static guint64 get_number_from_file (const gchar *path, GError **error) {
     gchar *content = NULL;
     gboolean success = FALSE;
     guint64 ret = 0;
@@ -401,7 +401,7 @@ static guint64 get_number_from_file (gchar *path, GError **error) {
  *
  * Returns: (transfer full): statistics for the zRAM device
  */
-BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
+BDKBDZramStats* bd_kbd_zram_get_stats (const gchar *device, GError **error) {
     gchar *path = NULL;
     gboolean success = FALSE;
     BDKBDZramStats *ret = g_new0 (BDKBDZramStats, 1);
@@ -545,8 +545,8 @@ BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error) {
  *
  * Returns: whether the bcache device was successfully created or not
  */
-gboolean bd_kbd_bcache_create (gchar *backing_device, gchar *cache_device, BDExtraArg **extra, gchar **bcache_device, GError **error) {
-    gchar *argv[6] = {"make-bcache", "-B", backing_device, "-C", cache_device, NULL};
+gboolean bd_kbd_bcache_create (const gchar *backing_device, const gchar *cache_device, const BDExtraArg **extra, const gchar **bcache_device, GError **error) {
+    const gchar *argv[6] = {"make-bcache", "-B", backing_device, "-C", cache_device, NULL};
     gboolean success = FALSE;
     gchar *output = NULL;
     gchar **lines = NULL;
@@ -665,7 +665,7 @@ gboolean bd_kbd_bcache_create (gchar *backing_device, gchar *cache_device, BDExt
  *
  * Returns: whether the @c_set_uuid cache was successfully attached to @bcache_device or not
  */
-gboolean bd_kbd_bcache_attach (gchar *c_set_uuid, gchar *bcache_device, GError **error) {
+gboolean bd_kbd_bcache_attach (const gchar *c_set_uuid, const gchar *bcache_device, GError **error) {
     gchar *path = NULL;
     gboolean success = FALSE;
 
@@ -689,7 +689,7 @@ gboolean bd_kbd_bcache_attach (gchar *c_set_uuid, gchar *bcache_device, GError *
  *
  * Note: Flushes the cache first.
  */
-gboolean bd_kbd_bcache_detach (gchar *bcache_device, gchar **c_set_uuid, GError **error) {
+gboolean bd_kbd_bcache_detach (const gchar *bcache_device, gchar **c_set_uuid, GError **error) {
     gchar *path = NULL;
     gchar *link = NULL;
     gchar *uuid = NULL;
@@ -750,7 +750,7 @@ gboolean bd_kbd_bcache_detach (gchar *bcache_device, gchar **c_set_uuid, GError 
  *
  * Returns: whether the bcache device @bcache_device was successfully destroyed or not
  */
-gboolean bd_kbd_bcache_destroy (gchar *bcache_device, GError **error) {
+gboolean bd_kbd_bcache_destroy (const gchar *bcache_device, GError **error) {
     gchar *path = NULL;
     gchar *c_set_uuid = NULL;
     gboolean success = FALSE;
@@ -800,7 +800,7 @@ gboolean bd_kbd_bcache_destroy (gchar *bcache_device, GError **error) {
  *
  * Returns: current mode of the @bcache_device
  */
-BDKBDBcacheMode bd_kbd_bcache_get_mode (gchar *bcache_device, GError **error) {
+BDKBDBcacheMode bd_kbd_bcache_get_mode (const gchar *bcache_device, GError **error) {
     gchar *path = NULL;
     gchar *content = NULL;
     gboolean success = FALSE;
@@ -871,7 +871,7 @@ const gchar* bd_kbd_bcache_get_mode_str (BDKBDBcacheMode mode, GError **error) {
  *
  * Returns: mode matching the @mode_str given or %BD_KBD_MODE_UNKNOWN in case of no match
  */
-BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (gchar *mode_str, GError **error) {
+BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (const gchar *mode_str, GError **error) {
     if (g_strcmp0 (mode_str, "writethrough") == 0)
         return BD_KBD_MODE_WRITETHROUGH;
     else if (g_strcmp0 (mode_str, "writeback") == 0)
@@ -898,7 +898,7 @@ BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (gchar *mode_str, GError **error
  *
  * Returns: whether the mode was successfully set or not
  */
-gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GError **error) {
+gboolean bd_kbd_bcache_set_mode (const gchar *bcache_device, BDKBDBcacheMode mode, GError **error) {
     gchar *path = NULL;
     gboolean success = FALSE;
     const gchar *mode_str = NULL;
@@ -930,7 +930,7 @@ gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GEr
     return TRUE;
 }
 
-static gboolean get_cache_size_used (gchar *cache_dev_sys, guint64 *size, guint64 *used, GError **error) {
+static gboolean get_cache_size_used (const gchar *cache_dev_sys, guint64 *size, guint64 *used, GError **error) {
     gchar *path = NULL;
     GIOChannel *file = NULL;
     gchar *line = NULL;
@@ -999,7 +999,7 @@ static gboolean get_cache_size_used (gchar *cache_dev_sys, guint64 *size, guint6
  * Returns: (transfer full): status of the @bcache_device or %NULL in case of
  *                           error (@error is set)
  */
-BDKBDBcacheStats* bd_kbd_bcache_status (gchar *bcache_device, GError **error) {
+BDKBDBcacheStats* bd_kbd_bcache_status (const gchar *bcache_device, GError **error) {
     gchar *path = NULL;
     gboolean success = FALSE;
     BDKBDBcacheStats *ret = g_new0 (BDKBDBcacheStats, 1);
@@ -1123,7 +1123,7 @@ BDKBDBcacheStats* bd_kbd_bcache_status (gchar *bcache_device, GError **error) {
     return ret;
 }
 
-static gchar* get_device_name (gchar *major_minor, GError **error) {
+static gchar* get_device_name (const gchar *major_minor, GError **error) {
     gchar *path = NULL;
     gchar *link = NULL;
     gchar *ret = NULL;
@@ -1168,7 +1168,7 @@ static gchar* get_device_name (gchar *major_minor, GError **error) {
  * Note: returns the name of the first backing device of @bcache_device (in case
  *       there are more)
  */
-gchar* bd_kbd_bcache_get_backing_device (gchar *bcache_device, GError **error) {
+gchar* bd_kbd_bcache_get_backing_device (const gchar *bcache_device, GError **error) {
     gchar *path = NULL;
     gboolean success = FALSE;
     gchar *major_minor = NULL;
@@ -1220,7 +1220,7 @@ gchar* bd_kbd_bcache_get_backing_device (gchar *bcache_device, GError **error) {
  * Note: returns the name of the first cache device of @bcache_device (in case
  *       there are more)
  */
-gchar* bd_kbd_bcache_get_cache_device (gchar *bcache_device, GError **error) {
+gchar* bd_kbd_bcache_get_cache_device (const gchar *bcache_device, GError **error) {
     gchar *path = NULL;
     gboolean success = FALSE;
     gchar *major_minor = NULL;

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -62,20 +62,20 @@ typedef struct BDKBDBcacheStats {
 BDKBDBcacheStats* bd_kbd_bcache_stats_copy (BDKBDBcacheStats *data);
 void bd_kbd_bcache_stats_free (BDKBDBcacheStats *data);
 
-gboolean bd_kbd_zram_create_devices (guint64 num_devices, guint64 *sizes, guint64 *nstreams, GError **error);
+gboolean bd_kbd_zram_create_devices (guint64 num_devices, const guint64 *sizes, const guint64 *nstreams, GError **error);
 gboolean bd_kbd_zram_destroy_devices (GError **error);
-BDKBDZramStats* bd_kbd_zram_get_stats (gchar *device, GError **error);
+BDKBDZramStats* bd_kbd_zram_get_stats (const gchar *device, GError **error);
 
-gboolean bd_kbd_bcache_create (gchar *backing_device, gchar *cache_device, BDExtraArg **extra, gchar **bcache_device, GError **error);
-gboolean bd_kbd_bcache_attach (gchar *c_set_uuid, gchar *bcache_device, GError **error);
-gboolean bd_kbd_bcache_detach (gchar *bcache_device, gchar **c_set_uuid, GError **error);
-gboolean bd_kbd_bcache_destroy (gchar *bcache_device, GError **error);
-BDKBDBcacheMode bd_kbd_bcache_get_mode (gchar *bcache_device, GError **error);
+gboolean bd_kbd_bcache_create (const gchar *backing_device, const gchar *cache_device, const BDExtraArg **extra, const gchar **bcache_device, GError **error);
+gboolean bd_kbd_bcache_attach (const gchar *c_set_uuid, const gchar *bcache_device, GError **error);
+gboolean bd_kbd_bcache_detach (const gchar *bcache_device, gchar **c_set_uuid, GError **error);
+gboolean bd_kbd_bcache_destroy (const gchar *bcache_device, GError **error);
+BDKBDBcacheMode bd_kbd_bcache_get_mode (const gchar *bcache_device, GError **error);
 const gchar* bd_kbd_bcache_get_mode_str (BDKBDBcacheMode mode, GError **error);
-BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (gchar *mode_str, GError **error);
-gboolean bd_kbd_bcache_set_mode (gchar *bcache_device, BDKBDBcacheMode mode, GError **error);
-BDKBDBcacheStats* bd_kbd_bcache_status (gchar *bcache_device, GError **error);
-gchar* bd_kbd_bcache_get_backing_device (gchar *bcache_device, GError **error);
-gchar* bd_kbd_bcache_get_cache_device (gchar *bcache_device, GError **error);
+BDKBDBcacheMode bd_kbd_bcache_get_mode_from_str (const gchar *mode_str, GError **error);
+gboolean bd_kbd_bcache_set_mode (const gchar *bcache_device, BDKBDBcacheMode mode, GError **error);
+BDKBDBcacheStats* bd_kbd_bcache_status (const gchar *bcache_device, GError **error);
+gchar* bd_kbd_bcache_get_backing_device (const gchar *bcache_device, GError **error);
+gchar* bd_kbd_bcache_get_cache_device (const gchar *bcache_device, GError **error);
 
 #endif  /* BD_KBD */

--- a/src/plugins/loop.c
+++ b/src/plugins/loop.c
@@ -63,7 +63,7 @@ gboolean check() {
  * Returns: (transfer full): path of the device's backing file or %NULL if none
  *                           is found
  */
-gchar* bd_loop_get_backing_file (gchar *dev_name, GError **error) {
+gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error) {
     gchar *sys_path = g_strdup_printf ("/sys/class/block/%s/loop/backing_file", dev_name);
     gchar *ret = NULL;
     gboolean success = FALSE;
@@ -92,7 +92,7 @@ gchar* bd_loop_get_backing_file (gchar *dev_name, GError **error) {
  * Returns: (transfer full): name of the loop device associated with the given
  * @file or %NULL if failed to determine
  */
-gchar* bd_loop_get_loop_name (gchar *file, GError **error __attribute__((unused))) {
+gchar* bd_loop_get_loop_name (const gchar *file, GError **error __attribute__((unused))) {
     glob_t globbuf;
     gchar **path_p;
     gboolean success = FALSE;
@@ -139,8 +139,8 @@ gchar* bd_loop_get_loop_name (gchar *file, GError **error __attribute__((unused)
  *
  * Returns: whether the @file was successfully setup as a loop device or not
  */
-gboolean bd_loop_setup (gchar *file, gchar **loop_name, GError **error) {
-    gchar *args[4] = {"losetup", "-f", file, NULL};
+gboolean bd_loop_setup (const gchar *file, const gchar **loop_name, GError **error) {
+    const gchar *args[4] = {"losetup", "-f", file, NULL};
     gboolean success = FALSE;
 
     success = bd_utils_exec_and_report_error (args, NULL, error);
@@ -160,11 +160,11 @@ gboolean bd_loop_setup (gchar *file, gchar **loop_name, GError **error) {
  *
  * Returns: whether the @loop device was successfully torn down or not
  */
-gboolean bd_loop_teardown (gchar *loop, GError **error) {
+gboolean bd_loop_teardown (const gchar *loop, GError **error) {
     gboolean success = FALSE;
     gchar *dev_loop = NULL;
 
-    gchar *args[4] = {"losetup", "-d", NULL, NULL};
+    const gchar *args[4] = {"losetup", "-d", NULL, NULL};
 
     if (g_str_has_prefix (loop, "/dev/"))
         args[2] = loop;

--- a/src/plugins/loop.h
+++ b/src/plugins/loop.h
@@ -11,9 +11,9 @@ typedef enum {
     BD_LOOP_ERROR_DEVICE,
 } BDLoopError;
 
-gchar* bd_loop_get_backing_file (gchar *dev_name, GError **error);
-gchar* bd_loop_get_loop_name (gchar *file, GError **error);
-gboolean bd_loop_setup (gchar *file, gchar **loop_name, GError **error);
-gboolean bd_loop_teardown (gchar *loop, GError **error);
+gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
+gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
+gboolean bd_loop_setup (const gchar *file, const gchar **loop_name, GError **error);
+gboolean bd_loop_teardown (const gchar *loop, GError **error);
 
 #endif  /* BD_LOOP */

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -64,7 +64,7 @@ static GDBusConnection *bus = NULL;
 
 /* "friend" functions from the utils library */
 guint64 get_next_task_id ();
-void log_task_status (guint64 task_id, gchar *msg);
+void log_task_status (guint64 task_id, const gchar *msg);
 
 /**
  * SECTION: lvm
@@ -281,11 +281,11 @@ gboolean init() {
     return TRUE;
 }
 
-static gchar** get_existing_objects (gchar *obj_prefix, GError **error) {
+static const gchar** get_existing_objects (const gchar *obj_prefix, GError **error) {
     GVariant *intro_v = NULL;
     gchar *intro_data = NULL;
     GDBusNodeInfo *info = NULL;
-    gchar **ret = NULL;
+    const gchar **ret = NULL;
     GDBusNodeInfo **nodes;
     guint64 n_nodes = 0;
     guint64 i = 0;
@@ -304,7 +304,7 @@ static gchar** get_existing_objects (gchar *obj_prefix, GError **error) {
     for (nodes = info->nodes; (*nodes); nodes++)
         n_nodes++;
 
-    ret = g_new0 (gchar*, n_nodes + 1);
+    ret = g_new0 (const gchar*, n_nodes + 1);
     for (nodes = info->nodes, i=0; (*nodes); nodes++, i++) {
         ret[i] = g_strdup_printf ("%s/%s", obj_prefix, ((*nodes)->path));
     }
@@ -315,7 +315,7 @@ static gchar** get_existing_objects (gchar *obj_prefix, GError **error) {
     return ret;
 }
 
-static gchar* get_object_path (gchar *obj_id, GError **error) {
+static gchar* get_object_path (const gchar *obj_id, GError **error) {
     GVariant *args = NULL;
     GVariant *ret = NULL;
     gchar *obj_path = NULL;
@@ -343,7 +343,7 @@ static gchar* get_object_path (gchar *obj_id, GError **error) {
     return obj_path;
 }
 
-static GVariant* get_object_property (gchar *obj_path, gchar *iface, gchar *property, GError **error) {
+static GVariant* get_object_property (const gchar *obj_path, const gchar *iface, const gchar *property, GError **error) {
     GVariant *args = NULL;
     GVariant *ret = NULL;
     GVariant *real_ret = NULL;
@@ -365,7 +365,7 @@ static GVariant* get_object_property (gchar *obj_path, gchar *iface, gchar *prop
     return real_ret;
 }
 
-static GVariant* get_lvm_object_property (gchar *obj_id, gchar *iface, gchar *property, GError **error) {
+static GVariant* get_lvm_object_property (const gchar *obj_id, const gchar *iface, const gchar *property, GError **error) {
     gchar *obj_path = NULL;
     GVariant *ret = NULL;
 
@@ -380,7 +380,7 @@ static GVariant* get_lvm_object_property (gchar *obj_id, gchar *iface, gchar *pr
     }
 }
 
-static GVariant* call_lvm_method (gchar *obj, gchar *intf, gchar *method, GVariant *params, GVariant *extra_params, BDExtraArg **extra_args, guint64 *task_id, GError **error) {
+static GVariant* call_lvm_method (const gchar *obj, const gchar *intf, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, guint64 *task_id, GError **error) {
     GVariant *config = NULL;
     GVariant *param = NULL;
     GVariantIter iter;
@@ -392,7 +392,7 @@ static GVariant* call_lvm_method (gchar *obj, gchar *intf, gchar *method, GVaria
     GVariant *ret = NULL;
     gchar *params_str = NULL;
     gchar *log_msg = NULL;
-    BDExtraArg **extra_p = NULL;
+    const BDExtraArg **extra_p = NULL;
 
     /* don't allow global config string changes during the run */
     g_mutex_lock (&global_config_lock);
@@ -469,7 +469,7 @@ static GVariant* call_lvm_method (gchar *obj, gchar *intf, gchar *method, GVaria
     return ret;
 }
 
-static void call_lvm_method_sync (gchar *obj, gchar *intf, gchar *method, GVariant *params, GVariant *extra_params, BDExtraArg **extra_args, GError **error) {
+static void call_lvm_method_sync (const gchar *obj, const gchar *intf, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, GError **error) {
     GVariant *ret = NULL;
     gchar *obj_path = NULL;
     gchar *task_path = NULL;
@@ -577,7 +577,7 @@ static void call_lvm_method_sync (gchar *obj, gchar *intf, gchar *method, GVaria
     g_free (task_path);
 }
 
-static void call_lvm_obj_method_sync (gchar *obj_id, gchar *intf, gchar *method, GVariant *params, GVariant *extra_params, BDExtraArg **extra_args, GError **error) {
+static void call_lvm_obj_method_sync (const gchar *obj_id, const gchar *intf, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, GError **error) {
     gchar *obj_path = get_object_path (obj_id, error);
     if (!obj_path)
         return;
@@ -586,21 +586,21 @@ static void call_lvm_obj_method_sync (gchar *obj_id, gchar *intf, gchar *method,
     g_free (obj_path);
 }
 
-static void call_lv_method_sync (gchar *vg_name, gchar *lv_name, gchar *method, GVariant *params, GVariant *extra_params, BDExtraArg **extra_args, GError **error) {
+static void call_lv_method_sync (const gchar *vg_name, const gchar *lv_name, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, GError **error) {
     gchar *obj_id = g_strdup_printf ("%s/%s", vg_name, lv_name);
 
     call_lvm_obj_method_sync (obj_id, LV_INTF, method, params, extra_params, extra_args, error);
     g_free (obj_id);
 }
 
-static void call_thpool_method_sync (gchar *vg_name, gchar *pool_name, gchar *method, GVariant *params, GVariant *extra_params, BDExtraArg **extra_args, GError **error) {
+static void call_thpool_method_sync (const gchar *vg_name, const gchar *pool_name, const gchar *method, GVariant *params, GVariant *extra_params, const BDExtraArg **extra_args, GError **error) {
     gchar *obj_id = g_strdup_printf ("%s/%s", vg_name, pool_name);
 
     call_lvm_obj_method_sync (obj_id, THPOOL_INTF, method, params, extra_params, extra_args, error);
     g_free (obj_id);
 }
 
-static GVariant* get_lv_property (gchar *vg_name, gchar *lv_name, gchar *property, GError **error) {
+static GVariant* get_lv_property (const gchar *vg_name, const gchar *lv_name, const gchar *property, GError **error) {
     gchar *lv_spec = NULL;
     GVariant *ret = NULL;
 
@@ -612,7 +612,7 @@ static GVariant* get_lv_property (gchar *vg_name, gchar *lv_name, gchar *propert
     return ret;
 }
 
-static GVariant* get_object_properties (gchar *obj_path, gchar *iface, GError **error) {
+static GVariant* get_object_properties (const gchar *obj_path, const gchar *iface, GError **error) {
     GVariant *args = NULL;
     GVariant *ret = NULL;
     GVariant *real_ret = NULL;
@@ -634,7 +634,7 @@ static GVariant* get_object_properties (gchar *obj_path, gchar *iface, GError **
     return real_ret;
 }
 
-static GVariant* get_lvm_object_properties (gchar *obj_id, gchar *iface, GError **error) {
+static GVariant* get_lvm_object_properties (const gchar *obj_id, const gchar *iface, GError **error) {
     GVariant *args = NULL;
     GVariant *ret = NULL;
     gchar *obj_path = NULL;
@@ -660,7 +660,7 @@ static GVariant* get_lvm_object_properties (gchar *obj_id, gchar *iface, GError 
 }
 
 
-static GVariant* get_pv_properties (gchar *pv_name, GError **error) {
+static GVariant* get_pv_properties (const gchar *pv_name, GError **error) {
     gchar *obj_id = NULL;
     GVariant *ret = NULL;
 
@@ -674,7 +674,7 @@ static GVariant* get_pv_properties (gchar *pv_name, GError **error) {
     return ret;
 }
 
-static GVariant* get_vg_properties (gchar *vg_name, GError **error) {
+static GVariant* get_vg_properties (const gchar *vg_name, GError **error) {
     GVariant *ret = NULL;
 
     ret = get_lvm_object_properties (vg_name, VG_INTF, error);
@@ -682,7 +682,7 @@ static GVariant* get_vg_properties (gchar *vg_name, GError **error) {
     return ret;
 }
 
-static GVariant* get_lv_properties (gchar *vg_name, gchar *lv_name, GError **error) {
+static GVariant* get_lv_properties (const gchar *vg_name, const gchar *lv_name, GError **error) {
     gchar *lvm_spec = NULL;
     GVariant *ret = NULL;
 
@@ -758,7 +758,7 @@ static BDLVMVGdata* get_vg_data_from_props (GVariant *props, GError **error __at
     return data;
 }
 
-static gchar get_lv_attr (GVariantDict *props, gchar *prop) {
+static gchar get_lv_attr (GVariantDict *props, const gchar *prop) {
     GVariant *value = NULL;
     gchar *letter = NULL;
     gchar *desc = NULL;
@@ -774,7 +774,7 @@ static gchar get_lv_attr (GVariantDict *props, gchar *prop) {
     return ret;
 }
 
-static gchar get_lv_attr_bool (GVariantDict *props, gchar *prop, gchar letter) {
+static gchar get_lv_attr_bool (GVariantDict *props, const gchar *prop, gchar letter) {
     gboolean set = FALSE;
     g_variant_dict_lookup (props, prop, "b", &set);
     if (set)
@@ -834,7 +834,7 @@ static BDLVMLVdata* get_lv_data_from_props (GVariant *props, GError **error __at
     return data;
 }
 
-static GVariant* create_size_str_param (guint64 size, gchar *unit) {
+static GVariant* create_size_str_param (guint64 size, const gchar *unit) {
     gchar *str = NULL;
 
     str = g_strdup_printf ("%"G_GUINT64_FORMAT"%s", size, unit ? unit : "");
@@ -994,7 +994,7 @@ gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard, GErr
  *
  * Returns: whether the PV was successfully created or not
  */
-gboolean bd_lvm_pvcreate (gchar *device, guint64 data_alignment, guint64 metadata_size, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_pvcreate (const gchar *device, guint64 data_alignment, guint64 metadata_size, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariant *param = NULL;
     GVariant *params = NULL;
@@ -1035,7 +1035,7 @@ gboolean bd_lvm_pvcreate (gchar *device, guint64 data_alignment, guint64 metadat
  * pvresize(8)). If given @size 0, adjusts the PV's size to the underlaying
  * block device's size.
  */
-gboolean bd_lvm_pvresize (gchar *device, guint64 size, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_pvresize (const gchar *device, guint64 size, const BDExtraArg **extra, GError **error) {
     GVariant *params = NULL;
     gchar *obj_path = get_object_path (device, error);
     if (!obj_path)
@@ -1056,7 +1056,7 @@ gboolean bd_lvm_pvresize (gchar *device, guint64 size, BDExtraArg **extra, GErro
  *
  * Returns: whether the PV was successfully removed/destroyed or not
  */
-gboolean bd_lvm_pvremove (gchar *device, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_pvremove (const gchar *device, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariant *params = NULL;
 
@@ -1097,7 +1097,7 @@ gboolean bd_lvm_pvremove (gchar *device, BDExtraArg **extra, GError **error) {
  * If @dest is %NULL, VG allocation rules are used for the extents from the @src
  * PV (see pvmove(8)).
  */
-gboolean bd_lvm_pvmove (gchar *src, gchar *dest, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_pvmove (const gchar *src, const gchar *dest, const BDExtraArg **extra, GError **error) {
     GVariant *prop = NULL;
     gchar *src_path = NULL;
     gchar *dest_path = NULL;
@@ -1165,7 +1165,7 @@ gboolean bd_lvm_pvmove (gchar *src, gchar *dest, BDExtraArg **extra, GError **er
  * The @device argument is used only if @update_cache is %TRUE. Otherwise the
  * whole system is scanned for PVs.
  */
-gboolean bd_lvm_pvscan (gchar *device, gboolean update_cache, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_pvscan (const gchar *device, gboolean update_cache, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariantType *type = NULL;
     GVariant *params = NULL;
@@ -1204,7 +1204,7 @@ gboolean bd_lvm_pvscan (gchar *device, gboolean update_cache, BDExtraArg **extra
  * Returns: (transfer full): information about the PV on the given @device or
  * %NULL in case of error (the @error) gets populated in those cases)
  */
-BDLVMPVdata* bd_lvm_pvinfo (gchar *device, GError **error) {
+BDLVMPVdata* bd_lvm_pvinfo (const gchar *device, GError **error) {
     GVariant *props = NULL;
     BDLVMPVdata *ret = NULL;
 
@@ -1226,7 +1226,7 @@ BDLVMPVdata* bd_lvm_pvinfo (gchar *device, GError **error) {
  * Returns: (array zero-terminated=1): information about PVs found in the system
  */
 BDLVMPVdata** bd_lvm_pvs (GError **error) {
-    gchar **objects = NULL;
+    const gchar **objects = NULL;
     guint64 n_pvs = 0;
     GVariant *props = NULL;
     BDLVMPVdata **ret = NULL;
@@ -1244,27 +1244,27 @@ BDLVMPVdata** bd_lvm_pvs (GError **error) {
             return NULL;
     }
 
-    n_pvs = g_strv_length (objects);
+    n_pvs = g_strv_length ((gchar **) objects);
 
     /* now create the return value -- NULL-terminated array of BDLVMPVdata */
     ret = g_new0 (BDLVMPVdata*, n_pvs + 1);
     for (i=0; i < n_pvs; i++) {
         props = get_object_properties (objects[i], PV_INTF, error);
         if (!props) {
-            g_strfreev (objects);
+            g_strfreev ((gchar **) objects);
             g_free (ret);
             return NULL;
         }
         ret[i] = get_pv_data_from_props (props, error);
         if (!(ret[i])) {
-            g_strfreev (objects);
+            g_strfreev ((gchar **) objects);
             g_free (ret);
             return NULL;
         }
     }
     ret[i] = NULL;
 
-    g_strfreev (objects);
+    g_strfreev ((gchar **) objects);
     return ret;
 }
 
@@ -1279,17 +1279,17 @@ BDLVMPVdata** bd_lvm_pvs (GError **error) {
  *
  * Returns: whether the VG @name was successfully created or not
  */
-gboolean bd_lvm_vgcreate (gchar *name, gchar **pv_list, guint64 pe_size, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_vgcreate (const gchar *name, const gchar **pv_list, guint64 pe_size, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     gchar *path = NULL;
-    gchar **pv = NULL;
+    const gchar **pv = NULL;
     GVariant *pvs = NULL;
     GVariant *params = NULL;
     GVariant *extra_params = NULL;
 
     /* build the array of PVs (object paths) */
     g_variant_builder_init (&builder, G_VARIANT_TYPE_OBJECT_PATH_ARRAY);
-    for (pv = pv_list; *pv; pv++) {
+    for (pv=pv_list; *pv; pv++) {
         path = get_object_path (*pv, error);
         if (!path) {
             g_variant_builder_clear (&builder);
@@ -1327,7 +1327,7 @@ gboolean bd_lvm_vgcreate (gchar *name, gchar **pv_list, guint64 pe_size, BDExtra
  *
  * Returns: whether the VG was successfully removed or not
  */
-gboolean bd_lvm_vgremove (gchar *vg_name, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_vgremove (const gchar *vg_name, const BDExtraArg **extra, GError **error) {
     call_lvm_obj_method_sync (vg_name, VG_INTF, "Remove", NULL, NULL, extra, error);
     return ((*error) == NULL);
 }
@@ -1342,7 +1342,7 @@ gboolean bd_lvm_vgremove (gchar *vg_name, BDExtraArg **extra, GError **error) {
  *
  * Returns: whether the VG was successfully renamed or not
  */
-gboolean bd_lvm_vgrename (gchar *old_vg_name, gchar *new_vg_name, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_vgrename (const gchar *old_vg_name, const gchar *new_vg_name, const BDExtraArg **extra, GError **error) {
     GVariant *params = g_variant_new ("(s)", new_vg_name);
     call_lvm_obj_method_sync (old_vg_name, VG_INTF, "Rename", params, NULL, extra, error);
     return ((*error) == NULL);
@@ -1357,7 +1357,7 @@ gboolean bd_lvm_vgrename (gchar *old_vg_name, gchar *new_vg_name, BDExtraArg **e
  *
  * Returns: whether the VG was successfully activated or not
  */
-gboolean bd_lvm_vgactivate (gchar *vg_name, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_vgactivate (const gchar *vg_name, const BDExtraArg **extra, GError **error) {
     GVariant *params = g_variant_new ("(t)", 0);
     call_lvm_obj_method_sync (vg_name, VG_INTF, "Activate", params, NULL, extra, error);
     return ((*error) == NULL);
@@ -1372,7 +1372,7 @@ gboolean bd_lvm_vgactivate (gchar *vg_name, BDExtraArg **extra, GError **error) 
  *
  * Returns: whether the VG was successfully deactivated or not
  */
-gboolean bd_lvm_vgdeactivate (gchar *vg_name, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_vgdeactivate (const gchar *vg_name, const BDExtraArg **extra, GError **error) {
     GVariant *params = g_variant_new ("(t)", 0);
     call_lvm_obj_method_sync (vg_name, VG_INTF, "Deactivate", params, NULL, extra, error);
     return ((*error) == NULL);
@@ -1388,7 +1388,7 @@ gboolean bd_lvm_vgdeactivate (gchar *vg_name, BDExtraArg **extra, GError **error
  *
  * Returns: whether the VG @vg_name was successfully extended with the given @device or not.
  */
-gboolean bd_lvm_vgextend (gchar *vg_name, gchar *device, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_vgextend (const gchar *vg_name, const gchar *device, const BDExtraArg **extra, GError **error) {
     gchar *pv = NULL;
     GVariant *pv_var = NULL;
     GVariant *pvs = NULL;
@@ -1420,7 +1420,7 @@ gboolean bd_lvm_vgextend (gchar *vg_name, gchar *device, BDExtraArg **extra, GEr
  * Note: This function does not move extents off of the PV before removing
  *       it from the VG. You must do that first by calling #bd_lvm_pvmove.
  */
-gboolean bd_lvm_vgreduce (gchar *vg_name, gchar *device, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_vgreduce (const gchar *vg_name, const gchar *device, const BDExtraArg **extra, GError **error) {
     gchar *pv = NULL;
     GVariantBuilder builder;
     GVariantType *type = NULL;
@@ -1470,7 +1470,7 @@ gboolean bd_lvm_vgreduce (gchar *vg_name, gchar *device, BDExtraArg **extra, GEr
  * Returns: (transfer full): information about the @vg_name VG or %NULL in case
  * of error (the @error) gets populated in those cases)
  */
-BDLVMVGdata* bd_lvm_vginfo (gchar *vg_name, GError **error) {
+BDLVMVGdata* bd_lvm_vginfo (const gchar *vg_name, GError **error) {
     GVariant *props = NULL;
     BDLVMVGdata *ret = NULL;
 
@@ -1492,7 +1492,7 @@ BDLVMVGdata* bd_lvm_vginfo (gchar *vg_name, GError **error) {
  * Returns: (array zero-terminated=1): information about VGs found in the system
  */
 BDLVMVGdata** bd_lvm_vgs (GError **error) {
-    gchar **objects = NULL;
+    const gchar **objects = NULL;
     guint64 n_vgs = 0;
     GVariant *props = NULL;
     BDLVMVGdata **ret = NULL;
@@ -1510,27 +1510,27 @@ BDLVMVGdata** bd_lvm_vgs (GError **error) {
             return NULL;
     }
 
-    n_vgs = g_strv_length (objects);
+    n_vgs = g_strv_length ((gchar **) objects);
 
     /* now create the return value -- NULL-terminated array of BDLVMVGdata */
     ret = g_new0 (BDLVMVGdata*, n_vgs + 1);
     for (i=0; i < n_vgs; i++) {
         props = get_object_properties (objects[i], VG_INTF, error);
         if (!props) {
-            g_strfreev (objects);
+            g_strfreev ((gchar **) objects);
             g_free (ret);
             return NULL;
         }
         ret[i] = get_vg_data_from_props (props, error);
         if (!(ret[i])) {
-            g_strfreev (objects);
+            g_strfreev ((gchar **) objects);
             g_free (ret);
             return NULL;
         }
     }
     ret[i] = NULL;
 
-    g_strfreev (objects);
+    g_strfreev ((gchar **) objects);
     return ret;
 }
 
@@ -1543,7 +1543,7 @@ BDLVMVGdata** bd_lvm_vgs (GError **error) {
  * Returns: (transfer full): the origin volume for the @vg_name/@lv_name LV or
  * %NULL if failed to determine (@error) is set in those cases)
  */
-gchar* bd_lvm_lvorigin (gchar *vg_name, gchar *lv_name, GError **error) {
+gchar* bd_lvm_lvorigin (const gchar *vg_name, const gchar *lv_name, GError **error) {
     GVariant *prop = NULL;
     gchar *obj_path = NULL;
     gchar *ret = NULL;
@@ -1585,10 +1585,10 @@ gchar* bd_lvm_lvorigin (gchar *vg_name, gchar *lv_name, GError **error) {
  *
  * Returns: whether the given @vg_name/@lv_name LV was successfully created or not
  */
-gboolean bd_lvm_lvcreate (gchar *vg_name, gchar *lv_name, guint64 size, gchar *type, gchar **pv_list, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_lvcreate (const gchar *vg_name, const gchar *lv_name, guint64 size, const gchar *type, const gchar **pv_list, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     gchar *path = NULL;
-    gchar **pv = NULL;
+    const gchar **pv = NULL;
     GVariant *pvs = NULL;
     GVariantType *var_type = NULL;
     GVariant *params = NULL;
@@ -1597,7 +1597,7 @@ gboolean bd_lvm_lvcreate (gchar *vg_name, gchar *lv_name, guint64 size, gchar *t
     /* build the array of PVs (object paths) */
     if (pv_list) {
         g_variant_builder_init (&builder, G_VARIANT_TYPE_ARRAY);
-        for (pv = pv_list; *pv; pv++) {
+        for (pv=pv_list; *pv; pv++) {
             path = get_object_path (*pv, error);
             if (!path) {
                 g_variant_builder_clear (&builder);
@@ -1625,7 +1625,7 @@ gboolean bd_lvm_lvcreate (gchar *vg_name, gchar *lv_name, guint64 size, gchar *t
         /* and now the extra_params params */
         g_variant_builder_init (&builder, G_VARIANT_TYPE_DICTIONARY);
         if (pv_list && g_strcmp0 (type, "striped") == 0)
-            g_variant_builder_add_value (&builder, g_variant_new ("{sv}", "stripes", g_variant_new ("i", g_strv_length (pv_list))));
+            g_variant_builder_add_value (&builder, g_variant_new ("{sv}", "stripes", g_variant_new ("i", g_strv_length ((gchar **) pv_list))));
         else
             g_variant_builder_add_value (&builder, g_variant_new ("{sv}", "type", g_variant_new ("s", type)));
         extra_params = g_variant_builder_end (&builder);
@@ -1647,7 +1647,7 @@ gboolean bd_lvm_lvcreate (gchar *vg_name, gchar *lv_name, guint64 size, gchar *t
  *
  * Returns: whether the @vg_name/@lv_name LV was successfully removed or not
  */
-gboolean bd_lvm_lvremove (gchar *vg_name, gchar *lv_name, gboolean force, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_lvremove (const gchar *vg_name, const gchar *lv_name, gboolean force, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariant *extra_params = NULL;
 
@@ -1677,7 +1677,7 @@ gboolean bd_lvm_lvremove (gchar *vg_name, gchar *lv_name, gboolean force, BDExtr
  * Returns: whether the @vg_name/@lv_name LV was successfully renamed to
  * @vg_name/@new_name or not
  */
-gboolean bd_lvm_lvrename (gchar *vg_name, gchar *lv_name, gchar *new_name, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_lvrename (const gchar *vg_name, const gchar *lv_name, const gchar *new_name, const BDExtraArg **extra, GError **error) {
     GVariant *params = NULL;
 
     params = g_variant_new ("(s)", new_name);
@@ -1696,7 +1696,7 @@ gboolean bd_lvm_lvrename (gchar *vg_name, gchar *lv_name, gchar *new_name, BDExt
  *
  * Returns: whether the @vg_name/@lv_name LV was successfully resized or not
  */
-gboolean bd_lvm_lvresize (gchar *vg_name, gchar *lv_name, guint64 size, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_lvresize (const gchar *vg_name, const gchar *lv_name, guint64 size, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariantType *type = NULL;
     GVariant *params = NULL;
@@ -1724,7 +1724,7 @@ gboolean bd_lvm_lvresize (gchar *vg_name, gchar *lv_name, guint64 size, BDExtraA
  *
  * Returns: whether the @vg_name/@lv_name LV was successfully activated or not
  */
-gboolean bd_lvm_lvactivate (gchar *vg_name, gchar *lv_name, gboolean ignore_skip, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, const BDExtraArg **extra, GError **error) {
     GVariant *params = g_variant_new ("(t)", 0);
     GVariantBuilder builder;
     GVariant *extra_params = NULL;
@@ -1750,7 +1750,7 @@ gboolean bd_lvm_lvactivate (gchar *vg_name, gchar *lv_name, gboolean ignore_skip
  *
  * Returns: whether the @vg_name/@lv_name LV was successfully deactivated or not
  */
-gboolean bd_lvm_lvdeactivate (gchar *vg_name, gchar *lv_name, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_lvdeactivate (const gchar *vg_name, const gchar *lv_name, const BDExtraArg **extra, GError **error) {
     GVariant *params = g_variant_new ("(t)", 0);
     call_lv_method_sync (vg_name, lv_name, "Deactivate", params, NULL, extra, error);
     return (*error == NULL);
@@ -1769,7 +1769,7 @@ gboolean bd_lvm_lvdeactivate (gchar *vg_name, gchar *lv_name, BDExtraArg **extra
  * Returns: whether the @snapshot_name snapshot of the @vg_name/@origin_name LV
  * was successfully created or not.
  */
-gboolean bd_lvm_lvsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *snapshot_name, guint64 size, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_lvsnapshotcreate (const gchar *vg_name, const gchar *origin_name, const gchar *snapshot_name, guint64 size, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariant *params = NULL;
 
@@ -1794,7 +1794,7 @@ gboolean bd_lvm_lvsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *sna
  *
  * Returns: whether the @vg_name/@snapshot_name LV snapshot was successfully merged or not
  */
-gboolean bd_lvm_lvsnapshotmerge (gchar *vg_name, gchar *snapshot_name, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_lvsnapshotmerge (const gchar *vg_name, const gchar *snapshot_name, const BDExtraArg **extra, GError **error) {
     gchar *obj_id = NULL;
     gchar *obj_path = NULL;
 
@@ -1818,7 +1818,7 @@ gboolean bd_lvm_lvsnapshotmerge (gchar *vg_name, gchar *snapshot_name, BDExtraAr
  * Returns: (transfer full): information about the @vg_name/@lv_name LV or %NULL in case
  * of error (the @error) gets populated in those cases)
  */
-BDLVMLVdata* bd_lvm_lvinfo (gchar *vg_name, gchar *lv_name, GError **error) {
+BDLVMLVdata* bd_lvm_lvinfo (const gchar *vg_name, const gchar *lv_name, GError **error) {
     GVariant *props = NULL;
 
     props = get_lv_properties (vg_name, lv_name, error);
@@ -1829,7 +1829,7 @@ BDLVMLVdata* bd_lvm_lvinfo (gchar *vg_name, gchar *lv_name, GError **error) {
     return get_lv_data_from_props (props, error);
 }
 
-static gchar* get_lv_vg_name (gchar *lv_obj_path, GError **error) {
+static gchar* get_lv_vg_name (const gchar *lv_obj_path, GError **error) {
     GVariant *value = NULL;
     gchar *vg_obj_path = NULL;
     gchar *ret = NULL;
@@ -1851,8 +1851,8 @@ static gchar* get_lv_vg_name (gchar *lv_obj_path, GError **error) {
  *
  * Filter LVs by VG name and prepend the matching ones to the @out list.
  */
-static gboolean filter_lvs_by_vg (gchar **lvs, gchar *vg_name, GSList **out, guint64 *n_lvs, GError **error) {
-    gchar **lv_p = NULL;
+static gboolean filter_lvs_by_vg (const gchar **lvs, const gchar *vg_name, GSList **out, guint64 *n_lvs, GError **error) {
+    const gchar **lv_p = NULL;
     gchar *lv_vg_name = NULL;
     gboolean success = TRUE;
 
@@ -1864,15 +1864,15 @@ static gboolean filter_lvs_by_vg (gchar **lvs, gchar *vg_name, GSList **out, gui
         if (vg_name) {
             lv_vg_name = get_lv_vg_name (*lv_p, error);
             if (!lv_vg_name) {
-                g_free (*lv_p);
+                g_free ((gchar *) *lv_p);
                 success = FALSE;
             }
         }
         if (!vg_name || g_strcmp0 (lv_vg_name, vg_name) == 0) {
-            *out = g_slist_prepend (*out, *lv_p);
+            *out = g_slist_prepend (*out, (gchar *) *lv_p);
             (*n_lvs)++;
         } else {
-            g_free (*lv_p);
+            g_free ((gchar *) *lv_p);
             *lv_p = NULL;
         }
         g_free (lv_vg_name);
@@ -1888,8 +1888,8 @@ static gboolean filter_lvs_by_vg (gchar **lvs, gchar *vg_name, GSList **out, gui
  * Returns: (array zero-terminated=1): information about LVs found in the given
  * @vg_name VG or in system if @vg_name is %NULL
  */
-BDLVMLVdata** bd_lvm_lvs (gchar *vg_name, GError **error) {
-    gchar **lvs = NULL;
+BDLVMLVdata** bd_lvm_lvs (const gchar *vg_name, GError **error) {
+    const gchar **lvs = NULL;
     guint64 n_lvs = 0;
     GVariant *props = NULL;
     BDLVMLVdata **ret = NULL;
@@ -1988,7 +1988,7 @@ BDLVMLVdata** bd_lvm_lvs (gchar *vg_name, GError **error) {
  *
  * Returns: whether the @vg_name/@lv_name thin pool was successfully created or not
  */
-gboolean bd_lvm_thpoolcreate (gchar *vg_name, gchar *lv_name, guint64 size, guint64 md_size, guint64 chunk_size, gchar *profile, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_thpoolcreate (const gchar *vg_name, const gchar *lv_name, guint64 size, guint64 md_size, guint64 chunk_size, const gchar *profile, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariant *params = NULL;
     GVariant *extra_params = NULL;
@@ -2032,7 +2032,7 @@ gboolean bd_lvm_thpoolcreate (gchar *vg_name, gchar *lv_name, guint64 size, guin
  *
  * Returns: whether the @vg_name/@lv_name thin LV was successfully created or not
  */
-gboolean bd_lvm_thlvcreate (gchar *vg_name, gchar *pool_name, gchar *lv_name, guint64 size, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_thlvcreate (const gchar *vg_name, const gchar *pool_name, const gchar *lv_name, guint64 size, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariant *params = NULL;
 
@@ -2056,7 +2056,7 @@ gboolean bd_lvm_thlvcreate (gchar *vg_name, gchar *pool_name, gchar *lv_name, gu
  * Returns: (transfer full): the name of the pool volume for the @vg_name/@lv_name
  * thin LV or %NULL if failed to determine (@error) is set in those cases)
  */
-gchar* bd_lvm_thlvpoolname (gchar *vg_name, gchar *lv_name, GError **error) {
+gchar* bd_lvm_thlvpoolname (const gchar *vg_name, const gchar *lv_name, GError **error) {
     GVariant *prop = NULL;
     gboolean is_thin = FALSE;
     gchar *pool_obj_path = NULL;
@@ -2100,7 +2100,7 @@ gchar* bd_lvm_thlvpoolname (gchar *vg_name, gchar *lv_name, GError **error) {
  * Returns: whether the @snapshot_name snapshot of the @vg_name/@origin_name
  * thin LV was successfully created or not.
  */
-gboolean bd_lvm_thsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *snapshot_name, gchar *pool_name, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_thsnapshotcreate (const gchar *vg_name, const gchar *origin_name, const gchar *snapshot_name, const gchar *pool_name, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariant *params = NULL;
     GVariant *extra_params = NULL;
@@ -2132,7 +2132,7 @@ gboolean bd_lvm_thsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *sna
  * Returns: whether the new requested global config @new_config was successfully
  *          set or not
  */
-gboolean bd_lvm_set_global_config (gchar *new_config, GError **error __attribute__((unused))) {
+gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error __attribute__((unused))) {
     /* XXX: the error attribute will likely be used in the future when
        some validation comes into the game */
 
@@ -2241,7 +2241,7 @@ const gchar* bd_lvm_cache_get_mode_str (BDLVMCacheMode mode, GError **error) {
  * Returns: cache mode for the @mode_str or %BD_LVM_CACHE_MODE_UNKNOWN if
  *          failed to determine
  */
-BDLVMCacheMode bd_lvm_cache_get_mode_from_str (gchar *mode_str, GError **error) {
+BDLVMCacheMode bd_lvm_cache_get_mode_from_str (const gchar *mode_str, GError **error) {
     if (g_strcmp0 (mode_str, "writethrough") == 0)
         return BD_LVM_CACHE_MODE_WRITETHROUGH;
     else if (g_strcmp0 (mode_str, "writeback") == 0)
@@ -2270,7 +2270,7 @@ BDLVMCacheMode bd_lvm_cache_get_mode_from_str (gchar *mode_str, GError **error) 
  *
  * Returns: whether the cache pool @vg_name/@pool_name was successfully created or not
  */
-gboolean bd_lvm_cache_create_pool (gchar *vg_name, gchar *pool_name, guint64 pool_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags, gchar **fast_pvs, GError **error) {
+gboolean bd_lvm_cache_create_pool (const gchar *vg_name, const gchar *pool_name, guint64 pool_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags, const gchar **fast_pvs, GError **error) {
     gboolean success = FALSE;
     gchar *type = NULL;
     gchar *name = NULL;
@@ -2355,7 +2355,7 @@ gboolean bd_lvm_cache_create_pool (gchar *vg_name, gchar *pool_name, guint64 poo
  *
  * Returns: whether the @cache_pool_lv was successfully attached to the @data_lv or not
  */
-gboolean bd_lvm_cache_attach (gchar *vg_name, gchar *data_lv, gchar *cache_pool_lv, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_cache_attach (const gchar *vg_name, const gchar *data_lv, const gchar *cache_pool_lv, const BDExtraArg **extra, GError **error) {
     GVariantBuilder builder;
     GVariant *params = NULL;
     gchar *lv_id = NULL;
@@ -2390,7 +2390,7 @@ gboolean bd_lvm_cache_attach (gchar *vg_name, gchar *data_lv, gchar *cache_pool_
  *
  * Note: synces the cache first
  */
-gboolean bd_lvm_cache_detach (gchar *vg_name, gchar *cached_lv, gboolean destroy, BDExtraArg **extra, GError **error) {
+gboolean bd_lvm_cache_detach (const gchar *vg_name, const gchar *cached_lv, gboolean destroy, const BDExtraArg **extra, GError **error) {
     gchar *lv_id = NULL;
     gchar *cache_pool_name = NULL;
     GVariantBuilder builder;
@@ -2425,8 +2425,8 @@ gboolean bd_lvm_cache_detach (gchar *vg_name, gchar *cached_lv, gboolean destroy
  *
  * Returns: whether the cached LV @lv_name was successfully created or not
  */
-gboolean bd_lvm_cache_create_cached_lv (gchar *vg_name, gchar *lv_name, guint64 data_size, guint64 cache_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags,
-                                        gchar **slow_pvs, gchar **fast_pvs, GError **error) {
+gboolean bd_lvm_cache_create_cached_lv (const gchar *vg_name, const gchar *lv_name, guint64 data_size, guint64 cache_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags,
+                                        const gchar **slow_pvs, const gchar **fast_pvs, GError **error) {
     gboolean success = FALSE;
     gchar *name = NULL;
 
@@ -2463,7 +2463,7 @@ gboolean bd_lvm_cache_create_cached_lv (gchar *vg_name, gchar *lv_name, guint64 
  *
  * Returns: name of the cache pool LV used by the @cached_lv or %NULL in case of error
  */
-gchar* bd_lvm_cache_pool_name (gchar *vg_name, gchar *cached_lv, GError **error) {
+gchar* bd_lvm_cache_pool_name (const gchar *vg_name, const gchar *cached_lv, GError **error) {
     gchar *ret = NULL;
     gchar *name_start = NULL;
     gchar *name_end = NULL;
@@ -2517,7 +2517,7 @@ gchar* bd_lvm_cache_pool_name (gchar *vg_name, gchar *cached_lv, GError **error)
  *
  * Returns: stats for the @cached_lv or %NULL in case of error
  */
-BDLVMCacheStats* bd_lvm_cache_stats (gchar *vg_name, gchar *cached_lv, GError **error) {
+BDLVMCacheStats* bd_lvm_cache_stats (const gchar *vg_name, const gchar *cached_lv, GError **error) {
     struct dm_pool *pool = NULL;
     struct dm_task *task = NULL;
     struct dm_info info;
@@ -2632,7 +2632,7 @@ BDLVMCacheStats* bd_lvm_cache_stats (gchar *vg_name, gchar *cached_lv, GError **
  * Returns: (transfer full): the name of the (internal) data LV of the
  * @vg_name/@lv_name LV
  */
-gchar* bd_lvm_data_lv_name (gchar *vg_name, gchar *lv_name, GError **error) {
+gchar* bd_lvm_data_lv_name (const gchar *vg_name, const gchar *lv_name, GError **error) {
     GVariant *prop = NULL;
     gchar *obj_id = NULL;
     gchar *obj_path = NULL;
@@ -2679,7 +2679,7 @@ gchar* bd_lvm_data_lv_name (gchar *vg_name, gchar *lv_name, GError **error) {
  * Returns: (transfer full): the name of the (internal) metadata LV of the
  * @vg_name/@lv_name LV
  */
-gchar* bd_lvm_metadata_lv_name (gchar *vg_name, gchar *lv_name, GError **error) {
+gchar* bd_lvm_metadata_lv_name (const gchar *vg_name, const gchar *lv_name, GError **error) {
     GVariant *prop = NULL;
     gchar *obj_id = NULL;
     gchar *obj_path = NULL;

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -133,55 +133,55 @@ guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean inclu
 gboolean bd_lvm_is_valid_thpool_md_size (guint64 size, GError **error);
 gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard, GError **error);
 
-gboolean bd_lvm_pvcreate (gchar *device, guint64 data_alignment, guint64 metadata_size, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_pvresize (gchar *device, guint64 size, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_pvremove (gchar *device, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_pvmove (gchar *src, gchar *dest, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_pvscan (gchar *device, gboolean update_cache, BDExtraArg **extra, GError **error);
-BDLVMPVdata* bd_lvm_pvinfo (gchar *device, GError **error);
+gboolean bd_lvm_pvcreate (const gchar *device, guint64 data_alignment, guint64 metadata_size, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_pvresize (const gchar *device, guint64 size, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_pvremove (const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_pvmove (const gchar *src, const gchar *dest, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_pvscan (const gchar *device, gboolean update_cache, const BDExtraArg **extra, GError **error);
+BDLVMPVdata* bd_lvm_pvinfo (const gchar *device, GError **error);
 BDLVMPVdata** bd_lvm_pvs (GError **error);
 
-gboolean bd_lvm_vgcreate (gchar *name, gchar **pv_list, guint64 pe_size, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_vgremove (gchar *vg_name, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_vgrename (gchar *old_vg_name, gchar *new_vg_name, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_vgactivate (gchar *vg_name, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_vgdeactivate (gchar *vg_name, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_vgextend (gchar *vg_name, gchar *device, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_vgreduce (gchar *vg_name, gchar *device, BDExtraArg **extra, GError **error);
-BDLVMVGdata* bd_lvm_vginfo (gchar *vg_name, GError **error);
+gboolean bd_lvm_vgcreate (const gchar *name, const gchar **pv_list, guint64 pe_size, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgremove (const gchar *vg_name, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgrename (const gchar *old_vg_name, const gchar *new_vg_name, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgactivate (const gchar *vg_name, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgdeactivate (const gchar *vg_name, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgextend (const gchar *vg_name, const gchar *device, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_vgreduce (const gchar *vg_name, const gchar *device, const BDExtraArg **extra, GError **error);
+BDLVMVGdata* bd_lvm_vginfo (const gchar *vg_name, GError **error);
 BDLVMVGdata** bd_lvm_vgs (GError **error);
 
-gchar* bd_lvm_lvorigin (gchar *vg_name, gchar *lv_name, GError **error);
-gboolean bd_lvm_lvcreate (gchar *vg_name, gchar *lv_name, guint64 size, gchar *type, gchar **pv_list, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_lvremove (gchar *vg_name, gchar *lv_name, gboolean force, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_lvrename (gchar *vg_name, gchar *lv_name, gchar *new_name, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_lvresize (gchar *vg_name, gchar *lv_name, guint64 size, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_lvactivate (gchar *vg_name, gchar *lv_name, gboolean ignore_skip, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_lvdeactivate (gchar *vg_name, gchar *lv_name, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_lvsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *snapshot_name, guint64 size, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_lvsnapshotmerge (gchar *vg_name, gchar *snapshot_name, BDExtraArg **extra, GError **error);
-BDLVMLVdata* bd_lvm_lvinfo (gchar *vg_name, gchar *lv_name, GError **error);
-BDLVMLVdata** bd_lvm_lvs (gchar *vg_name, GError **error);
+gchar* bd_lvm_lvorigin (const gchar *vg_name, const gchar *lv_name, GError **error);
+gboolean bd_lvm_lvcreate (const gchar *vg_name, const gchar *lv_name, guint64 size, const gchar *type, const gchar **pv_list, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvremove (const gchar *vg_name, const gchar *lv_name, gboolean force, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvrename (const gchar *vg_name, const gchar *lv_name, const gchar *new_name, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvresize (const gchar *vg_name, const gchar *lv_name, guint64 size, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvactivate (const gchar *vg_name, const gchar *lv_name, gboolean ignore_skip, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvdeactivate (const gchar *vg_name, const gchar *lv_name, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvsnapshotcreate (const gchar *vg_name, const gchar *origin_name, const gchar *snapshot_name, guint64 size, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_lvsnapshotmerge (const gchar *vg_name, const gchar *snapshot_name, const BDExtraArg **extra, GError **error);
+BDLVMLVdata* bd_lvm_lvinfo (const gchar *vg_name, const gchar *lv_name, GError **error);
+BDLVMLVdata** bd_lvm_lvs (const gchar *vg_name, GError **error);
 
-gboolean bd_lvm_thpoolcreate (gchar *vg_name, gchar *lv_name, guint64 size, guint64 md_size, guint64 chunk_size, gchar *profile, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_thlvcreate (gchar *vg_name, gchar *pool_name, gchar *lv_name, guint64 size, BDExtraArg **extra, GError **error);
-gchar* bd_lvm_thlvpoolname (gchar *vg_name, gchar *lv_name, GError **error);
-gboolean bd_lvm_thsnapshotcreate (gchar *vg_name, gchar *origin_name, gchar *snapshot_name, gchar *pool_name, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_set_global_config (gchar *new_config, GError **error);
+gboolean bd_lvm_thpoolcreate (const gchar *vg_name, const gchar *lv_name, guint64 size, guint64 md_size, guint64 chunk_size, const gchar *profile, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_thlvcreate (const gchar *vg_name, const gchar *pool_name, const gchar *lv_name, guint64 size, const BDExtraArg **extra, GError **error);
+gchar* bd_lvm_thlvpoolname (const gchar *vg_name, const gchar *lv_name, GError **error);
+gboolean bd_lvm_thsnapshotcreate (const gchar *vg_name, const gchar *origin_name, const gchar *snapshot_name, const gchar *pool_name, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_set_global_config (const gchar *new_config, GError **error);
 gchar* bd_lvm_get_global_config (GError **error);
 
 guint64 bd_lvm_cache_get_default_md_size (guint64 cache_size, GError **error);
 const gchar* bd_lvm_cache_get_mode_str (BDLVMCacheMode mode, GError **error);
-BDLVMCacheMode bd_lvm_cache_get_mode_from_str (gchar *mode_str, GError **error);
-gboolean bd_lvm_cache_create_pool (gchar *vg_name, gchar *pool_name, guint64 pool_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags, gchar **fast_pvs, GError **error);
-gboolean bd_lvm_cache_attach (gchar *vg_name, gchar *data_lv, gchar *cache_pool_lv, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_cache_detach (gchar *vg_name, gchar *cached_lv, gboolean destroy, BDExtraArg **extra, GError **error);
-gboolean bd_lvm_cache_create_cached_lv (gchar *vg_name, gchar *lv_name, guint64 data_size, guint64 cache_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags,
-                                        gchar **slow_pvs, gchar **fast_pvs, GError **error);
-gchar* bd_lvm_cache_pool_name (gchar *vg_name, gchar *cached_lv, GError **error);
-BDLVMCacheStats* bd_lvm_cache_stats (gchar *vg_name, gchar *cached_lv, GError **error);
+BDLVMCacheMode bd_lvm_cache_get_mode_from_str (const gchar *mode_str, GError **error);
+gboolean bd_lvm_cache_create_pool (const gchar *vg_name, const gchar *pool_name, guint64 pool_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags, const gchar **fast_pvs, GError **error);
+gboolean bd_lvm_cache_attach (const gchar *vg_name, const gchar *data_lv, const gchar *cache_pool_lv, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_cache_detach (const gchar *vg_name, const gchar *cached_lv, gboolean destroy, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_cache_create_cached_lv (const gchar *vg_name, const gchar *lv_name, guint64 data_size, guint64 cache_size, guint64 md_size, BDLVMCacheMode mode, BDLVMCachePoolFlags flags,
+                                        const gchar **slow_pvs, const gchar **fast_pvs, GError **error);
+gchar* bd_lvm_cache_pool_name (const gchar *vg_name, const gchar *cached_lv, GError **error);
+BDLVMCacheStats* bd_lvm_cache_stats (const gchar *vg_name, const gchar *cached_lv, GError **error);
 
-gchar* bd_lvm_data_lv_name (gchar *vg_name, gchar *lv_name, GError **error);
-gchar* bd_lvm_metadata_lv_name (gchar *vg_name, gchar *lv_name, GError **error);
+gchar* bd_lvm_data_lv_name (const gchar *vg_name, const gchar *lv_name, GError **error);
+gchar* bd_lvm_metadata_lv_name (const gchar *vg_name, const gchar *lv_name, GError **error);
 
 #endif /* BD_LVM */

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -150,7 +150,7 @@ gboolean check() {
  * Returns: (transfer full): GHashTable containing the key-value pairs parsed
  * from the @str.
  */
-static GHashTable* parse_mdadm_vars (gchar *str, gchar *item_sep, gchar *key_val_sep, guint *num_items) {
+static GHashTable* parse_mdadm_vars (const gchar *str, const gchar *item_sep, const gchar *key_val_sep, guint *num_items) {
     GHashTable *table = NULL;
     gchar **items = NULL;
     gchar **item_p = NULL;
@@ -162,7 +162,7 @@ static GHashTable* parse_mdadm_vars (gchar *str, gchar *item_sep, gchar *key_val
     items = g_strsplit_set (str, item_sep, 0);
     for (item_p=items; *item_p; item_p++) {
         key_val = g_strsplit (*item_p, key_val_sep, 2);
-        if (g_strv_length (key_val) == 2) {
+        if (g_strv_length ((gchar **) key_val) == 2) {
             /* we only want to process valid lines (with the separator) */
             g_hash_table_insert (table, g_strstrip (key_val[0]), g_strstrip (key_val[1]));
             (*num_items)++;
@@ -340,7 +340,7 @@ static BDMDDetailData* get_detail_data_from_table (GHashTable *table, gboolean f
  * Returns: Calculated superblock size for an array with a given @member_size
  * and metadata @version or default if unsupported @version is used.
  */
-guint64 bd_md_get_superblock_size (guint64 member_size, gchar *version, GError **error __attribute__((unused))) {
+guint64 bd_md_get_superblock_size (guint64 member_size, const gchar *version, GError **error __attribute__((unused))) {
     guint64 headroom = BD_MD_SUPERBLOCK_SIZE;
     guint64 min_headroom = (1 MiB);
 
@@ -375,8 +375,8 @@ guint64 bd_md_get_superblock_size (guint64 member_size, gchar *version, GError *
  *
  * Returns: whether the new MD RAID device @device_name was successfully created or not
  */
-gboolean bd_md_create (gchar *device_name, gchar *level, gchar **disks, guint64 spares, gchar *version, gboolean bitmap, BDExtraArg **extra, GError **error) {
-    gchar **argv = NULL;
+gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, const BDExtraArg **extra, GError **error) {
+    const gchar **argv = NULL;
     /* ["mdadm", "create", device, "--run", "level", "raid-devices",...] */
     guint argv_len = 6;
     guint argv_top = 0;
@@ -394,10 +394,10 @@ gboolean bd_md_create (gchar *device_name, gchar *level, gchar **disks, guint64 
         argv_len++;
     if (bitmap)
         argv_len++;
-    num_disks = g_strv_length (disks);
+    num_disks = g_strv_length ((gchar **) disks);
     argv_len += num_disks;
 
-    argv = g_new0 (gchar*, argv_len + 1);
+    argv = g_new0 (const gchar*, argv_len + 1);
 
     level_str = g_strdup_printf ("--level=%s", level);
     rdevices_str = g_strdup_printf ("--raid-devices=%"G_GUINT64_FORMAT, (num_disks - spares));
@@ -450,8 +450,8 @@ gboolean bd_md_create (gchar *device_name, gchar *level, gchar **disks, guint64 
  *
  * Returns: whether the new MD RAID device @device_name was successfully created or not
  */
-gboolean bd_md_create_with_chunk_size (gchar *device_name, gchar *level, gchar **disks, guint64 spares, gchar *version, gboolean bitmap, guint64 chunk_size, BDExtraArg **extra, GError **error) {
-    gchar **argv = NULL;
+gboolean bd_md_create_with_chunk_size (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error) {
+    const gchar **argv = NULL;
     /* {"mdadm", "create", device, "--run", "level", "raid-devices",...} */
     guint argv_len = 6;
     guint argv_top = 0;
@@ -473,10 +473,10 @@ gboolean bd_md_create_with_chunk_size (gchar *device_name, gchar *level, gchar *
     if (chunk_size != 0)
         argv_len++;
 
-    num_disks = g_strv_length (disks);
+    num_disks = g_strv_length ((gchar **) disks);
     argv_len += num_disks;
 
-    argv = g_new0 (gchar*, argv_len + 1);
+    argv = g_new0 (const gchar*, argv_len + 1);
 
     level_str = g_strdup_printf ("--level=%s", level);
     rdevices_str = g_strdup_printf ("--raid-devices=%"G_GUINT64_FORMAT, (num_disks - spares));
@@ -526,8 +526,8 @@ gboolean bd_md_create_with_chunk_size (gchar *device_name, gchar *level, gchar *
  *
  * Returns: whether the MD RAID metadata was successfully destroyed on @device or not
  */
-gboolean bd_md_destroy (gchar *device, GError **error) {
-    gchar *argv[] = {"mdadm", "--zero-superblock", device, NULL};
+gboolean bd_md_destroy (const gchar *device, GError **error) {
+    const gchar *argv[] = {"mdadm", "--zero-superblock", device, NULL};
 
     return bd_utils_exec_and_report_error (argv, NULL, error);
 }
@@ -539,8 +539,8 @@ gboolean bd_md_destroy (gchar *device, GError **error) {
  *
  * Returns: whether the RAID device @device_name was successfully deactivated or not
  */
-gboolean bd_md_deactivate (gchar *device_name, GError **error) {
-    gchar *argv[] = {"mdadm", "--stop", device_name, NULL};
+gboolean bd_md_deactivate (const gchar *device_name, GError **error) {
+    const gchar *argv[] = {"mdadm", "--stop", device_name, NULL};
     gchar *dev_md_path = NULL;
     gboolean ret = FALSE;
 
@@ -569,9 +569,9 @@ gboolean bd_md_deactivate (gchar *device_name, GError **error) {
  *
  * Note: either @members or @uuid (or both) have to be specified.
  */
-gboolean bd_md_activate (gchar *device_name, gchar **members, gchar *uuid, BDExtraArg **extra, GError **error) {
-    guint64 num_members = members ? g_strv_length (members) : 0;
-    gchar **argv = NULL;
+gboolean bd_md_activate (const gchar *device_name, const gchar **members, const gchar *uuid, const BDExtraArg **extra, GError **error) {
+    guint64 num_members = members ? g_strv_length ((gchar **) members) : 0;
+    const gchar **argv = NULL;
     gchar *uuid_str = NULL;
     guint argv_top = 0;
     guint i = 0;
@@ -579,11 +579,11 @@ gboolean bd_md_activate (gchar *device_name, gchar **members, gchar *uuid, BDExt
 
     /* mdadm, --assemble, device_name, --run, --uuid=uuid, member1, member2,..., NULL*/
     if (uuid) {
-        argv = g_new0 (gchar*, num_members + 6);
+        argv = g_new0 (const gchar*, num_members + 6);
         uuid_str = g_strdup_printf ("--uuid=%s", uuid);
     }
     else
-        argv = g_new0 (gchar*, num_members + 5);
+        argv = g_new0 (const gchar*, num_members + 5);
 
     argv[argv_top++] = "mdadm";
     argv[argv_top++] = "--assemble";
@@ -610,8 +610,8 @@ gboolean bd_md_activate (gchar *device_name, gchar **members, gchar *uuid, BDExt
  *
  * Returns: whether the @raid_name was successfully started or not
  */
-gboolean bd_md_run (gchar *raid_name, GError **error) {
-    gchar *argv[] = {"mdadm", "--run", NULL, NULL};
+gboolean bd_md_run (const gchar *raid_name, GError **error) {
+    const gchar *argv[] = {"mdadm", "--run", NULL, NULL};
     gchar *raid_name_str = NULL;
     gboolean ret = FALSE;
 
@@ -636,8 +636,8 @@ gboolean bd_md_run (gchar *raid_name, GError **error) {
  *
  * Note: may start the MD RAID if it becomes ready by adding @device.
  */
-gboolean bd_md_nominate (gchar *device, GError **error) {
-    gchar *argv[] = {"mdadm", "--incremental", "--quiet", "--run", device, NULL};
+gboolean bd_md_nominate (const gchar *device, GError **error) {
+    const gchar *argv[] = {"mdadm", "--incremental", "--quiet", "--run", device, NULL};
 
     return bd_utils_exec_and_report_error (argv, NULL, error);
 }
@@ -652,8 +652,8 @@ gboolean bd_md_nominate (gchar *device, GError **error) {
  *
  * Note: may start the MD RAID if it becomes ready by adding @device.
  */
-gboolean bd_md_denominate (gchar *device, GError **error) {
-    gchar *argv[] = {"mdadm", "--incremental", "--fail", device, NULL};
+gboolean bd_md_denominate (const gchar *device, GError **error) {
+    const gchar *argv[] = {"mdadm", "--incremental", "--fail", device, NULL};
 
     /* XXX: stupid mdadm! --incremental --fail requires "sda1" instead of "/dev/sda1" */
     if (g_str_has_prefix (device, "/dev/"))
@@ -682,8 +682,8 @@ gboolean bd_md_denominate (gchar *device, GError **error) {
  * Whether the new device will be added as a spare or an active member is
  * decided by mdadm.
  */
-gboolean bd_md_add (gchar *raid_name, gchar *device, guint64 raid_devs, BDExtraArg **extra, GError **error) {
-    gchar *argv[7] = {"mdadm", NULL, NULL, NULL, NULL, NULL, NULL};
+gboolean bd_md_add (const gchar *raid_name, const gchar *device, guint64 raid_devs, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[7] = {"mdadm", NULL, NULL, NULL, NULL, NULL, NULL};
     guint argv_top = 1;
     gchar *raid_name_str = NULL;
     gchar *raid_devs_str = NULL;
@@ -723,8 +723,8 @@ gboolean bd_md_add (gchar *raid_name, gchar *device, guint64 raid_devs, BDExtraA
  * Returns: whether the @device was successfully removed from the @raid_name
  * RAID or not.
  */
-gboolean bd_md_remove (gchar *raid_name, gchar *device, gboolean fail, BDExtraArg **extra, GError **error) {
-    gchar *argv[] = {"mdadm", raid_name, NULL, NULL, NULL, NULL};
+gboolean bd_md_remove (const gchar *raid_name, const gchar *device, gboolean fail, const BDExtraArg **extra, GError **error) {
+    const gchar *argv[] = {"mdadm", raid_name, NULL, NULL, NULL, NULL};
     guint argv_top = 2;
     gchar *raid_name_str = NULL;
     gboolean ret = FALSE;
@@ -756,8 +756,8 @@ gboolean bd_md_remove (gchar *raid_name, gchar *device, gboolean fail, BDExtraAr
  *
  * Returns: information about the MD RAID extracted from the @device
  */
-BDMDExamineData* bd_md_examine (gchar *device, GError **error) {
-    gchar *argv[] = {"mdadm", "--examine", "-E", device, NULL};
+BDMDExamineData* bd_md_examine (const gchar *device, GError **error) {
+    const gchar *argv[] = {"mdadm", "--examine", "-E", device, NULL};
     gchar *output = NULL;
     gboolean success = FALSE;
     GHashTable *table = NULL;
@@ -848,8 +848,8 @@ BDMDExamineData* bd_md_examine (gchar *device, GError **error) {
  *
  * Returns: information about the MD RAID @raid_name
  */
-BDMDDetailData* bd_md_detail (gchar *raid_name, GError **error) {
-    gchar *argv[] = {"mdadm", "--detail", raid_name, NULL};
+BDMDDetailData* bd_md_detail (const gchar *raid_name, GError **error) {
+    const gchar *argv[] = {"mdadm", "--detail", raid_name, NULL};
     gchar *output = NULL;
     gboolean success = FALSE;
     GHashTable *table = NULL;
@@ -910,8 +910,8 @@ BDMDDetailData* bd_md_detail (gchar *raid_name, GError **error) {
  * This function expects a UUID in the form that mdadm returns. The change is as
  * follows: 3386ff85:f5012621:4a435f06:1eb47236 -> 3386ff85-f501-2621-4a43-5f061eb47236
  */
-gchar* bd_md_canonicalize_uuid (gchar *uuid, GError **error) {
-    gchar *next_set = uuid;
+gchar* bd_md_canonicalize_uuid (const gchar *uuid, GError **error) {
+    const gchar *next_set = uuid;
     gchar *ret = g_new0 (gchar, 37);
     gchar *dest = ret;
     GRegex *regex = NULL;
@@ -980,8 +980,8 @@ gchar* bd_md_canonicalize_uuid (gchar *uuid, GError **error) {
  * bd_md_canonicalize_uuid(). The change is as follows:
  * 3386ff85-f501-2621-4a43-5f061eb47236 -> 3386ff85:f5012621:4a435f06:1eb47236
  */
-gchar* bd_md_get_md_uuid (gchar *uuid, GError **error) {
-    gchar *next_set = uuid;
+gchar* bd_md_get_md_uuid (const gchar *uuid, GError **error) {
+    const gchar *next_set = uuid;
     gchar *ret = g_new0 (gchar, 37);
     gchar *dest = ret;
     GRegex *regex = NULL;
@@ -1043,7 +1043,7 @@ gchar* bd_md_get_md_uuid (gchar *uuid, GError **error) {
  *
  * Returns: path to the @name MD RAID's device node or %NULL in case of error
  */
-gchar* bd_md_node_from_name (gchar *name, GError **error) {
+gchar* bd_md_node_from_name (const gchar *name, GError **error) {
     gchar *symlink = NULL;
     gchar *ret = NULL;
     gchar *md_path = g_strdup_printf ("/dev/md/%s", name);
@@ -1071,7 +1071,7 @@ gchar* bd_md_node_from_name (gchar *name, GError **error) {
  *
  * Returns: @name of the MD RAID the device node belongs to or %NULL in case of error
  */
-gchar* bd_md_name_from_node (gchar *node, GError **error) {
+gchar* bd_md_name_from_node (const gchar *node, GError **error) {
     gchar *node_path = NULL;
     glob_t glob_buf;
     gchar **path_p;

--- a/src/plugins/mdraid.h
+++ b/src/plugins/mdraid.h
@@ -56,22 +56,22 @@ typedef struct BDMDDetailData {
 void bd_md_detail_data_free (BDMDDetailData *data);
 BDMDDetailData* bd_md_detail_data_copy (BDMDDetailData *data);
 
-guint64 bd_md_get_superblock_size (guint64 member_size, gchar *version, GError **error);
-gboolean bd_md_create (gchar *device_name, gchar *level, gchar **disks, guint64 spares, gchar *version, gboolean bitmap, BDExtraArg **extra, GError **error);
-gboolean bd_md_create_with_chunk_size (gchar *device_name, gchar *level, gchar **disks, guint64 spares, gchar *version, gboolean bitmap, guint64 chunk_size, BDExtraArg **extra, GError **error);
-gboolean bd_md_destroy (gchar *device, GError **error);
-gboolean bd_md_deactivate (gchar *device_name, GError **error);
-gboolean bd_md_activate (gchar *device_name, gchar **members, gchar *uuid, BDExtraArg **extra, GError **error);
-gboolean bd_md_run (gchar *raid_name, GError **error);
-gboolean bd_md_nominate (gchar *device, GError **error);
-gboolean bd_md_denominate (gchar *device, GError **error);
-gboolean bd_md_add (gchar *raid_name, gchar *device, guint64 raid_devs, BDExtraArg **extra, GError **error);
-gboolean bd_md_remove (gchar *raid_name, gchar *device, gboolean fail, BDExtraArg **extra, GError **error);
-BDMDExamineData* bd_md_examine (gchar *device, GError **error);
-BDMDDetailData* bd_md_detail (gchar *raid_name, GError **error);
-gchar* bd_md_canonicalize_uuid (gchar *uuid, GError **error);
-gchar* bd_md_get_md_uuid (gchar *uuid, GError **error);
-gchar* bd_md_node_from_name (gchar *name, GError **error);
-gchar* bd_md_name_from_node (gchar *node, GError **error);
+guint64 bd_md_get_superblock_size (guint64 member_size, const gchar *version, GError **error);
+gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, const BDExtraArg **extra, GError **error);
+gboolean bd_md_create_with_chunk_size (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error);
+gboolean bd_md_destroy (const gchar *device, GError **error);
+gboolean bd_md_deactivate (const gchar *device_name, GError **error);
+gboolean bd_md_activate (const gchar *device_name, const gchar **members, const gchar *uuid, const BDExtraArg **extra, GError **error);
+gboolean bd_md_run (const gchar *raid_name, GError **error);
+gboolean bd_md_nominate (const gchar *device, GError **error);
+gboolean bd_md_denominate (const gchar *device, GError **error);
+gboolean bd_md_add (const gchar *raid_name, const gchar *device, guint64 raid_devs, const BDExtraArg **extra, GError **error);
+gboolean bd_md_remove (const gchar *raid_name, const gchar *device, gboolean fail, const BDExtraArg **extra, GError **error);
+BDMDExamineData* bd_md_examine (const gchar *device, GError **error);
+BDMDDetailData* bd_md_detail (const gchar *raid_name, GError **error);
+gchar* bd_md_canonicalize_uuid (const gchar *uuid, GError **error);
+gchar* bd_md_get_md_uuid (const gchar *uuid, GError **error);
+gchar* bd_md_node_from_name (const gchar *name, GError **error);
+gchar* bd_md_name_from_node (const gchar *node, GError **error);
 
 #endif  /* BD_MD */

--- a/src/plugins/mpath.c
+++ b/src/plugins/mpath.c
@@ -75,7 +75,7 @@ gboolean check() {
  * Flushes all unused multipath device maps.
  */
 gboolean bd_mpath_flush_mpaths (GError **error) {
-    gchar *argv[3] = {"multipath", "-F", NULL};
+    const gchar *argv[3] = {"multipath", "-F", NULL};
     gboolean success = FALSE;
     gchar *output = NULL;
 
@@ -98,7 +98,7 @@ gboolean bd_mpath_flush_mpaths (GError **error) {
     return TRUE;
 }
 
-static gchar* get_device_name (gchar *major_minor, GError **error) {
+static gchar* get_device_name (const gchar *major_minor, GError **error) {
     gchar *path = NULL;
     gchar *link = NULL;
     gchar *ret = NULL;
@@ -132,7 +132,7 @@ static gchar* get_device_name (gchar *major_minor, GError **error) {
     return ret;
 }
 
-static gboolean map_is_multipath (gchar *map_name, GError **error) {
+static gboolean map_is_multipath (const gchar *map_name, GError **error) {
     struct dm_task *task = NULL;
     struct dm_info info;
     guint64 start = 0;
@@ -186,7 +186,7 @@ static gboolean map_is_multipath (gchar *map_name, GError **error) {
     return ret;
 }
 
-static gchar** get_map_deps (gchar *map_name, GError **error) {
+static gchar** get_map_deps (const gchar *map_name, GError **error) {
     struct dm_task *task;
     struct dm_deps *deps;
     guint64 major = 0;
@@ -262,7 +262,7 @@ static gchar** get_map_deps (gchar *map_name, GError **error) {
  * Returns: %TRUE if the device is a multipath member, %FALSE if not or an error
  * appeared when queried (@error is set in those cases)
  */
-gboolean bd_mpath_is_mpath_member (gchar *device, GError **error) {
+gboolean bd_mpath_is_mpath_member (const gchar *device, GError **error) {
     struct dm_task *task_names = NULL;
 	struct dm_names *names = NULL;
     gchar *symlink = NULL;
@@ -349,7 +349,7 @@ gboolean bd_mpath_is_mpath_member (gchar *device, GError **error) {
  * Returns: if successfully set or not
  */
 gboolean bd_mpath_set_friendly_names (gboolean enabled, GError **error) {
-    gchar *argv[8] = {"mpathconf", "--find_multipaths", "y", "--user_friendly_names", NULL, "--with_multipathd", "y", NULL};
+    const gchar *argv[8] = {"mpathconf", "--find_multipaths", "y", "--user_friendly_names", NULL, "--with_multipathd", "y", NULL};
     argv[4] = enabled ? "y" : "n";
 
     return bd_utils_exec_and_report_error (argv, NULL, error);

--- a/src/plugins/mpath.h
+++ b/src/plugins/mpath.h
@@ -15,7 +15,7 @@ typedef enum {
 } BDMpathError;
 
 gboolean bd_mpath_flush_mpaths (GError **error);
-gboolean bd_mpath_is_mpath_member (gchar *device, GError **error);
+gboolean bd_mpath_is_mpath_member (const gchar *device, GError **error);
 gboolean bd_mpath_set_friendly_names (gboolean enabled, GError **error);
 
 #endif  /* BD_MPATH */

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -94,7 +94,7 @@ gboolean init() {
 
 static const gchar *table_type_str[BD_PART_TABLE_UNDEF] = {"msdos", "gpt"};
 
-static gboolean disk_commit (PedDisk *disk, gchar *path, GError **error) {
+static gboolean disk_commit (PedDisk *disk, const gchar *path, GError **error) {
     gint ret = 0;
 
     ret = ped_disk_commit_to_dev (disk);
@@ -124,7 +124,7 @@ static gboolean disk_commit (PedDisk *disk, gchar *path, GError **error) {
  *
  * Returns: whether the partition table was successfully created or not
  */
-gboolean bd_part_create_table (gchar *disk, BDPartTableType type, gboolean ignore_existing, GError **error) {
+gboolean bd_part_create_table (const gchar *disk, BDPartTableType type, gboolean ignore_existing, GError **error) {
     PedDevice *dev = NULL;
     PedDisk *ped_disk = NULL;
     PedDiskType *disk_type = NULL;
@@ -202,11 +202,11 @@ static BDPartSpec* get_part_spec (PedDevice *dev, PedPartition *part) {
  *
  * Returns: spec of the @part partition from @disk or %NULL in case of error
  */
-BDPartSpec* bd_part_get_part_spec (gchar *disk, gchar *part, GError **error) {
+BDPartSpec* bd_part_get_part_spec (const gchar *disk, const gchar *part, GError **error) {
     PedDevice *dev = NULL;
     PedDisk *ped_disk = NULL;
     PedPartition *ped_part = NULL;
-    gchar *part_num_str = NULL;
+    const gchar *part_num_str = NULL;
     gint part_num = 0;
     BDPartSpec *ret = NULL;
 
@@ -272,7 +272,7 @@ BDPartSpec* bd_part_get_part_spec (gchar *disk, gchar *part, GError **error) {
  *
  * Returns: (transfer full) (array zero-terminated=1): specs of the partitions from @disk or %NULL in case of error
  */
-BDPartSpec** bd_part_get_disk_parts (gchar *disk, GError **error) {
+BDPartSpec** bd_part_get_disk_parts (const gchar *disk, GError **error) {
     PedDevice *dev = NULL;
     PedDisk *ped_disk = NULL;
     PedPartition *ped_part = NULL;
@@ -377,7 +377,7 @@ static PedPartition* add_part_to_disk (PedDevice *dev, PedDisk *disk, BDPartType
  * NOTE: The resulting partition may start at a different position than given by
  *       @start and can have different size than @size due to alignment.
  */
-BDPartSpec* bd_part_create_part (gchar *disk, BDPartTypeReq type, guint64 start, guint64 size, BDPartAlign align, GError **error) {
+BDPartSpec* bd_part_create_part (const gchar *disk, BDPartTypeReq type, guint64 start, guint64 size, BDPartAlign align, GError **error) {
     PedDevice *dev = NULL;
     PedDisk *ped_disk = NULL;
     PedPartition *ped_part = NULL;
@@ -473,11 +473,11 @@ BDPartSpec* bd_part_create_part (gchar *disk, BDPartTypeReq type, guint64 start,
  *
  * Returns: whether the @part partition was successfully deleted from @disk
  */
-gboolean bd_part_delete_part (gchar *disk, gchar *part, GError **error) {
+gboolean bd_part_delete_part (const gchar *disk, const gchar *part, GError **error) {
     PedDevice *dev = NULL;
     PedDisk *ped_disk = NULL;
     PedPartition *ped_part = NULL;
-    gchar *part_num_str = NULL;
+    const gchar *part_num_str = NULL;
     gint part_num = 0;
     gint status = 0;
     gboolean ret = FALSE;
@@ -556,12 +556,12 @@ gboolean bd_part_delete_part (gchar *disk, gchar *part, GError **error) {
  * Returns: whether the flag @flag was successfully set on the @part partition
  * or not.
  */
-gboolean bd_part_set_part_flag (gchar *disk, gchar *part, BDPartFlag flag, gboolean state, GError **error) {
+gboolean bd_part_set_part_flag (const gchar *disk, const gchar *part, BDPartFlag flag, gboolean state, GError **error) {
     PedDevice *dev = NULL;
     PedDisk *ped_disk = NULL;
     PedPartition *ped_part = NULL;
     PedPartitionFlag ped_flag = PED_PARTITION_FIRST_FLAG;
-    gchar *part_num_str = NULL;
+    const gchar *part_num_str = NULL;
     gint part_num = 0;
     gint status = 0;
     gboolean ret = FALSE;

--- a/src/plugins/part.h
+++ b/src/plugins/part.h
@@ -71,12 +71,12 @@ typedef struct BDPartSpec {
 BDPartSpec* bd_part_spec_copy (BDPartSpec *data);
 void bd_part_spec_free (BDPartSpec *data);
 
-gboolean bd_part_create_table (gchar *disk, BDPartTableType type, gboolean ignore_existing, GError **error);
-BDPartSpec* bd_part_get_part_spec (gchar *disk, gchar *part, GError **error);
-BDPartSpec** bd_part_get_disk_parts (gchar *disk, GError **error);
-BDPartSpec* bd_part_create_part (gchar *disk, BDPartTypeReq type, guint64 start, guint64 size, BDPartAlign align, GError **error);
-gboolean bd_part_delete_part (gchar *disk, gchar *part, GError **error);
-gboolean bd_part_set_part_flag (gchar *disk, gchar *part, BDPartFlag flag, gboolean state, GError **error);
+gboolean bd_part_create_table (const gchar *disk, BDPartTableType type, gboolean ignore_existing, GError **error);
+BDPartSpec* bd_part_get_part_spec (const gchar *disk, const gchar *part, GError **error);
+BDPartSpec** bd_part_get_disk_parts (const gchar *disk, GError **error);
+BDPartSpec* bd_part_create_part (const gchar *disk, BDPartTypeReq type, guint64 start, guint64 size, BDPartAlign align, GError **error);
+gboolean bd_part_delete_part (const gchar *disk, const gchar *part, GError **error);
+gboolean bd_part_set_part_flag (const gchar *disk, const gchar *part, BDPartFlag flag, gboolean state, GError **error);
 const gchar* bd_part_get_part_table_type_str (BDPartTableType type, GError **error);
 const gchar* bd_part_get_flag_str (BDPartFlag flag, GError **error);
 const gchar* bd_part_get_type_str (BDPartType type, GError **error);

--- a/src/plugins/s390.c
+++ b/src/plugins/s390.c
@@ -68,7 +68,7 @@ gboolean check() {
  *
  * Returns: whether dasdfmt was successful or not
  */
-gboolean bd_s390_dasd_format (const gchar *dasd, BDExtraArg **extra, GError **error) {
+gboolean bd_s390_dasd_format (const gchar *dasd, const BDExtraArg **extra, GError **error) {
     gboolean rc = FALSE;
     gchar *dev = g_strdup_printf ("/dev/%s", dasd);
     gchar *argv[] = {"/sbin/dasdfmt", "-y", "-d", "cdl", "-b", "4096", dev, NULL};
@@ -130,7 +130,7 @@ gboolean bd_s390_dasd_needs_format (const gchar *dasd, GError **error) {
  *
  * Returns: whether a dasd was successfully switched online
  */
-gboolean bd_s390_dasd_online (gchar *dasd, GError **error) {
+gboolean bd_s390_dasd_online (const gchar *dasd, GError **error) {
     gboolean rc = FALSE;
     gint wrc = 0;
     gint online = 0;

--- a/src/plugins/s390.h
+++ b/src/plugins/s390.h
@@ -15,9 +15,9 @@ typedef enum {
     BD_S390_ERROR_DASDFMT,
 } BDS390Error;
 
-gboolean bd_s390_dasd_format (const gchar *dasd, BDExtraArg **extra, GError **error);
+gboolean bd_s390_dasd_format (const gchar *dasd, const BDExtraArg **extra, GError **error);
 gboolean bd_s390_dasd_needs_format (const gchar *dasd, GError **error);
-gboolean bd_s390_dasd_online (gchar *dasd, GError **error);
+gboolean bd_s390_dasd_online (const gchar *dasd, GError **error);
 gboolean bd_s390_dasd_is_ldl (const gchar *dasd, GError **error);
 gchar* bd_s390_sanitize_dev_input (const gchar *dev, GError **error);
 gchar* bd_s390_zfcp_sanitize_wwpn_input (const gchar *wwpn, GError **error);

--- a/src/plugins/swap.c
+++ b/src/plugins/swap.c
@@ -83,12 +83,12 @@ gboolean check() {
  *
  * Returns: whether the swap space was successfully created or not
  */
-gboolean bd_swap_mkswap (gchar *device, gchar *label, BDExtraArg **extra, GError **error) {
+gboolean bd_swap_mkswap (const gchar *device, const gchar *label, const BDExtraArg **extra, GError **error) {
     guint8 next_arg = 2;
 
     /* We use -f to force since mkswap tends to refuse creation on lvs with
        a message about erasing bootbits sectors on whole disks. Bah. */
-    gchar *argv[6] = {"mkswap", "-f", NULL, NULL, NULL, NULL};
+    const gchar *argv[6] = {"mkswap", "-f", NULL, NULL, NULL, NULL};
 
     if (label) {
         argv[next_arg] = "-L";
@@ -110,7 +110,7 @@ gboolean bd_swap_mkswap (gchar *device, gchar *label, BDExtraArg **extra, GError
  *
  * Returns: whether the swap device was successfully activated or not
  */
-gboolean bd_swap_swapon (gchar *device, gint priority, GError **error) {
+gboolean bd_swap_swapon (const gchar *device, gint priority, GError **error) {
     gboolean success = FALSE;
     guint8 next_arg = 1;
     guint8 to_free_idx = 0;
@@ -122,7 +122,7 @@ gboolean bd_swap_swapon (gchar *device, gint priority, GError **error) {
     dev_status[10] = '\0';
     gint page_size;
 
-    gchar *argv[5] = {"swapon", NULL, NULL, NULL, NULL};
+    const gchar *argv[5] = {"swapon", NULL, NULL, NULL, NULL};
 
     /* check the device if it is an activatable swap */
     dev_file = g_io_channel_new_file (device, "r", error);
@@ -182,7 +182,7 @@ gboolean bd_swap_swapon (gchar *device, gint priority, GError **error) {
     success = bd_utils_exec_and_report_error (argv, NULL, error);
 
     if (to_free_idx > 0)
-        g_free (argv[to_free_idx]);
+        g_free ((gchar *) argv[to_free_idx]);
 
     return success;
 }
@@ -194,8 +194,8 @@ gboolean bd_swap_swapon (gchar *device, gint priority, GError **error) {
  *
  * Returns: whether the swap device was successfully deactivated or not
  */
-gboolean bd_swap_swapoff (gchar *device, GError **error) {
-    gchar *argv[3] = {"swapoff", NULL, NULL};
+gboolean bd_swap_swapoff (const gchar *device, GError **error) {
+    const gchar *argv[3] = {"swapoff", NULL, NULL};
     argv[1] = device;
 
     return bd_utils_exec_and_report_error (argv, NULL, error);
@@ -209,7 +209,7 @@ gboolean bd_swap_swapoff (gchar *device, GError **error) {
  * Returns: %TRUE if the swap device is active, %FALSE if not active or failed
  * to determine (@error) is set not a non-NULL value in such case)
  */
-gboolean bd_swap_swapstatus (gchar *device, GError **error) {
+gboolean bd_swap_swapstatus (const gchar *device, GError **error) {
     gchar *file_content;
     gchar *real_device = NULL;
     gchar *symlink = NULL;

--- a/src/plugins/swap.h
+++ b/src/plugins/swap.h
@@ -14,9 +14,9 @@ typedef enum {
     BD_SWAP_ERROR_ACTIVATE,
 } BDSwapError;
 
-gboolean bd_swap_mkswap (gchar *device, gchar *label, BDExtraArg **extra, GError **error);
-gboolean bd_swap_swapon (gchar *device, gint priority, GError **error);
-gboolean bd_swap_swapoff (gchar *device, GError **error);
-gboolean bd_swap_swapstatus (gchar *device, GError **error);
+gboolean bd_swap_mkswap (const gchar *device, const gchar *label, const BDExtraArg **extra, GError **error);
+gboolean bd_swap_swapon (const gchar *device, gint priority, GError **error);
+gboolean bd_swap_swapoff (const gchar *device, GError **error);
+gboolean bd_swap_swapstatus (const gchar *device, GError **error);
 
 #endif  /* BD_SWAP */

--- a/src/utils/exec.c
+++ b/src/utils/exec.c
@@ -56,7 +56,7 @@ guint64 get_next_task_id () {
  * @task_id: ID of the task the status of which is being logged
  * @msg: log message
  */
-void log_task_status (guint64 task_id, gchar *msg) {
+void log_task_status (guint64 task_id, const gchar *msg) {
     gchar *log_msg = NULL;
 
     if (log_func) {
@@ -71,7 +71,7 @@ void log_task_status (guint64 task_id, gchar *msg) {
  *
  * Returns: id of the running task
  */
-static guint64 log_running (gchar **argv) {
+static guint64 log_running (const gchar **argv) {
     guint64 task_id = 0;
     gchar *str_argv = NULL;
     gchar *log_msg = NULL;
@@ -79,7 +79,7 @@ static guint64 log_running (gchar **argv) {
     task_id = get_next_task_id ();
 
     if (log_func) {
-        str_argv = g_strjoinv (" ", argv);
+        str_argv = g_strjoinv (" ", (gchar **) argv);
         log_msg = g_strdup_printf ("Running [%"G_GUINT64_FORMAT"] %s ...", task_id, str_argv);
         log_func (LOG_INFO, log_msg);
         g_free (str_argv);
@@ -93,7 +93,7 @@ static guint64 log_running (gchar **argv) {
  * log_out: (skip)
  *
  */
-static void log_out (guint64 task_id, gchar *stdout, gchar *stderr) {
+static void log_out (guint64 task_id, const gchar *stdout, const gchar *stderr) {
     gchar *log_msg = NULL;
 
     if (log_func) {
@@ -138,7 +138,7 @@ static void set_c_locale(gpointer user_data __attribute__((unused))) {
  *
  * Returns: whether the @argv was successfully executed (no error and exit code 0) or not
  */
-gboolean bd_utils_exec_and_report_error (gchar **argv, BDExtraArg **extra, GError **error) {
+gboolean bd_utils_exec_and_report_error (const gchar **argv, const BDExtraArg **extra, GError **error) {
     gint status = 0;
     /* just use the "stronger" function and throw away the returned status */
     return bd_utils_exec_and_report_status_error (argv, extra, &status, error);
@@ -153,26 +153,26 @@ gboolean bd_utils_exec_and_report_error (gchar **argv, BDExtraArg **extra, GErro
  *
  * Returns: whether the @argv was successfully executed (no error and exit code 0) or not
  */
-gboolean bd_utils_exec_and_report_status_error (gchar **argv, BDExtraArg **extra, gint *status, GError **error) {
+gboolean bd_utils_exec_and_report_status_error (const gchar **argv, const BDExtraArg **extra, gint *status, GError **error) {
     gboolean success = FALSE;
     gchar *stdout_data = NULL;
     gchar *stderr_data = NULL;
     guint64 task_id = 0;
-    gchar **args = NULL;
+    const gchar **args = NULL;
     guint args_len = 0;
-    gchar **arg_p = NULL;
-    BDExtraArg **extra_p = NULL;
+    const gchar **arg_p = NULL;
+    const BDExtraArg **extra_p = NULL;
     guint i = 0;
 
     if (extra) {
-        args_len = g_strv_length (argv);
+        args_len = g_strv_length ((gchar **) argv);
         for (extra_p=extra; *extra_p; extra_p++) {
             if ((*extra_p)->opt && (g_strcmp0 ((*extra_p)->opt, "") != 0))
                 args_len++;
             if ((*extra_p)->val && (g_strcmp0 ((*extra_p)->val, "") != 0))
                 args_len++;
         }
-        args = g_new0 (gchar*, args_len + 1);
+        args = g_new0 (const gchar*, args_len + 1);
         for (arg_p=argv; *arg_p; arg_p++, i++)
             args[i] = *arg_p;
         for (extra_p=extra; *extra_p; extra_p++) {
@@ -189,7 +189,7 @@ gboolean bd_utils_exec_and_report_status_error (gchar **argv, BDExtraArg **extra
     }
 
     task_id = log_running (args ? args : argv);
-    success = g_spawn_sync (NULL, args ? args : argv, NULL, G_SPAWN_SEARCH_PATH,
+    success = g_spawn_sync (NULL, args ? (gchar **) args : (gchar **) argv, NULL, G_SPAWN_SEARCH_PATH,
                             (GSpawnChildSetupFunc) set_c_locale, NULL,
                             &stdout_data, &stderr_data, status, error);
     log_out (task_id, stdout_data, stderr_data);
@@ -229,27 +229,27 @@ gboolean bd_utils_exec_and_report_status_error (gchar **argv, BDExtraArg **extra
  *
  * Returns: whether the @argv was successfully executed capturing the output or not
  */
-gboolean bd_utils_exec_and_capture_output (gchar **argv, BDExtraArg **extra, gchar **output, GError **error) {
+gboolean bd_utils_exec_and_capture_output (const gchar **argv, const BDExtraArg **extra, gchar **output, GError **error) {
     gchar *stdout_data = NULL;
     gchar *stderr_data = NULL;
     gint status = 0;
     gboolean success = FALSE;
     guint64 task_id = 0;
-    gchar **args = NULL;
+    const gchar **args = NULL;
     guint args_len = 0;
-    gchar **arg_p = NULL;
-    BDExtraArg **extra_p = NULL;
+    const gchar **arg_p = NULL;
+    const BDExtraArg **extra_p = NULL;
     guint i = 0;
 
     if (extra) {
-        args_len = g_strv_length (argv);
+        args_len = g_strv_length ((gchar **) argv);
         for (extra_p=extra; *extra_p; extra_p++) {
             if ((*extra_p)->opt && (g_strcmp0 ((*extra_p)->opt, "") != 0))
                 args_len++;
             if ((*extra_p)->val && (g_strcmp0 ((*extra_p)->val, "") != 0))
                 args_len++;
         }
-        args = g_new0 (gchar*, args_len + 1);
+        args = g_new0 (const gchar*, args_len + 1);
         for (arg_p=argv; *arg_p; arg_p++, i++)
             args[i] = *arg_p;
         for (extra_p=extra; *extra_p; extra_p++) {
@@ -266,7 +266,7 @@ gboolean bd_utils_exec_and_capture_output (gchar **argv, BDExtraArg **extra, gch
     }
 
     task_id = log_running (argv);
-    success = g_spawn_sync (NULL, argv, NULL, G_SPAWN_SEARCH_PATH,
+    success = g_spawn_sync (NULL, (gchar **) argv, NULL, G_SPAWN_SEARCH_PATH,
                             (GSpawnChildSetupFunc) set_c_locale, NULL,
                             &stdout_data, &stderr_data, &status, error);
     log_out (task_id, stdout_data, stderr_data);
@@ -326,7 +326,7 @@ gboolean bd_utils_init_logging (BDUtilsLogFunc new_log_func, GError **error __at
  * **ONLY SUPPORTS VERSION STRINGS OF FORMAT X[.Y[.Z[.Z2[.Z3...[-R]]]]] where all components
  *   are natural numbers!**
  */
-gint bd_utils_version_cmp (gchar *ver_string1, gchar *ver_string2, GError **error) {
+gint bd_utils_version_cmp (const gchar *ver_string1, const gchar *ver_string2, GError **error) {
     gchar **v1_fields = NULL;
     gchar **v2_fields = NULL;
     guint v1_fields_len = 0;
@@ -401,9 +401,9 @@ gint bd_utils_version_cmp (gchar *ver_string1, gchar *ver_string2, GError **erro
  * Returns: whether the @util is available in a version >= @version or not
  *          (@error is set in such case).
  */
-gboolean bd_utils_check_util_version (gchar *util, gchar *version, gchar *version_arg, gchar *version_regexp, GError **error) {
+gboolean bd_utils_check_util_version (const gchar *util, const gchar *version, const gchar *version_arg, const gchar *version_regexp, GError **error) {
     gchar *util_path = NULL;
-    gchar *argv[] = {util, version_arg ? version_arg : "--version", NULL};
+    const gchar *argv[] = {util, version_arg ? version_arg : "--version", NULL};
     gchar *output = NULL;
     gboolean succ = FALSE;
     GRegex *regex = NULL;

--- a/src/utils/exec.h
+++ b/src/utils/exec.h
@@ -12,7 +12,7 @@
  * Function type for logging function used by the libblockdev's exec utils to
  * log the information about program executing.
  */
-typedef void (*BDUtilsLogFunc) (gint level, gchar *msg);
+typedef void (*BDUtilsLogFunc) (gint level, const gchar *msg);
 
 GQuark bd_utils_exec_error_quark (void);
 #define BD_UTILS_EXEC_ERROR bd_utils_exec_error_quark ()
@@ -25,11 +25,11 @@ typedef enum {
     BD_UTILS_EXEC_ERROR_UTIL_LOW_VER,
 } BDUtilsExecError;
 
-gboolean bd_utils_exec_and_report_error (gchar **argv, BDExtraArg **extra, GError **error);
-gboolean bd_utils_exec_and_report_status_error (gchar **argv, BDExtraArg **extra, gint *status, GError **error);
-gboolean bd_utils_exec_and_capture_output (gchar **argv, BDExtraArg **extra, gchar **output, GError **error);
+gboolean bd_utils_exec_and_report_error (const gchar **argv, const BDExtraArg **extra, GError **error);
+gboolean bd_utils_exec_and_report_status_error (const gchar **argv, const BDExtraArg **extra, gint *status, GError **error);
+gboolean bd_utils_exec_and_capture_output (const gchar **argv, const BDExtraArg **extra, gchar **output, GError **error);
 gboolean bd_utils_init_logging (BDUtilsLogFunc new_log_func, GError **error);
-gint bd_utils_version_cmp (gchar *ver_string1, gchar *ver_string2, GError **error);
-gboolean bd_utils_check_util_version (gchar *util, gchar *version, gchar *version_arg, gchar *version_regexp, GError **error);
+gint bd_utils_version_cmp (const gchar *ver_string1, const gchar *ver_string2, GError **error);
+gboolean bd_utils_check_util_version (const gchar *util, const gchar *version, const gchar *version_arg, const gchar *version_regexp, GError **error);
 
 #endif  /* BD_UTILS_EXEC */

--- a/src/utils/extra_arg.c
+++ b/src/utils/extra_arg.c
@@ -45,7 +45,7 @@ GType bd_extra_arg_get_type (void) {
  *
  * Returns: (transfer full): a new extra argument
  */
-BDExtraArg* bd_extra_arg_new (gchar *opt, gchar *val) {
+BDExtraArg* bd_extra_arg_new (const gchar *opt, const gchar *val) {
     BDExtraArg *ret = g_new0 (BDExtraArg, 1);
     ret->opt = g_strdup (opt);
     ret->val = g_strdup (val);

--- a/src/utils/extra_arg.h
+++ b/src/utils/extra_arg.h
@@ -14,6 +14,6 @@ typedef struct BDExtraArg {
 
 BDExtraArg* bd_extra_arg_copy (BDExtraArg *arg);
 void bd_extra_arg_free (BDExtraArg *arg);
-BDExtraArg* bd_extra_arg_new (gchar *opt, gchar *val);
+BDExtraArg* bd_extra_arg_new (const gchar *opt, const gchar *val);
 
 #endif  /* BD_UTILS_EXTRA_ARG */

--- a/src/utils/sizes.c
+++ b/src/utils/sizes.c
@@ -23,7 +23,7 @@ GQuark bd_utils_size_error_quark (void)
  *
  * Returns: power of the @prefix or %NUM_PREFIXES if not found
  */
-static guint8 get_unit_prefix_power (gchar *prefix) {
+static guint8 get_unit_prefix_power (const gchar *prefix) {
     guint i = 0;
 
     for (i = 0; size_prefixes[i]; i++)
@@ -68,7 +68,7 @@ gchar* bd_utils_size_human_readable (guint64 size) {
  * Returns: number of bytes equal to the size specification rounded to bytes, if
  * 0, @error) may be set in case of error
  */
-guint64 bd_utils_size_from_spec (gchar *spec, GError **error) {
+guint64 bd_utils_size_from_spec (const gchar *spec, GError **error) {
     gchar const * const pattern = "^\\s*(\\d+\\.?\\d*)\\s*([kmgtpeKMGTPE]i?)[bB]";
     gchar const * const zero_pattern = "^\\s*0\\.?0*\\s*([kmgtpeKMGTPE]i?)?[bB]?$";
     GRegex *regex = NULL;

--- a/src/utils/sizes.h
+++ b/src/utils/sizes.h
@@ -23,6 +23,6 @@ typedef enum {
 } BDUtilsSizeError;
 
 gchar* bd_utils_size_human_readable (guint64 size);
-guint64 bd_utils_size_from_spec (gchar *spec, GError **error);
+guint64 bd_utils_size_from_spec (const gchar *spec, GError **error);
 
 #endif /* BD_UTILS_SIZES */


### PR DESCRIPTION
Otherwise the caller cannot tell if we are going to change the referenced
value/data or not.

Note: Requested in the issue #56 