### PR TITLE
Extra LVM info

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -189,6 +189,10 @@ typedef struct BDLVMLVdata {
     guint64 size;
     gchar *attr;
     gchar *segtype;
+    gchar *origin;
+    gchar *pool_lv;
+    gchar *data_lv;
+    gchar *metadata_lv;
 } BDLVMLVdata;
 
 /**
@@ -205,6 +209,10 @@ BDLVMLVdata* bd_lvm_lvdata_copy (BDLVMLVdata *data) {
     new_data->size = data->size;
     new_data->attr = g_strdup (data->attr);
     new_data->segtype = g_strdup (data->segtype);
+    new_data->origin = g_strdup (data->origin);
+    new_data->pool_lv = g_strdup (data->pool_lv);
+    new_data->data_lv = g_strdup (data->data_lv);
+    new_data->metadata_lv = g_strdup (data->metadata_lv);
     return new_data;
 }
 
@@ -219,6 +227,10 @@ void bd_lvm_lvdata_free (BDLVMLVdata *data) {
     g_free (data->uuid);
     g_free (data->attr);
     g_free (data->segtype);
+    g_free (data->origin);
+    g_free (data->pool_lv);
+    g_free (data->data_lv);
+    g_free (data->metadata_lv);
     g_free (data);
 }
 

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -138,6 +138,10 @@ BDLVMLVdata* bd_lvm_lvdata_copy (BDLVMLVdata *data) {
     new_data->size = data->size;
     new_data->attr = g_strdup (data->attr);
     new_data->segtype = g_strdup (data->segtype);
+    new_data->origin = g_strdup (data->origin);
+    new_data->pool_lv = g_strdup (data->pool_lv);
+    new_data->data_lv = g_strdup (data->data_lv);
+    new_data->metadata_lv = g_strdup (data->metadata_lv);
     return new_data;
 }
 
@@ -147,6 +151,10 @@ void bd_lvm_lvdata_free (BDLVMLVdata *data) {
     g_free (data->uuid);
     g_free (data->attr);
     g_free (data->segtype);
+    g_free (data->origin);
+    g_free (data->pool_lv);
+    g_free (data->data_lv);
+    g_free (data->metadata_lv);
     g_free (data);
 }
 
@@ -783,12 +791,12 @@ static gchar get_lv_attr_bool (GVariantDict *props, const gchar *prop, gchar let
         return '-';
 }
 
-static BDLVMLVdata* get_lv_data_from_props (GVariant *props, GError **error __attribute__((unused))) {
+static BDLVMLVdata* get_lv_data_from_props (GVariant *props, GError **error) {
     BDLVMLVdata *data = g_new0 (BDLVMLVdata, 1);
     GVariantDict dict;
     GVariant *value = NULL;
-    gchar *vg_path = NULL;
-    GVariant *vg_name = NULL;
+    gchar *path = NULL;
+    GVariant *name = NULL;
 
     g_variant_dict_init (&dict, props);
 
@@ -822,13 +830,29 @@ static BDLVMLVdata* get_lv_data_from_props (GVariant *props, GError **error __at
     }
 
     /* returns an object path for the VG */
-    g_variant_dict_lookup (&dict, "Vg", "o", &vg_path);
+    g_variant_dict_lookup (&dict, "Vg", "o", &path);
+    name = get_object_property (path, VG_INTF, "Name", error);
+    g_free (path);
+    g_variant_get (name, "s", &(data->vg_name));
+    g_variant_unref (name);
 
-    vg_name = get_object_property (vg_path, VG_INTF, "Name", error);
-    g_variant_get (vg_name, "s", &(data->vg_name));
+    g_variant_dict_lookup (&dict, "OriginLv", "o", &path);
+    if (g_strcmp0 (path, "/") != 0) {
+        name = get_object_property (path, LV_CMN_INTF, "Name", error);
+        g_variant_get (name, "s", &(data->origin));
+        g_variant_unref (name);
+    }
+    g_free (path);
+
+    g_variant_dict_lookup (&dict, "PoolLv", "o", &path);
+    if (g_strcmp0 (path, "/") != 0) {
+        name = get_object_property (path, LV_CMN_INTF, "Name", error);
+        g_variant_get (name, "s", &(data->pool_lv));
+        g_variant_unref (name);
+    }
+    g_free (path);
 
     g_variant_dict_clear (&dict);
-    g_variant_unref (vg_name);
     g_variant_unref (props);
 
     return data;
@@ -1820,13 +1844,21 @@ gboolean bd_lvm_lvsnapshotmerge (const gchar *vg_name, const gchar *snapshot_nam
  */
 BDLVMLVdata* bd_lvm_lvinfo (const gchar *vg_name, const gchar *lv_name, GError **error) {
     GVariant *props = NULL;
+    BDLVMLVdata* ret = NULL;
 
     props = get_lv_properties (vg_name, lv_name, error);
     if (!props)
         /* the error is already populated */
         return NULL;
 
-    return get_lv_data_from_props (props, error);
+    ret = get_lv_data_from_props (props, error);
+    if (ret && ((g_strcmp0 (ret->segtype, "thin-pool") == 0) ||
+                (g_strcmp0 (ret->segtype, "cache-pool") == 0))) {
+        ret->data_lv = bd_lvm_data_lv_name (vg_name, lv_name, error);
+        ret->metadata_lv = bd_lvm_metadata_lv_name (vg_name, lv_name, error);
+    }
+
+    return ret;
 }
 
 static gchar* get_lv_vg_name (const gchar *lv_obj_path, GError **error) {
@@ -1961,6 +1993,14 @@ BDLVMLVdata** bd_lvm_lvs (const gchar *vg_name, GError **error) {
         }
         ret[j] = get_lv_data_from_props (props, error);
         if (!(ret[j])) {
+            g_slist_free (matched_lvs);
+            return NULL;
+        } else if ((g_strcmp0 (ret[j]->segtype, "thin-pool") == 0) ||
+                   (g_strcmp0 (ret[j]->segtype, "cache-pool") == 0)) {
+            ret[j]->data_lv = bd_lvm_data_lv_name (ret[j]->vg_name, ret[j]->lv_name, error);
+            ret[j]->metadata_lv = bd_lvm_metadata_lv_name (ret[j]->vg_name, ret[j]->lv_name, error);
+        }
+        if (error && *error) {
             g_slist_free (matched_lvs);
             return NULL;
         }

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -105,6 +105,10 @@ BDLVMLVdata* bd_lvm_lvdata_copy (BDLVMLVdata *data) {
     new_data->size = data->size;
     new_data->attr = g_strdup (data->attr);
     new_data->segtype = g_strdup (data->segtype);
+    new_data->origin = g_strdup (data->origin);
+    new_data->pool_lv = g_strdup (data->pool_lv);
+    new_data->data_lv = g_strdup (data->data_lv);
+    new_data->metadata_lv = g_strdup (data->metadata_lv);
     return new_data;
 }
 
@@ -114,6 +118,10 @@ void bd_lvm_lvdata_free (BDLVMLVdata *data) {
     g_free (data->uuid);
     g_free (data->attr);
     g_free (data->segtype);
+    g_free (data->origin);
+    g_free (data->pool_lv);
+    g_free (data->data_lv);
+    g_free (data->metadata_lv);
     g_free (data);
 }
 
@@ -372,6 +380,16 @@ static BDLVMLVdata* get_lv_data_from_table (GHashTable *table, gboolean free_tab
 
     data->attr = g_strdup (g_hash_table_lookup (table, "LVM2_LV_ATTR"));
     data->segtype = g_strdup (g_hash_table_lookup (table, "LVM2_SEGTYPE"));
+    data->origin = g_strdup (g_hash_table_lookup (table, "LVM2_ORIGIN"));
+    data->pool_lv = g_strdup (g_hash_table_lookup (table, "LVM2_POOL_LV"));
+    data->data_lv = g_strdup (g_hash_table_lookup (table, "LVM2_DATA_LV"));
+    data->metadata_lv = g_strdup (g_hash_table_lookup (table, "LVM2_METADATA_LV"));
+
+    /* replace '[' and ']' (marking LVs as internal) with spaces and then
+       remove all the leading and trailing whitespace */
+    g_strstrip (g_strdelimit (data->pool_lv, "[]", ' '));
+    g_strstrip (g_strdelimit (data->data_lv, "[]", ' '));
+    g_strstrip (g_strdelimit (data->metadata_lv, "[]", ' '));
 
     if (free_table)
         g_hash_table_destroy (table);
@@ -1296,7 +1314,7 @@ gboolean bd_lvm_lvsnapshotmerge (const gchar *vg_name, const gchar *snapshot_nam
 BDLVMLVdata* bd_lvm_lvinfo (const gchar *vg_name, const gchar *lv_name, GError **error) {
     const gchar *args[11] = {"lvs", "--noheadings", "--nosuffix", "--nameprefixes",
                        "--unquoted", "--units=b", "-a",
-                       "-o", "vg_name,lv_name,lv_uuid,lv_size,lv_attr,segtype",
+                       "-o", "vg_name,lv_name,lv_uuid,lv_size,lv_attr,segtype,origin,pool_lv,data_lv,metadata_lv",
                        NULL, NULL};
 
     GHashTable *table = NULL;
@@ -1320,7 +1338,7 @@ BDLVMLVdata* bd_lvm_lvinfo (const gchar *vg_name, const gchar *lv_name, GError *
 
     for (lines_p = lines; *lines_p; lines_p++) {
         table = parse_lvm_vars ((*lines_p), &num_items);
-        if (table && (num_items == 6)) {
+        if (table && (num_items == 10)) {
             g_strfreev (lines);
             return get_lv_data_from_table (table, TRUE);
         } else
@@ -1345,7 +1363,7 @@ BDLVMLVdata* bd_lvm_lvinfo (const gchar *vg_name, const gchar *lv_name, GError *
 BDLVMLVdata** bd_lvm_lvs (const gchar *vg_name, GError **error) {
     const gchar *args[11] = {"lvs", "--noheadings", "--nosuffix", "--nameprefixes",
                        "--unquoted", "--units=b", "-a",
-                       "-o", "vg_name,lv_name,lv_uuid,lv_size,lv_attr,segtype",
+                       "-o", "vg_name,lv_name,lv_uuid,lv_size,lv_attr,segtype,origin,pool_lv,data_lv,metadata_lv",
                        NULL, NULL};
 
     GHashTable *table = NULL;
@@ -1382,7 +1400,7 @@ BDLVMLVdata** bd_lvm_lvs (const gchar *vg_name, GError **error) {
 
     for (lines_p = lines; *lines_p; lines_p++) {
         table = parse_lvm_vars ((*lines_p), &num_items);
-        if (table && (num_items == 6)) {
+        if (table && (num_items == 10)) {
             /* valid line, try to parse and record it */
             lvdata = get_lv_data_from_table (table, TRUE);
             if (lvdata)

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -139,18 +139,6 @@ void bd_lvm_cache_stats_free (BDLVMCacheStats *data) {
     g_free (data);
 }
 
-static gchar const * const supported_functions[] = {
-    "bd_lvm_is_supported_pe_size",
-    "bd_lvm_get_max_lv_size",
-    "bd_lvm_round_size_to_pe",
-    "bd_lvm_get_lv_physical_size",
-    "bd_lvm_get_thpool_padding",
-    NULL};
-
-gchar const * const * get_supported_functions () {
-    return supported_functions;
-}
-
 /**
  * check: (skip)
  */

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -102,6 +102,10 @@ typedef struct BDLVMLVdata {
     guint64 size;
     gchar *attr;
     gchar *segtype;
+    gchar *origin;
+    gchar *pool_lv;
+    gchar *data_lv;
+    gchar *metadata_lv;
 } BDLVMLVdata;
 
 void bd_lvm_lvdata_free (BDLVMLVdata *data);

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -829,7 +829,9 @@ class LvmTestLVsnapshots(LvmPVVGLVTestCase):
         self.assertTrue(succ)
 
         origin_name = BlockDev.lvm_lvorigin("testVG", "testLV_bak")
+        lvi = BlockDev.lvm_lvinfo("testVG", "testLV_bak")
         self.assertEqual(origin_name, "testLV")
+        self.assertEqual(lvi.origin, "testLV")
 
         succ = BlockDev.lvm_lvsnapshotmerge("testVG", "testLV_bak", None)
         self.assertTrue(succ)
@@ -956,17 +958,21 @@ class LvmTestDataMetadataLV(LvmPVVGthpoolTestCase):
         self.assertTrue(succ)
 
         name = BlockDev.lvm_data_lv_name("testVG", "testPool")
+        lvi = BlockDev.lvm_lvinfo("testVG", "testPool")
         self.assertTrue(name)
         self.assertTrue(name.startswith("testPool"))
         self.assertIn("_tdata", name)
+        self.assertEqual(name, lvi.data_lv)
 
         info = BlockDev.lvm_lvinfo("testVG", name)
         self.assertTrue(info.attr.startswith("T"))
 
         name = BlockDev.lvm_metadata_lv_name("testVG", "testPool")
+        lvi = BlockDev.lvm_lvinfo("testVG", "testPool")
         self.assertTrue(name)
         self.assertTrue(name.startswith("testPool"))
         self.assertIn("_tmeta", name)
+        self.assertEqual(name, lvi.metadata_lv)
 
         info = BlockDev.lvm_lvinfo("testVG", name)
         self.assertTrue(info.attr.startswith("e"))
@@ -1008,7 +1014,9 @@ class LvmTestThLVcreate(LvmPVVGLVthLVTestCase):
         self.assertIn("V", info.attr)
 
         pool = BlockDev.lvm_thlvpoolname("testVG", "testThLV")
+        lvi = BlockDev.lvm_lvinfo("testVG", "testThLV")
         self.assertEqual(pool, "testPool")
+        self.assertEqual(lvi.pool_lv, "testPool")
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmPVVGLVthLVsnapshotTestCase(LvmPVVGLVthLVTestCase):

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -795,7 +795,9 @@ class LvmTestLVsnapshots(LvmPVVGLVTestCase):
         self.assertTrue(succ)
 
         origin_name = BlockDev.lvm_lvorigin("testVG", "testLV_bak")
+        lvi = BlockDev.lvm_lvinfo("testVG", "testLV_bak")
         self.assertEqual(origin_name, "testLV")
+        self.assertEqual(lvi.origin, "testLV")
 
         succ = BlockDev.lvm_lvsnapshotmerge("testVG", "testLV_bak", None)
         self.assertTrue(succ)
@@ -913,17 +915,21 @@ class LvmTestDataMetadataLV(LvmPVVGthpoolTestCase):
         self.assertTrue(succ)
 
         name = BlockDev.lvm_data_lv_name("testVG", "testPool")
+        lvi = BlockDev.lvm_lvinfo("testVG", "testPool")
         self.assertTrue(name)
         self.assertTrue(name.startswith("testPool"))
         self.assertIn("_tdata", name)
+        self.assertEqual(name, lvi.data_lv)
 
         info = BlockDev.lvm_lvinfo("testVG", name)
         self.assertTrue(info.attr.startswith("T"))
 
         name = BlockDev.lvm_metadata_lv_name("testVG", "testPool")
+        lvi = BlockDev.lvm_lvinfo("testVG", "testPool")
         self.assertTrue(name)
         self.assertTrue(name.startswith("testPool"))
         self.assertIn("_tmeta", name)
+        self.assertEqual(name, lvi.metadata_lv)
 
         info = BlockDev.lvm_lvinfo("testVG", name)
         self.assertTrue(info.attr.startswith("e"))
@@ -960,7 +966,9 @@ class LvmTestThLVcreate(LvmPVVGLVthLVTestCase):
         self.assertIn("V", info.attr)
 
         pool = BlockDev.lvm_thlvpoolname("testVG", "testThLV")
+        lvi = BlockDev.lvm_lvinfo("testVG", "testThLV")
         self.assertEqual(pool, "testPool")
+        self.assertEqual(lvi.pool_lv, "testPool")
 
 class LvmPVVGLVthLVsnapshotTestCase(LvmPVVGLVthLVTestCase):
     def _clean_up(self):


### PR DESCRIPTION
The second commit adds some extra information to the ``LVMLVdata`` structure returned by the ``lvinfo()`` and ``lvs()`` functions. The existing tests should pass, but some more should probably be added which I'll do later before I push this.