### PR TITLE
Zfcp functionality

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -378,4 +378,7 @@ bd_s390_dasd_online
 bd_s390_dasd_is_ldl
 bd_s390_zfcp_sanitize_wwpn_input
 bd_s390_zfcp_sanitize_lun_input
+bd_s390_zfcp_online
+bd_s390_zfcp_scsi_offline
+bd_s390_zfcp_offline
 </SECTION>

--- a/features.rst
+++ b/features.rst
@@ -247,8 +247,9 @@ s390
    * s390_sanitize_dev_input [DONE]
    * s390_zfcp_sanitize_wwpn_input [DONE]
    * s390_zfcp_sanitize_lun_input [DONE]
-   * s390_zfcp_online
-   * s390_zfcp_offline
+   * s390_zfcp_online [DONE]
+   * s390_zfcp_scsi_offline [DONE]
+   * s390_zfcp_offline [DONE]
 
 
 KBD (Kernel Block Devices)

--- a/src/lib/plugin_apis/s390.api
+++ b/src/lib/plugin_apis/s390.api
@@ -78,3 +78,44 @@ gchar* bd_s390_zfcp_sanitize_wwpn_input (const gchar *wwpn, GError **error);
  * Returns: (transfer full): a synthesized zFCP LUN
  */
 gchar* bd_s390_zfcp_sanitize_lun_input (const gchar *lun, GError **error);
+
+/**
+ * bd_s390_zfcp_online:
+ * @devno a zFCP device number
+ * @wwpn a zFCP WWPN identifier
+ * @lun a zFCP LUN identifier
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a zFCP device was successfully switched online
+ */
+gboolean bd_s390_zfcp_online (const gchar *devno, const gchar *wwpn, const gchar *lun, GError **error);
+
+/*
+ * bd_s390_zfcp_scsi_offline:
+ * @devno a zFCP device number
+ * @wwpn a zFCP WWPN identifier
+ * @lun a zFCP LUN identifier
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a LUN was successfully removed from associated WWPN
+ *
+ * This function looks through /proc/scsi/scsi and manually removes LUNs from
+ * associated WWPNs. zFCP devices are SCSI devices accessible over FCP protocol.
+ * In z/OS the IODF (I/O definition file) contains basic information about the
+ * I/O config, but WWPN and LUN configuration is done at the OS level, hence
+ * this function becomes necessary when switching the device offline. This
+ * particular sequence of actions is for some reason unnecessary when switching
+ * the device online. Chalk it up to s390x being s390x.
+ */
+gboolean bd_s390_zfcp_scsi_offline(const gchar *devno, const gchar *wwpn, const gchar *lun, GError **error);
+
+/*
+ * bd_s390_zfcp_offline:
+ * @devno: zfcp device number
+ * @wwpn: zfcp WWPN (World Wide Port Number)
+ * @lun: zfcp LUN (Logical Unit Number)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a zfcp device was successfully switched offline
+ */
+gboolean bd_s390_zfcp_offline (const gchar *devno, const gchar *wwpn, const gchar *lun, GError **error);

--- a/src/plugins/s390.c
+++ b/src/plugins/s390.c
@@ -71,7 +71,7 @@ gboolean check() {
 gboolean bd_s390_dasd_format (const gchar *dasd, const BDExtraArg **extra, GError **error) {
     gboolean rc = FALSE;
     gchar *dev = g_strdup_printf ("/dev/%s", dasd);
-    gchar *argv[] = {"/sbin/dasdfmt", "-y", "-d", "cdl", "-b", "4096", dev, NULL};
+    const gchar *argv[8] = {"/sbin/dasdfmt", "-y", "-d", "cdl", "-b", "4096", dev, NULL};
 
     rc = bd_utils_exec_and_report_error (argv, extra, error);
     g_free (dev);
@@ -136,7 +136,7 @@ gboolean bd_s390_dasd_online (const gchar *dasd, GError **error) {
     gint online = 0;
     gchar *path = NULL;
     FILE *fd = NULL;
-    gchar *argv[] = {"/usr/sbin/dasd_cio_free", "-d", dasd, NULL};
+    const gchar *argv[4] = {"/usr/sbin/dasd_cio_free", "-d", dasd, NULL};
 
     path = g_strdup_printf ("/sys/bus/ccw/drivers/dasd-eckd/%s/online", dasd);
     fd = fopen(path, "r+");

--- a/src/plugins/s390.c
+++ b/src/plugins/s390.c
@@ -18,6 +18,7 @@
  */
 
 #include <glib.h>
+#include <glob.h>
 #include <linux/fs.h>
 #include <stdio.h>
 #include <string.h>
@@ -397,4 +398,400 @@ gchar* bd_s390_zfcp_sanitize_lun_input (const gchar *lun, GError **error) {
     g_free (append);
 
     return fulllun;
+}
+
+/**
+ * bd_s390_zfcp_online:
+ * @devno: zfcp device number
+ * @wwpn: zfcp WWPN (World Wide Port Number)
+ * @lun: zfcp LUN (Logical Unit Number)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a zfcp device was successfully switched online
+ */
+gboolean bd_s390_zfcp_online (const gchar *devno, const gchar *wwpn, const gchar *lun, GError **error) {
+    gboolean boolrc = FALSE;
+    gint rc = 0;
+    FILE *fd = NULL;
+    DIR *pdfd = NULL;
+    const gchar *zfcp_cio_free[4] = {"/usr/sbin/zfcp_cio_free", "-d", devno, NULL};
+    const gchar *chccwdev[4] = {"/usr/sbin/chccwdev", "-e", devno, NULL};
+
+    gchar *zfcpsysfs = "/sys/bus/ccw/drivers/zfcp";
+    gchar *online = g_strdup_printf ("%s/%s/online", zfcpsysfs, devno);
+    gchar *portdir = NULL;
+    gchar *unitadd = NULL;
+    gchar *failed = NULL;
+
+    /* part 01: make sure device is available/not on device ignore list */
+    fd = fopen (online, "r");
+    if (!fd) {
+        boolrc = bd_utils_exec_and_report_error (zfcp_cio_free, NULL, error);
+
+        if (!boolrc) {
+            fclose (fd);
+            g_free (online);
+            g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                         "Could not remove device %s from device ignore list.", devno);
+            return FALSE;
+        }
+        /* fd is NULL at this point, so try to open it again */
+        fd = fopen (online, "r");
+
+        /* still no luck, fail */
+        if (!fd) {
+            g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                         "Could not open device %s even after removing it from" " the device ignore list.", devno);
+            g_free (online);
+            return FALSE;
+        }
+    }
+    g_free (online);
+
+    /* part 02: check to make sure/turn device online */
+    rc = fgetc (fd);
+    if (rc == EOF) {
+        /* there was some error checking the 'online' status */
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_IO,
+                     "Error checking if device %s is online", devno);
+        fclose (fd);
+        return FALSE;
+    }
+    if (rc == 1) {
+        /**
+         * otherwise device's status indicates that it's already online, so
+         * just close the fd and proceed; we don't return because although 'online'
+         * status may be correct, the device may not be completely online and ready
+         * to use just yet, so just throw a warning.
+         */
+        fclose (fd);
+        g_warning ("Device %s is already online", devno);
+    }
+    else {
+        /* offline */
+        fclose (fd);
+        boolrc = bd_utils_exec_and_report_error (chccwdev, NULL, error);
+        if (!boolrc) {
+            g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                         "Could not set zFCP device %s online", devno);
+            return FALSE;
+        }
+    }
+
+    /* part 03: set other properties to use the device */
+    /* check this dir exists */
+    portdir = g_strdup_printf ("%s/%s/%s", zfcpsysfs, devno, wwpn);
+    pdfd = opendir (portdir);
+    if (!pdfd) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                     "WWPN %s not found for zFCP device %s", wwpn, devno);
+        g_free (portdir);
+        return FALSE;
+    }
+    closedir (pdfd);
+
+    unitadd = g_strdup_printf ("%s/unit_add", portdir);
+    fd = fopen (unitadd, "w");
+    if (!fd) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_IO,
+                     "Could not open %s", unitadd);
+        g_free (unitadd);
+        g_free (portdir);
+        return FALSE;
+    }
+    rc = fputs (lun, fd);
+    if (rc == EOF) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_IO,
+                     "Could not add LUN %s to WWPN %s on zFCP device %s", lun, wwpn, devno);
+        g_free (unitadd);
+        g_free (portdir);
+        fclose (fd);
+        return FALSE;
+    }
+    g_free (unitadd);
+    fclose (fd);
+
+    /* part 04: other error checking to verify device turned on properly */
+    failed = g_strdup_printf ("%s/%s/failed", portdir, lun);
+    fd = fopen (failed, "r");
+    if (!fd) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_IO,
+                     "Could not open %s", failed);
+        g_free (failed);
+        g_free (portdir);
+        return FALSE;
+    }
+
+    rc = fgetc (fd);
+    if (rc == EOF) {
+        /* there was some error checking the 'failed' status */
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_IO,
+                     "Could not read failed attribute of LUN %s at WWPN %s on" " zFCP device %s", lun, wwpn, devno);
+        g_free (failed);
+        g_free (portdir);
+        fclose (fd);
+        return FALSE;
+    }
+    /**
+     * read value here is either 0 or 1; fgetc casts this from char->int, so
+     * subtract '0' here to get the literal read value
+     */
+    rc -= '0';
+    if (rc != 0) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                     "Failed LUN %s at WWPN %s on zFCP device %s removed again", lun, wwpn, devno);
+        g_free (failed);
+        g_free (portdir);
+        fclose (fd);
+        return FALSE;
+    }
+    /* if you haven't failed yet, you deserve this */
+    g_free (failed);
+    g_free (portdir);
+    fclose (fd);
+    return TRUE;
+}
+
+/**
+ * bd_s390_zfcp_scsi_offline
+ *
+ * @devno: zfcp device number
+ * @wwpn: zfcp WWPN (World Wide Port Number)
+ * @lun: zfcp LUN (Logical Unit Number)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a LUN was successfully removed from its associated WWPN
+ *
+ * This function looks through /proc/scsi/scsi and manually removes LUNs from
+ * associated WWPNs. zFCP devices are SCSI devices accessible over FCP protocol.
+ * In z/OS the IODF (I/O definition file) contains basic information about the
+ * I/O config, but WWPN and LUN configuration is done at the OS level, hence
+ * this function becomes necessary when switching the device offline. This
+ * particular sequence of actions is for some reason unnecessary when switching
+ * the device online. Chalk it up to s390x being s390x.
+ */
+gboolean bd_s390_zfcp_scsi_offline(const gchar *devno, const gchar *wwpn, const gchar *lun, GError **error) {
+    FILE *scsifd = NULL;
+    FILE *fd = NULL;
+    size_t len = 0;
+    ssize_t read, rc;
+
+    const gchar *delim = " ";
+    gchar *channel = "0";
+    gchar *devid = "0";
+    gchar *path = "/proc/scsi/scsi";
+    gchar *scsidevsysfs = "/sys/bus/scsi/devices";
+
+    gchar *line = NULL;
+    gchar *fcphbasysfs = NULL;
+    gchar *fcpwwpnsysfs = NULL;
+    gchar *fcplunsysfs = NULL;
+    gchar *hba_path = NULL;
+    gchar *wwpn_path = NULL;
+    gchar *lun_path = NULL;
+    gchar *host = NULL;
+    gchar *fcplun = NULL;
+    gchar *scsidev = NULL;
+    gchar *fcpsysfs = NULL;
+    gchar *scsidel = NULL;
+    gchar **tokens = NULL;
+
+    scsifd = fopen (path, "r");
+    if (!scsifd) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                     "Failed to open path to SCSI device: %s", path);
+        return FALSE;
+    }
+
+    while ((read = getline(&line, &len, scsifd)) != -1) {
+        if (!g_str_has_prefix(line, "Host")) {
+            continue;
+        }
+
+        /* tokenize line and assign certain values we'll need later */
+        tokens = g_strsplit (line, delim, 8);
+
+        host = tokens[1];
+        fcplun = tokens[7];
+
+        scsidev = g_strdup_printf ("%s:%s:%s:%s", host + 4, channel, devid, fcplun);
+        scsidev = g_strchomp (scsidev);
+        fcpsysfs = g_strdup_printf ("%s/%s", scsidevsysfs, scsidev);
+        fcpsysfs = g_strchomp (fcpsysfs);
+
+        /* get HBA path value (same as device number) */
+        hba_path = g_strdup_printf ("%s/hba_id", fcpsysfs);
+        len = 0; /* should be zero, but re-set it just in case */
+        fd = fopen (hba_path, "r");
+        rc = getline (&fcphbasysfs, &len, fd);
+        if (rc == -1) {
+            g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                         "Failed to read value from %s", hba_path);
+            fclose (fd);
+            g_free (hba_path);
+            g_free (fcpsysfs);
+            g_free (scsidev);
+            return FALSE;
+        }
+        fclose (fd);
+        g_free (hba_path);
+
+        /* get WWPN value */
+        wwpn_path = g_strdup_printf ("%s/wwpn", fcpsysfs);
+        len = 0;
+        fd = fopen (wwpn_path, "r");
+        rc = getline (&fcpwwpnsysfs, &len, fd);
+        if (rc == -1) {
+            g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                         "Failed to read value from %s", wwpn_path);
+            g_free (wwpn_path);
+            g_free (fcphbasysfs);
+            g_free (fcpsysfs);
+            g_free (scsidev);
+            fclose (fd);
+            return FALSE;
+        }
+        fclose(fd);
+        g_free (wwpn_path);
+
+        /* read LUN value */
+        lun_path = g_strdup_printf ("%s/fcp_lun", fcpsysfs);
+        len = 0;
+        fd = fopen (lun_path, "r");
+        rc = getline (&fcplunsysfs, &len, fd);
+        if (rc == -1) {
+            g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                         "Failed to read value from %s", lun_path);
+            fclose (fd);
+            g_free (lun_path);
+            g_free (fcpwwpnsysfs);
+            g_free (fcphbasysfs);
+            g_free (fcpsysfs);
+            g_free (scsidev);
+            return FALSE;
+        }
+        fclose(fd);
+        g_free (lun_path);
+        g_free (fcpsysfs);
+
+        /* make sure read values align with expected values */
+        scsidel = g_strdup_printf ("%s/%s/delete", scsidevsysfs, scsidev);
+        scsidel = g_strchomp (scsidel);
+        if ((fcphbasysfs == devno) && (fcpwwpnsysfs == wwpn) && (fcplunsysfs == lun)) {
+            fd = fopen (scsidel, "w");
+            if (!fd) {
+                g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                             "Failed to open %s", scsidel);
+                g_free (scsidel);
+                g_free (fcplunsysfs);
+                g_free (fcpwwpnsysfs);
+                g_free (fcphbasysfs);
+                g_free (scsidev);
+                return FALSE;
+            }
+            rc = fputs ("1", fd);
+            if (rc == EOF) {
+                g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                             "Could not write to %s", scsidel);
+                fclose (fd);
+                g_free (scsidel);
+                g_free (fcplunsysfs);
+                g_free (fcpwwpnsysfs);
+                g_free (fcphbasysfs);
+                g_free (scsidev);
+                return FALSE;
+            }
+            fclose (fd);
+        }
+    }
+    fclose (scsifd);
+    g_free (scsidel);
+    g_free (fcplunsysfs);
+    g_free (fcpwwpnsysfs);
+    g_free (fcphbasysfs);
+    g_free (scsidev);
+    return TRUE;
+}
+
+/**
+ * bd_s390_zfcp_offline:
+ * @devno: zfcp device number
+ * @wwpn: zfcp WWPN (World Wide Port Number)
+ * @lun: zfcp LUN (Logical Unit Number)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a zfcp device was successfully switched offline
+ */
+gboolean bd_s390_zfcp_offline (const gchar *devno, const gchar *wwpn, const gchar *lun, GError **error) {
+    gboolean failed = FALSE;
+    gint rc = 0;
+    FILE *fd = NULL;
+    glob_t luns;
+
+    gchar *zfcpsysfs = "/sys/bus/ccw/drivers/zfcp";
+    gchar *offline = NULL;
+    gchar *unitrm = NULL;
+    gchar *pattern = NULL;
+    const gchar *chccwdev[4] = {"/usr/sbin/chccwdev", "-d", devno, NULL};
+
+    failed = bd_s390_zfcp_scsi_offline(devno, wwpn, lun, error);
+    if (failed == 0) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                     "Could not correctly delete SCSI device of zFCP %s with WWPN %s, LUN %s", devno, wwpn, lun);
+        return FALSE;
+    }
+
+    /* remove lun */
+    unitrm = g_strdup_printf ("%s/%s/%s/unit_remove", zfcpsysfs, devno, wwpn);
+    fd = fopen (unitrm, "w");
+    if (!fd) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                     "Failed to open %s", unitrm);
+        g_free (unitrm);
+        return FALSE;
+    }
+    rc = fputs (lun, fd);
+    if (rc == EOF) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                     "Could not remove LUN %s at WWPN %s on zFCP device %s", lun, wwpn, devno);
+        g_free (unitrm);
+        return FALSE;
+    }
+    fclose (fd);
+    g_free (unitrm);
+    rc = 0;
+
+    /* gather the luns  */
+    pattern = g_strdup_printf ("%s/0x??????????????\?\?/0x????????????????", zfcpsysfs);
+    rc = glob (pattern, GLOB_ONLYDIR, NULL, &luns);
+    if (rc == GLOB_ABORTED || rc == GLOB_NOSPACE) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                     "An error occurred trying to determine if other LUNs are still associated with WWPN %s", wwpn);
+        globfree (&luns);
+        g_free (pattern);
+        return FALSE;
+    }
+    /* check if we have any matches found; if so, bail */
+    if (luns.gl_pathc > 0) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                     "Not setting zFCP device offline since it still has other LUNs");
+        globfree (&luns);
+        g_free (pattern);
+        return FALSE;
+    }
+    globfree (&luns);
+    g_free (pattern);
+    rc = 0;
+
+    /* offline */
+    offline = g_strdup_printf ("%s/%s/online", zfcpsysfs, devno);
+    failed = bd_utils_exec_and_report_error (chccwdev, NULL, error);
+    g_free (offline);
+    if (failed == 0) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                     "Could not set zFCP device %s online", devno);
+        return FALSE;
+    }
+
+    return TRUE;
 }

--- a/src/plugins/s390.h
+++ b/src/plugins/s390.h
@@ -13,6 +13,7 @@ typedef enum {
     BD_S390_ERROR_DEVICE,
     BD_S390_ERROR_FORMAT_FAILED,
     BD_S390_ERROR_DASDFMT,
+    BD_S390_ERROR_IO,
 } BDS390Error;
 
 gboolean bd_s390_dasd_format (const gchar *dasd, const BDExtraArg **extra, GError **error);
@@ -22,3 +23,6 @@ gboolean bd_s390_dasd_is_ldl (const gchar *dasd, GError **error);
 gchar* bd_s390_sanitize_dev_input (const gchar *dev, GError **error);
 gchar* bd_s390_zfcp_sanitize_wwpn_input (const gchar *wwpn, GError **error);
 gchar* bd_s390_zfcp_sanitize_lun_input (const gchar *lun, GError **error);
+gboolean bd_s390_zfcp_online (const gchar *devno, const gchar *wwpn, const gchar *lun, GError **error);
+gboolean bd_s390_zfcp_scsi_offline(const gchar *devno, const gchar *wwpn, const gchar *lun, GError **error);
+gboolean bd_s390_zfcp_offline(const gchar *devno, const gchar *wwpn, const gchar *lun, GError **error);


### PR DESCRIPTION
Some pretty isolated and self-explanatory (I hope) changes.

One commit fixes a tiny amount of fall-out from commit b733870 by making sure to pass const parameters to blockdev utility functions.

The other commit adds zFCP functionality. Unfortunately, there is no real way to test these other than manually.