### PR TITLE
Report (meta)data LV name properly for cache pools in lvm-dbus

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -2645,6 +2645,8 @@ gchar* bd_lvm_data_lv_name (const gchar *vg_name, const gchar *lv_name, GError *
         return NULL;
 
     prop = get_object_property (obj_path, THPOOL_INTF, "DataLv", error);
+    if (!prop)
+        prop = get_object_property (obj_path, CACHE_POOL_INTF, "DataLv", error);
     g_free (obj_path);
     if (!prop) {
         g_clear_error (error);
@@ -2692,6 +2694,8 @@ gchar* bd_lvm_metadata_lv_name (const gchar *vg_name, const gchar *lv_name, GErr
         return NULL;
 
     prop = get_object_property (obj_path, THPOOL_INTF, "MetaDataLv", error);
+    if (!prop)
+        prop = get_object_property (obj_path, CACHE_POOL_INTF, "MetaDataLv", error);
     g_free (obj_path);
     if (!prop) {
         g_clear_error (error);


### PR DESCRIPTION
We need to use a different interface for cache pools. Let's just try both.