### PR TITLE
Add functions for creating thin/cache pools from existing LVs

### DIFF
--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -990,4 +990,40 @@ gchar* bd_lvm_data_lv_name (const gchar *vg_name, const gchar *lv_name, GError *
  */
 gchar* bd_lvm_metadata_lv_name (const gchar *vg_name, const gchar *lv_name, GError **error);
 
+/**
+ * bd_lvm_thpool_convert:
+ * @vg_name: name of the VG to create the new thin pool in
+ * @data_lv: name of the LV that should become the data part of the new pool
+ * @metadata_lv: name of the LV that should become the metadata part of the new pool
+ * @name: (allow-none): name for the thin pool (if %NULL, the name @data_lv is inherited)
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the thin pool creation
+ *                                                 (just passed to LVM as is)
+ * @error: (out): place to store error (if any)
+ *
+ * Converts the @data_lv and @metadata_lv into a new thin pool in the @vg_name
+ * VG.
+ *
+ * Returns: whether the new thin pool was successfully created from @data_lv and
+ *          @metadata_lv or not
+ */
+gboolean bd_lvm_thpool_convert (const gchar *vg_name, const gchar *data_lv, const gchar *metadata_lv, const gchar *name, const BDExtraArg **extra, GError **error);
+
+/**
+ * bd_lvm_cache_pool_convert:
+ * @vg_name: name of the VG to create the new thin pool in
+ * @data_lv: name of the LV that should become the data part of the new pool
+ * @metadata_lv: name of the LV that should become the metadata part of the new pool
+ * @name: (allow-none): name for the thin pool (if %NULL, the name @data_lv is inherited)
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the thin pool creation
+ *                                                 (just passed to LVM as is)
+ * @error: (out): place to store error (if any)
+ *
+ * Converts the @data_lv and @metadata_lv into a new cache pool in the @vg_name
+ * VG.
+ *
+ * Returns: whether the new cache pool was successfully created from @data_lv and
+ *          @metadata_lv or not
+ */
+gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, const gchar *metadata_lv, const gchar *name, const BDExtraArg **extra, GError **error);
+
 #endif  /* BD_LVM_API */

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -2068,3 +2068,66 @@ gchar* bd_lvm_metadata_lv_name (const gchar *vg_name, const gchar *lv_name, GErr
        remove all the leading and trailing whitespace */
     return g_strstrip (g_strdelimit (output, "[]", ' '));
 }
+
+
+/**
+ * bd_lvm_thpool_convert:
+ * @vg_name: name of the VG to create the new thin pool in
+ * @data_lv: name of the LV that should become the data part of the new pool
+ * @metadata_lv: name of the LV that should become the metadata part of the new pool
+ * @name: (allow-none): name for the thin pool (if %NULL, the name @data_lv is inherited)
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the thin pool creation
+ *                                                 (just passed to LVM as is)
+ * @error: (out): place to store error (if any)
+ *
+ * Converts the @data_lv and @metadata_lv into a new thin pool in the @vg_name
+ * VG.
+ *
+ * Returns: whether the new thin pool was successfully created from @data_lv and
+ *          @metadata_lv or not
+ */
+gboolean bd_lvm_thpool_convert (const gchar *vg_name, const gchar *data_lv, const gchar *metadata_lv, const gchar *name, const BDExtraArg **extra, GError **error) {
+    const gchar *args[8] = {"lvconvert", "--yes", "--type", "thin-pool", "--poolmetadata", metadata_lv, NULL, NULL};
+    gboolean success = FALSE;
+
+    args[6] = g_strdup_printf ("%s/%s", vg_name, data_lv);
+
+    success = call_lvm_and_report_error (args, extra, error);
+    g_free ((gchar *) args[6]);
+
+    if (success && name)
+        success = bd_lvm_lvrename (vg_name, data_lv, name, NULL, error);
+
+    return success;
+}
+
+/**
+ * bd_lvm_cache_pool_convert:
+ * @vg_name: name of the VG to create the new thin pool in
+ * @data_lv: name of the LV that should become the data part of the new pool
+ * @metadata_lv: name of the LV that should become the metadata part of the new pool
+ * @name: (allow-none): name for the thin pool (if %NULL, the name @data_lv is inherited)
+ * @extra: (allow-none) (array zero-terminated=1): extra options for the thin pool creation
+ *                                                 (just passed to LVM as is)
+ * @error: (out): place to store error (if any)
+ *
+ * Converts the @data_lv and @metadata_lv into a new cache pool in the @vg_name
+ * VG.
+ *
+ * Returns: whether the new cache pool was successfully created from @data_lv and
+ *          @metadata_lv or not
+ */
+gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, const gchar *metadata_lv, const gchar *name, const BDExtraArg **extra, GError **error) {
+    const gchar *args[8] = {"lvconvert", "--yes", "--type", "cache-pool", "--poolmetadata", metadata_lv, NULL, NULL};
+    gboolean success = FALSE;
+
+    args[6] = g_strdup_printf ("%s/%s", vg_name, data_lv);
+
+    success = call_lvm_and_report_error (args, extra, error);
+    g_free ((gchar *) args[6]);
+
+    if (success && name)
+        success = bd_lvm_lvrename (vg_name, data_lv, name, NULL, error);
+
+    return success;
+}

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -189,4 +189,7 @@ BDLVMCacheStats* bd_lvm_cache_stats (const gchar *vg_name, const gchar *cached_l
 gchar* bd_lvm_data_lv_name (const gchar *vg_name, const gchar *lv_name, GError **error);
 gchar* bd_lvm_metadata_lv_name (const gchar *vg_name, const gchar *lv_name, GError **error);
 
+gboolean bd_lvm_thpool_convert (const gchar *vg_name, const gchar *data_lv, const gchar *metadata_lv, const gchar *name, const BDExtraArg **extra, GError **error);
+gboolean bd_lvm_cache_pool_convert (const gchar *vg_name, const gchar *data_lv, const gchar *metadata_lv, const gchar *name, const BDExtraArg **extra, GError **error);
+
 #endif /* BD_LVM */

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -493,6 +493,20 @@ def lvm_set_global_config(new_config=None):
     return _lvm_set_global_config(new_config)
 __all__.append("lvm_set_global_config")
 
+_lvm_thpool_convert = BlockDev.lvm_thpool_convert
+@override(BlockDev.lvm_thpool_convert)
+def lvm_thpool_convert(vg_name, data_lv, metadata_lv, name=None, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _lvm_thpool_convert(vg_name, data_lv, metadata_lv, name, extra)
+__all__.append("lvm_thpool_convert")
+
+_lvm_cache_pool_convert = BlockDev.lvm_cache_pool_convert
+@override(BlockDev.lvm_cache_pool_convert)
+def lvm_cache_pool_convert(vg_name, data_lv, metadata_lv, name=None, extra=None, **kwargs):
+    extra = _get_extra(extra, kwargs)
+    return _lvm_cache_pool_convert(vg_name, data_lv, metadata_lv, name, extra)
+__all__.append("lvm_cache_pool_convert")
+
 
 _md_get_superblock_size = BlockDev.md_get_superblock_size
 @override(BlockDev.md_get_superblock_size)

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -944,6 +944,33 @@ class LvmTestThpoolCreate(LvmPVVGthpoolTestCase):
         self.assertIn("private", info.roles.split(","))
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
+class LvmTestThpoolConvert(LvmPVVGthpoolTestCase):
+    def test_thpool_convert(self):
+        """Verify that it is possible to create a thin pool by conversion"""
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev2, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_vgcreate("testVG", [self.loop_dev, self.loop_dev2], 0, None)
+        self.assertTrue(succ)
+
+        # the name of the data LV is used for the pool
+        succ = BlockDev.lvm_lvcreate("testVG", "dataLV", 512 * 1024**2, None, [self.loop_dev], None)
+        self.assertTrue(succ)
+        succ = BlockDev.lvm_lvcreate("testVG", "metadataLV", 50 * 1024**2, None, [self.loop_dev2], None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_thpool_convert("testVG", "dataLV", "metadataLV", "testPool", None)
+        self.assertTrue(succ)
+
+        info = BlockDev.lvm_lvinfo("testVG", "testPool")
+        self.assertIn("t", info.attr)
+
+
+@unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
 class LvmTestDataMetadataLV(LvmPVVGthpoolTestCase):
     def test_data_metadata_lv_name(self):
         """Verify that it is possible to get name of the data/metadata LV"""
@@ -1103,6 +1130,28 @@ class LvmPVVGLVcachePoolCreateRemoveTestCase(LvmPVVGLVcachePoolTestCase):
         succ = BlockDev.lvm_cache_create_pool("testVG", "testCache", 512 * 1024**2, 0, BlockDev.LVMCacheMode.WRITEBACK,
                                               BlockDev.LVMCachePoolFlags.STRIPED|BlockDev.LVMCachePoolFlags.META_RAID1,
                                               [self.loop_dev, self.loop_dev2])
+        self.assertTrue(succ)
+
+@unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")
+class LvmTestCachePoolConvert(LvmPVVGLVcachePoolTestCase):
+    def test_cache_pool_convert(self):
+        """Verify that it is possible to create a cache pool by conversion"""
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev2, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_vgcreate("testVG", [self.loop_dev, self.loop_dev2], 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_lvcreate("testVG", "dataLV", 512 * 1024**2, None, [self.loop_dev], None)
+        self.assertTrue(succ)
+        succ = BlockDev.lvm_lvcreate("testVG", "metadataLV", 50 * 1024**2, None, [self.loop_dev2], None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_cache_pool_convert("testVG", "dataLV", "metadataLV", "testCache", None)
         self.assertTrue(succ)
 
 @unittest.skipUnless(lvm_dbus_running, "LVM DBus not running")

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -901,6 +901,33 @@ class LvmTestThpoolCreate(LvmPVVGthpoolTestCase):
         self.assertIn("t", info.attr)
         self.assertIn("private", info.roles.split(","))
 
+
+class LvmTestThpoolConvert(LvmPVVGthpoolTestCase):
+    def test_thpool_convert(self):
+        """Verify that it is possible to create a thin pool by conversion"""
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev2, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_vgcreate("testVG", [self.loop_dev, self.loop_dev2], 0, None)
+        self.assertTrue(succ)
+
+        # the name of the data LV is used for the pool
+        succ = BlockDev.lvm_lvcreate("testVG", "dataLV", 512 * 1024**2, None, [self.loop_dev], None)
+        self.assertTrue(succ)
+        succ = BlockDev.lvm_lvcreate("testVG", "metadataLV", 50 * 1024**2, None, [self.loop_dev2], None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_thpool_convert("testVG", "dataLV", "metadataLV", "testPool", None)
+        self.assertTrue(succ)
+
+        info = BlockDev.lvm_lvinfo("testVG", "testPool")
+        self.assertIn("t", info.attr)
+
+
 class LvmTestDataMetadataLV(LvmPVVGthpoolTestCase):
     def test_data_metadata_lv_name(self):
         """Verify that it is possible to get name of the data/metadata LV"""
@@ -1046,6 +1073,28 @@ class LvmPVVGLVcachePoolCreateRemoveTestCase(LvmPVVGLVcachePoolTestCase):
                                               BlockDev.LVMCachePoolFlags.STRIPED|BlockDev.LVMCachePoolFlags.META_RAID1,
                                               [self.loop_dev, self.loop_dev2])
         self.assertTrue(succ)
+
+class LvmTestCachePoolConvert(LvmPVVGLVcachePoolTestCase):
+    def test_cache_pool_convert(self):
+        """Verify that it is possible to create a cache pool by conversion"""
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_pvcreate(self.loop_dev2, 0, 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_vgcreate("testVG", [self.loop_dev, self.loop_dev2], 0, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_lvcreate("testVG", "dataLV", 512 * 1024**2, None, [self.loop_dev], None)
+        self.assertTrue(succ)
+        succ = BlockDev.lvm_lvcreate("testVG", "metadataLV", 50 * 1024**2, None, [self.loop_dev2], None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.lvm_cache_pool_convert("testVG", "dataLV", "metadataLV", "testCache", None)
+        self.assertTrue(succ)
+
 
 class LvmPVVGLVcachePoolAttachDetachTestCase(LvmPVVGLVcachePoolTestCase):
     def test_cache_pool_attach_detach(self):


### PR DESCRIPTION
These allow for a multi-step creation of thin/cache pools with much better
control of their data/metadata parts' features.