### PR TITLE
Make tests pass on aarch64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,6 @@ AC_SUBST([PYTHON3_EXEC_PREFIX], ['${exec_prefix}'])
 PYTHON3_EXECDIR=`$PYTHON3 -c "import distutils.sysconfig; \
                           print(distutils.sysconfig.get_python_lib(1,0,prefix='$PYTHON3_EXEC_PREFIX'))"`
 AC_SUBST(py3execdir, $PYTHON3_EXECDIR)
-AM_CONDITIONAL(USE_PYTHON3, test ${use_python3} = "yes")
 
 # Run tests on build?
 AC_ARG_ENABLE([tests], AS_HELP_STRING([--enable-tests], [Run tests at compile time (default=yes)]))

--- a/configure.ac
+++ b/configure.ac
@@ -18,9 +18,11 @@ LT_INIT
 
 AC_CONFIG_FILES([Makefile src/Makefile \
                           src/plugins/Makefile \
+                          src/plugins/btrfs.h \
                           src/utils/Makefile \
                           src/lib/Makefile \
                           src/lib/plugin_apis/Makefile \
+                          src/lib/plugin_apis/btrfs.api \
                           src/lib/blockdev.c \
                           src/lib/blockdev.pc \
                           src/python/Makefile \
@@ -54,6 +56,11 @@ uname -p|grep s390
 on_s390=$?
 
 AM_CONDITIONAL(ON_S390, test "$on_s390" = "0")
+
+uname -p|grep aarch64
+on_aarch64=$?
+
+AS_IF([test "$on_aarch64" = "0"], AC_SUBST([BTRFS_MIN_SIZE], ["(256 MiB)"]), AC_SUBST([BTRFS_MIN_SIZE], ["(128 MiB)"]))
 
 # Complain if introspection was not enabled
 AS_IF([test "x$found_introspection" = xyes], [:],

--- a/src/lib/plugin_apis/btrfs.api.in
+++ b/src/lib/plugin_apis/btrfs.api.in
@@ -3,7 +3,7 @@
 #include <utils.h>
 
 #define BD_BTRFS_MAIN_VOLUME_ID 5
-#define BD_BTRFS_MIN_MEMBER_SIZE (128 MiB)
+#define BD_BTRFS_MIN_MEMBER_SIZE @BTRFS_MIN_SIZE@
 
 #define BD_BTRFS_ERROR bd_btrfs_error_quark ()
 typedef enum {

--- a/src/plugins/btrfs.h.in
+++ b/src/plugins/btrfs.h.in
@@ -8,7 +8,7 @@
 #define BTRFS_MIN_VERSION "3.18.2"
 
 #define BD_BTRFS_MAIN_VOLUME_ID 5
-#define BD_BTRFS_MIN_MEMBER_SIZE (128 MiB)
+#define BD_BTRFS_MIN_MEMBER_SIZE @BTRFS_MIN_SIZE@
 
 GQuark bd_btrfs_error_quark (void);
 #define BD_BTRFS_ERROR bd_btrfs_error_quark ()


### PR DESCRIPTION
For that to start happening we need to define specific constant for the minimum size of a btrfs member device which is (for some reason, page size?) 256 MiB on aarch64. I run the tests manually on our jenkins slave and everything worked just fine. 