### PR TITLE
Correct underlinking of shared libraries

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -5,7 +5,7 @@ SUBDIRS = plugin_apis
 lib_LTLIBRARIES = libblockdev.la
 libblockdev_la_CFLAGS = $(GLIB_CFLAGS)
 libblockdev_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la
-libblockdev_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 4:1:4
+libblockdev_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 4:1:4 -Wl,--no-undefined
 libblockdev_la_CPPFLAGS = -I${srcdir}/../utils/
 libblockdev_la_SOURCES = blockdev.c blockdev.h plugins.c plugins.h
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -4,7 +4,7 @@ SUBDIRS = plugin_apis
 
 lib_LTLIBRARIES = libblockdev.la
 libblockdev_la_CFLAGS = $(GLIB_CFLAGS)
-libblockdev_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la
+libblockdev_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la -ldl
 libblockdev_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 4:1:4 -Wl,--no-undefined
 libblockdev_la_CPPFLAGS = -I${srcdir}/../utils/
 libblockdev_la_SOURCES = blockdev.c blockdev.h plugins.c plugins.h

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -12,7 +12,7 @@ libbd_btrfs_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_btrfs_la_SOURCES = btrfs.c btrfs.h
 
 libbd_crypto_la_CFLAGS = $(GLIB_CFLAGS) $(CRYPTSETUP_CFLAGS) $(NSS_CFLAGS) -Wall -Wextra -Werror
-libbd_crypto_la_LIBADD = $(GLIB_LIBS) $(CRYTPSETUP_LIBS) $(NSS_LIBS) -lvolume_key ${builddir}/../utils/libbd_utils.la
+libbd_crypto_la_LIBADD = $(GLIB_LIBS) $(CRYPTSETUP_LIBS) $(NSS_LIBS) -lvolume_key ${builddir}/../utils/libbd_utils.la
 libbd_crypto_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
 libbd_crypto_la_CPPFLAGS = -I${srcdir}/../utils/ -I/usr/include/volume_key
 libbd_crypto_la_SOURCES = crypto.c crypto.h

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -7,82 +7,82 @@ endif
 
 libbd_btrfs_la_CFLAGS = $(GLIB_CFLAGS) $(BYTESIZE_CFLAGS) -Wall -Wextra -Werror
 libbd_btrfs_la_LIBADD = $(GLIB_LIBS) $(BYTESIZE_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_btrfs_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0
+libbd_btrfs_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
 libbd_btrfs_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_btrfs_la_SOURCES = btrfs.c btrfs.h
 
 libbd_crypto_la_CFLAGS = $(GLIB_CFLAGS) $(CRYPTSETUP_CFLAGS) $(NSS_CFLAGS) -Wall -Wextra -Werror
 libbd_crypto_la_LIBADD = $(GLIB_LIBS) $(CRYTPSETUP_LIBS) $(NSS_LIBS) -lvolume_key ${builddir}/../utils/libbd_utils.la
-libbd_crypto_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0
+libbd_crypto_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
 libbd_crypto_la_CPPFLAGS = -I${srcdir}/../utils/ -I/usr/include/volume_key
 libbd_crypto_la_SOURCES = crypto.c crypto.h
 
 libbd_dm_la_CFLAGS = $(GLIB_CFLAGS) $(DEVMAPPER_CFLAGS) $(UDEV_CFLAGS) -Wall -Wextra -Werror
 libbd_dm_la_LIBADD = $(GLIB_LIBS) $(DEVMAPPER_LIBS) $(UDEV_LIBS) -ldmraid ${builddir}/../utils/libbd_utils.la
-libbd_dm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0
+libbd_dm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
 # Dear author of libdmdraid, VERSION really is not a good name for an enum member!
 libbd_dm_la_CPPFLAGS = -I${srcdir}/../utils/ -UVERSION
 libbd_dm_la_SOURCES = dm.c dm.h
 
 libbd_loop_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
 libbd_loop_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_loop_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0
+libbd_loop_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
 libbd_loop_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_loop_la_SOURCES = loop.c loop.h
 
 libbd_lvm_la_CFLAGS = $(GLIB_CFLAGS) $(DEVMAPPER_CFLAGS) -Wall -Wextra -Werror
 libbd_lvm_la_LIBADD = $(GLIB_LIBS) $(DEVMAPPER_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_lvm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 4:1:4
+libbd_lvm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 4:1:4 -Wl,--no-undefined
 libbd_lvm_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_lvm_la_SOURCES = lvm.c lvm.h
 
 libbd_lvm_dbus_la_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(DEVMAPPER_CFLAGS) -Wall -Wextra -Werror
 libbd_lvm_dbus_la_LIBADD = $(GLIB_LIBS) $(GIO_LIBS) $(DEVMAPPER_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_lvm_dbus_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1
+libbd_lvm_dbus_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1 -Wl,--no-undefined
 libbd_lvm_dbus_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_lvm_dbus_la_SOURCES = lvm-dbus.c lvm.h
 
 libbd_mdraid_la_CFLAGS = $(GLIB_CFLAGS) $(BYTESIZE_CFLAGS) -Wall -Wextra -Werror
 libbd_mdraid_la_LIBADD = $(GLIB_LIBS) $(BYTESIZE_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_mdraid_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1
+libbd_mdraid_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1 -Wl,--no-undefined
 libbd_mdraid_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_mdraid_la_SOURCES = mdraid.c mdraid.h
 
 libbd_mpath_la_CFLAGS = $(GLIB_CFLAGS) $(DEVMAPPER_CFLAGS) -Wall -Wextra -Werror
 libbd_mpath_la_LIBADD = $(GLIB_LIBS) $(DEVMAPPER_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_mpath_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1
+libbd_mpath_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1 -Wl,--no-undefined
 libbd_mpath_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_mpath_la_SOURCES = mpath.c mpath.h
 
 libbd_swap_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
 libbd_swap_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_swap_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0
+libbd_swap_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
 libbd_swap_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_swap_la_SOURCES = swap.c swap.h
 
 libbd_kbd_la_CFLAGS = $(GLIB_CFLAGS) $(KMOD_CFLAGS) -Wall -Wextra -Werror
 libbd_kbd_la_LIBADD = $(GLIB_LIBS) $(KMOD_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_kbd_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0
+libbd_kbd_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
 libbd_kbd_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_kbd_la_SOURCES = kbd.c kbd.h
 
 if ON_S390
 libbd_s390_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
 libbd_s390_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_s390_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0
+libbd_s390_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
 libbd_s390_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_s390_la_SOURCES = s390.c s390.h
 endif
 
 libbd_part_la_CFLAGS = $(GLIB_CFLAGS) $(PARTED_CFLAGS) -Wall -Wextra -Werror
 libbd_part_la_LIBADD = $(GLIB_LIBS) $(PARTED_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_part_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1
+libbd_part_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1 -Wl,--no-undefined
 libbd_part_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_part_la_SOURCES = part.c part.h
 
 libbd_fs_la_CFLAGS = $(GLIB_CFLAGS) $(BLKID_CFLAGS) -Wall -Wextra -Werror
 libbd_fs_la_LIBADD = $(GLIB_LIBS) $(BLKID_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_fs_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0
+libbd_fs_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
 libbd_fs_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_fs_la_SOURCES = fs.c fs.h
 

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -1,6 +1,6 @@
 lib_LTLIBRARIES = libbd_utils.la
 libbd_utils_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
-libbd_utils_la_LDFLAGS = -version-info 4:1:2
+libbd_utils_la_LDFLAGS = -version-info 4:1:2 -Wl,--no-undefined
 libbd_utils_la_LIBADD = $(GLIB_LIBS)
 libbd_utils_la_SOURCES = utils.h exec.c exec.h sizes.h extra_arg.c extra_arg.h
 

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libbd_utils.la
 libbd_utils_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
 libbd_utils_la_LDFLAGS = -version-info 4:1:2 -Wl,--no-undefined
-libbd_utils_la_LIBADD = $(GLIB_LIBS)
+libbd_utils_la_LIBADD = $(GLIB_LIBS) -lm $(GIO_LIBS)
 libbd_utils_la_SOURCES = utils.h exec.c exec.h sizes.h extra_arg.c extra_arg.h
 
 libincludedir = $(includedir)/blockdev


### PR DESCRIPTION
When playing around with the library I discovered that I needed to link in libraries which were needed by libblockdev libraries themselves and not my application.  This __underlinking__ is more than just an inconvenience, it creates direct dependencies to libraries that the end application doesn't directly use.  Thus when a new dependent library is released, the end binaries need to be recompiled too, when only the underlying library needed to be re-compiled.

```
gcc -Wall main.c `pkg-config blockdev --cflags --libs`
/usr/lib/gcc/x86_64-redhat-linux/6.1.1/../../../../lib64/libblockdev.so: undefined reference to `dlopen'
/usr/lib/gcc/x86_64-redhat-linux/6.1.1/../../../../lib64/libblockdev.so: undefined reference to `dlclose'
/usr/lib/gcc/x86_64-redhat-linux/6.1.1/../../../../lib64/libblockdev.so: undefined reference to `dlerror'
/usr/lib/gcc/x86_64-redhat-linux/6.1.1/../../../../lib64/libblockdev.so: undefined reference to `dlsym'
/usr/lib64/libbd_utils.so.0: undefined reference to `pow'
/usr/lib/gcc/x86_64-redhat-linux/6.1.1/../../../../lib64/libblockdev.so: undefined reference to `g_boxed_type_register_static'
collect2: error: ld returned 1 exit status
```