### PR TITLE
Add a function for setting multiple partition flags at once

### DIFF
--- a/src/lib/plugin_apis/part.api
+++ b/src/lib/plugin_apis/part.api
@@ -173,6 +173,21 @@ gboolean bd_part_delete_part (const gchar *disk, const gchar *part, GError **err
 gboolean bd_part_set_part_flag (const gchar *disk, const gchar *part, BDPartFlag flag, gboolean state, GError **error);
 
 /**
+ * bd_part_set_part_flags:
+ * @disk: disk the partition belongs to
+ * @part: partition to set the flag on
+ * @flags: flags to set (mask combined from #BDPartFlag numbers)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @flags were successfully set on the @part partition or
+ *          not
+ *
+ * Note: Unsets all the other flags on the partition.
+ *
+ */
+gboolean bd_part_set_part_flags (const gchar *disk, const gchar *part, guint64 flags, GError **error);
+
+/**
  * bd_part_get_part_table_type_str:
  * @type: table type to get string representation for
  * @error: (out): place to store error (if any)

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -76,7 +76,7 @@ endif
 
 libbd_part_la_CFLAGS = $(GLIB_CFLAGS) $(PARTED_CFLAGS) -Wall -Wextra -Werror
 libbd_part_la_LIBADD = $(GLIB_LIBS) $(PARTED_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_part_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0
+libbd_part_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1
 libbd_part_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_part_la_SOURCES = part.c part.h
 

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -227,7 +227,6 @@ BDPartSpec* bd_part_get_part_spec (const gchar *disk, const gchar *part, GError 
     if (!ped_disk) {
         set_parted_error (error, BD_PART_ERROR_FAIL);
         g_prefix_error (error, "Failed to read partition table on device '%s'", disk);
-        ped_disk_destroy (ped_disk);
         ped_device_destroy (dev);
         return FALSE;
     }
@@ -430,7 +429,6 @@ BDPartSpec* bd_part_create_part (const gchar *disk, BDPartTypeReq type, guint64 
     if (!ped_disk) {
         set_parted_error (error, BD_PART_ERROR_FAIL);
         g_prefix_error (error, "Failed to read partition table on device '%s'", disk);
-        ped_disk_destroy (ped_disk);
         ped_device_destroy (dev);
         return NULL;
     }
@@ -531,7 +529,6 @@ gboolean bd_part_delete_part (const gchar *disk, const gchar *part, GError **err
     if (!ped_disk) {
         set_parted_error (error, BD_PART_ERROR_FAIL);
         g_prefix_error (error, "Failed to read partition table on device '%s'", disk);
-        ped_disk_destroy (ped_disk);
         ped_device_destroy (dev);
         return FALSE;
     }
@@ -616,7 +613,6 @@ gboolean bd_part_set_part_flag (const gchar *disk, const gchar *part, BDPartFlag
     if (!ped_disk) {
         set_parted_error (error, BD_PART_ERROR_FAIL);
         g_prefix_error (error, "Failed to read partition table on device '%s'", disk);
-        ped_disk_destroy (ped_disk);
         ped_device_destroy (dev);
         return FALSE;
     }
@@ -706,7 +702,6 @@ gboolean bd_part_set_part_flags (const gchar *disk, const gchar *part, guint64 f
     if (!ped_disk) {
         set_parted_error (error, BD_PART_ERROR_FAIL);
         g_prefix_error (error, "Failed to read partition table on device '%s'", disk);
-        ped_disk_destroy (ped_disk);
         ped_device_destroy (dev);
         return FALSE;
     }

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -666,6 +666,100 @@ gboolean bd_part_set_part_flag (const gchar *disk, const gchar *part, BDPartFlag
 }
 
 /**
+ * bd_part_set_part_flags:
+ * @disk: disk the partition belongs to
+ * @part: partition to set the flag on
+ * @flags: flags to set (mask combined from #BDPartFlag numbers)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @flags were successfully set on the @part partition or
+ *          not
+ *
+ * Note: Unsets all the other flags on the partition.
+ *
+ */
+gboolean bd_part_set_part_flags (const gchar *disk, const gchar *part, guint64 flags, GError **error) {
+    PedDevice *dev = NULL;
+    PedDisk *ped_disk = NULL;
+    PedPartition *ped_part = NULL;
+    const gchar *part_num_str = NULL;
+    gint part_num = 0;
+    guint64 i = 0;
+    gint status = 0;
+    gboolean ret = FALSE;
+
+    /* TODO: share this code with the other functions modifying a partition */
+    if (!part || (part && (*part == '\0'))) {
+        g_set_error (error, BD_PART_ERROR, BD_PART_ERROR_INVAL,
+                     "Invalid partition path given: '%s'", part);
+        return FALSE;
+    }
+
+    dev = ped_device_get (disk);
+    if (!dev) {
+        set_parted_error (error, BD_PART_ERROR_INVAL);
+        g_prefix_error (error, "Device '%s' invalid or not existing", disk);
+        return FALSE;
+    }
+
+    ped_disk = ped_disk_new (dev);
+    if (!ped_disk) {
+        set_parted_error (error, BD_PART_ERROR_FAIL);
+        g_prefix_error (error, "Failed to read partition table on device '%s'", disk);
+        ped_disk_destroy (ped_disk);
+        ped_device_destroy (dev);
+        return FALSE;
+    }
+
+    part_num_str = part + (strlen (part) - 1);
+    while (isdigit (*part_num_str) || (*part_num_str == '-')) {
+        part_num_str--;
+    }
+    part_num_str++;
+
+    part_num = atoi (part_num_str);
+    if (part_num == 0) {
+        g_set_error (error, BD_PART_ERROR, BD_PART_ERROR_INVAL,
+                     "Invalid partition path given: '%s'. Cannot extract partition number", part);
+        ped_disk_destroy (ped_disk);
+        ped_device_destroy (dev);
+        return FALSE;
+    }
+
+    ped_part = ped_disk_get_partition (ped_disk, part_num);
+    if (!ped_part) {
+        set_parted_error (error, BD_PART_ERROR_FAIL);
+        g_prefix_error (error, "Failed to get partition '%d' on device '%s'", part_num, disk);
+        ped_disk_destroy (ped_disk);
+        ped_device_destroy (dev);
+        return FALSE;
+    }
+
+    /* our flags are 1s shifted to the bit determined by parted's flags
+     * (i.e. 1 << 3 instead of 3, etc.) */
+    for (i=1; i <= (int) log2 ((double)BD_PART_FLAG_BASIC_LAST); i++) {
+        if ((1 << i) & flags)
+            status = ped_partition_set_flag (ped_part, (PedPartitionFlag) i, (int) 1);
+        else if (ped_partition_is_flag_available (ped_part, (PedPartitionFlag) i))
+            status = ped_partition_set_flag (ped_part, (PedPartitionFlag) i, (int) 0);
+        if (status == 0) {
+            set_parted_error (error, BD_PART_ERROR_FAIL);
+            g_prefix_error (error, "Failed to set flag on the partition '%d' on device '%s'", part_num, disk);
+            ped_disk_destroy (ped_disk);
+            ped_device_destroy (dev);
+            return FALSE;
+        }
+    }
+
+    ret = disk_commit (ped_disk, disk, error);
+
+    ped_disk_destroy (ped_disk);
+    ped_device_destroy (dev);
+
+    return ret;
+}
+
+/**
  * bd_part_get_part_table_type_str:
  * @type: table type to get string representation for
  * @error: (out): place to store error (if any)

--- a/src/plugins/part.h
+++ b/src/plugins/part.h
@@ -35,7 +35,8 @@ typedef enum {
     BD_PART_FLAG_LEGACY_BOOT = 1 << 15,
     BD_PART_FLAG_MSFT_DATA = 1 << 16,
     BD_PART_FLAG_IRST = 1 << 17,
-    BD_PART_FLAG_ESP = 1 << 18
+    BD_PART_FLAG_ESP = 1 << 18,
+    BD_PART_FLAG_BASIC_LAST = 1 << 19,
 } BDPartFlag;
 
 typedef enum {
@@ -77,6 +78,7 @@ BDPartSpec** bd_part_get_disk_parts (const gchar *disk, GError **error);
 BDPartSpec* bd_part_create_part (const gchar *disk, BDPartTypeReq type, guint64 start, guint64 size, BDPartAlign align, GError **error);
 gboolean bd_part_delete_part (const gchar *disk, const gchar *part, GError **error);
 gboolean bd_part_set_part_flag (const gchar *disk, const gchar *part, BDPartFlag flag, gboolean state, GError **error);
+gboolean bd_part_set_part_flags (const gchar *disk, const gchar *part, guint64 flags, GError **error);
 const gchar* bd_part_get_part_table_type_str (BDPartTableType type, GError **error);
 const gchar* bd_part_get_flag_str (BDPartFlag flag, GError **error);
 const gchar* bd_part_get_type_str (BDPartType type, GError **error);


### PR DESCRIPTION
Not sure how often multiple partition flags are set, but if it happens, it's
better to do it in a single function call with a single commit to disk. This
also brings some atomicity to the operation as if (un)setting one flag fails,
nothing is commited to the disk.

Requested in the issue #81.