### PR TITLE
Public check/init/close functions

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -413,12 +413,21 @@ bd_fs_xfs_check
 bd_fs_xfs_get_info
 bd_fs_xfs_info_copy
 bd_fs_xfs_info_free
-bd_fs_xfs_info_get_type
 bd_fs_xfs_mkfs
 bd_fs_xfs_repair
 bd_fs_xfs_resize
 bd_fs_xfs_set_label
 bd_fs_xfs_wipe
+BDFSVfatInfo
+bd_fs_vfat_check
+bd_fs_vfat_get_info
+bd_fs_vfat_info_copy
+bd_fs_vfat_info_free
+bd_fs_vfat_mkfs
+bd_fs_vfat_repair
+bd_fs_vfat_resize
+bd_fs_vfat_set_label
+bd_fs_vfat_wipe
 </SECTION>
 
 <SECTION>

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -13,6 +13,9 @@ bd_init_error_quark
 
 <SECTION>
 <FILE>btrfs</FILE>
+bd_btrfs_check_deps
+bd_btrfs_init
+bd_btrfs_close
 BD_BTRFS_MAIN_VOLUME_ID
 BD_BTRFS_MIN_MEMBER_SIZE
 bd_btrfs_error_quark
@@ -47,6 +50,9 @@ bd_btrfs_change_label
 
 <SECTION>
 <FILE>crypto</FILE>
+bd_crypto_check_deps
+bd_crypto_close
+bd_crypto_init
 BD_CRYPTO_LUKS_METADATA_SIZE
 bd_crypto_error_quark
 BD_CRYPTO_ERROR
@@ -71,6 +77,9 @@ bd_crypto_escrow_device
 
 <SECTION>
 <FILE>dm</FILE>
+bd_dm_check_deps
+bd_dm_close
+bd_dm_init
 bd_dm_error_quark
 BD_DM_ERROR
 BDDMError
@@ -128,6 +137,9 @@ TiB
 
 <SECTION>
 <FILE>loop</FILE>
+bd_loop_check_deps
+bd_loop_init
+bd_loop_close
 bd_loop_error_quark
 BD_LOOP_ERROR
 BDLoopError
@@ -139,6 +151,9 @@ bd_loop_teardown
 
 <SECTION>
 <FILE>lvm</FILE>
+bd_lvm_check_deps
+bd_lvm_close
+bd_lvm_init
 BD_LVM_MAX_LV_SIZE
 BD_LVM_DEFAULT_PE_SIZE
 BD_LVM_DEFAULT_PE_START
@@ -228,6 +243,9 @@ bd_lvm_metadata_lv_name
 
 <SECTION>
 <FILE>mdraid</FILE>
+bd_md_check_deps
+bd_md_init
+bd_md_close
 BD_MD_SUPERBLOCK_SIZE
 BD_MD_CHUNK_SIZE
 bd_md_error_quark
@@ -260,6 +278,9 @@ bd_md_name_from_node
 
 <SECTION>
 <FILE>mpath</FILE>
+bd_mpath_check_deps
+bd_mpath_init
+bd_mpath_close
 bd_mpath_error_quark
 BD_MPATH_ERROR
 BDMpathError
@@ -285,6 +306,9 @@ bd_plugin_spec_get_type
 
 <SECTION>
 <FILE>swap</FILE>
+bd_swap_check_deps
+bd_swap_init
+bd_swap_close
 bd_swap_error_quark
 BD_SWAP_ERROR
 BDSwapError
@@ -296,6 +320,9 @@ bd_swap_swapstatus
 
 <SECTION>
 <FILE>kbd</FILE>
+bd_kbd_check_deps
+bd_kbd_init
+bd_kbd_close
 BDKBDBcacheMode
 BDKBDBcacheStats
 BDKBDError
@@ -326,6 +353,9 @@ bd_kbd_zram_stats_free
 
 <SECTION>
 <FILE>part</FILE>
+bd_part_check_deps
+bd_part_init
+bd_part_close
 BD_PART_ERROR
 BD_PART_TYPE_SPEC
 BDPartAlign
@@ -362,6 +392,9 @@ bd_part_error_quark
 
 <SECTION>
 <FILE>fs</FILE>
+bd_fs_check_deps
+bd_fs_init
+bd_fs_close
 BDFSExt4Info
 BDFsError
 bd_fs_error_quark
@@ -390,6 +423,9 @@ bd_fs_xfs_wipe
 
 <SECTION>
 <FILE>s390</FILE>
+bd_s390_check_deps
+bd_s390_init
+bd_s390_close
 bd_s390_error_quark
 BDS390Error
 bd_s390_dasd_format

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -96,6 +96,9 @@ bd_dm_get_raid_set_type
 
 <SECTION>
 <FILE>utils</FILE>
+BDUtilsProgExtract
+BDUtilsProgFunc
+BDUtilsProgStatus
 BDUtilsLogFunc
 bd_utils_exec_error_quark
 BD_UTILS_EXEC_ERROR

--- a/scripts/boilerplate_generator.py
+++ b/scripts/boilerplate_generator.py
@@ -37,6 +37,9 @@ EB = 1000 * PB
 UNIT_MULTS = {"KiB": KiB, "MiB": MiB, "GiB": GiB, "TiB": TiB, "PiB": PiB, "EiB": EiB,
               "KB": KB, "MB": MB, "GB": GB, "TB": TB, "PB": PB, "EB": EB}
 
+# overrides for function prefixes not matching the modules' names
+MOD_FNAME_OVERRIDES = {"mdraid": "md"}
+
 def expand_size_constants(definitions):
     """
     Expand macros that define size constants (e.g. '#define DEFAULT_PE_SIZE (4 MiB)').
@@ -220,7 +223,7 @@ def get_loading_func(fn_infos, module_name):
     ret += '    }\n\n'
 
     ret += '    dlerror();\n'
-    ret += '    * (void**) (&check_fn) = dlsym(handle, "bd_{0}_check_deps");\n'.format(module_name)
+    ret += '    * (void**) (&check_fn) = dlsym(handle, "bd_{0}_check_deps");\n'.format(MOD_FNAME_OVERRIDES.get(module_name, module_name))
     ret += '    if ((error = dlerror()) != NULL)\n'
     ret += '        g_debug("failed to load the check() function for {0}: %s", error);\n'.format(module_name)
     ret += '    if (check_fn && !check_fn()) {\n'
@@ -230,7 +233,7 @@ def get_loading_func(fn_infos, module_name):
     ret += '    check_fn = NULL;\n\n'
 
     ret += '    dlerror();\n'
-    ret += '    * (void**) (&init_fn) = dlsym(handle, "bd_{0}_init");\n'.format(module_name)
+    ret += '    * (void**) (&init_fn) = dlsym(handle, "bd_{0}_init");\n'.format(MOD_FNAME_OVERRIDES.get(module_name, module_name))
     ret += '    if ((error = dlerror()) != NULL)\n'
     ret += '        g_debug("failed to load the init() function for {0}: %s", error);\n'.format(module_name)
     ret += '    if (init_fn && !init_fn()) {\n'
@@ -262,7 +265,7 @@ def get_unloading_func(fn_infos, module_name):
 
     ret += '\n'
     ret += '    dlerror();\n'
-    ret += '    * (void**) (&close_fn) = dlsym(handle, "bd_{0}_close");\n'.format(module_name)
+    ret += '    * (void**) (&close_fn) = dlsym(handle, "bd_{0}_close");\n'.format(MOD_FNAME_OVERRIDES.get(module_name, module_name))
     ret += '    if (((error = dlerror()) != NULL) || !close_fn)\n'
     ret += '        g_debug("failed to load the close_plugin() function for {0}: %s", error);\n'.format(module_name)
     ret += '    if (close_fn) {\n'

--- a/scripts/boilerplate_generator.py
+++ b/scripts/boilerplate_generator.py
@@ -220,7 +220,7 @@ def get_loading_func(fn_infos, module_name):
     ret += '    }\n\n'
 
     ret += '    dlerror();\n'
-    ret += '    * (void**) (&check_fn) = dlsym(handle, "check");\n'
+    ret += '    * (void**) (&check_fn) = dlsym(handle, "bd_{0}_check_deps");\n'.format(module_name)
     ret += '    if ((error = dlerror()) != NULL)\n'
     ret += '        g_debug("failed to load the check() function for {0}: %s", error);\n'.format(module_name)
     ret += '    if (check_fn && !check_fn()) {\n'
@@ -230,7 +230,7 @@ def get_loading_func(fn_infos, module_name):
     ret += '    check_fn = NULL;\n\n'
 
     ret += '    dlerror();\n'
-    ret += '    * (void**) (&init_fn) = dlsym(handle, "init");\n'
+    ret += '    * (void**) (&init_fn) = dlsym(handle, "bd_{0}_init");\n'.format(module_name)
     ret += '    if ((error = dlerror()) != NULL)\n'
     ret += '        g_debug("failed to load the init() function for {0}: %s", error);\n'.format(module_name)
     ret += '    if (init_fn && !init_fn()) {\n'
@@ -262,7 +262,7 @@ def get_unloading_func(fn_infos, module_name):
 
     ret += '\n'
     ret += '    dlerror();\n'
-    ret += '    * (void**) (&close_fn) = dlsym(handle, "close_plugin");\n'
+    ret += '    * (void**) (&close_fn) = dlsym(handle, "bd_{0}_close");\n'.format(module_name)
     ret += '    if (((error = dlerror()) != NULL) || !close_fn)\n'
     ret += '        g_debug("failed to load the close_plugin() function for {0}: %s", error);\n'.format(module_name)
     ret += '    if (close_fn) {\n'

--- a/src/lib/plugin_apis/Makefile.am
+++ b/src/lib/plugin_apis/Makefile.am
@@ -4,7 +4,7 @@ HEADER_FILES := $(patsubst %.api,%.h,${API_FILES})
 
 all-local: generate_boilerplate
 
-%.c %.h: %.api
+%.c %.h: %.api ${srcdir}/../../../scripts/boilerplate_generator.py
 	${srcdir}/../../../scripts/boilerplate_generator.py $*.api ./
 
 generate_boilerplate: ${SOURCE_FILES} ${HEADER_FILES}

--- a/src/plugins/btrfs.c
+++ b/src/plugins/btrfs.c
@@ -91,9 +91,14 @@ void bd_btrfs_filesystem_info_free (BDBtrfsFilesystemInfo *info) {
 }
 
 /**
- * check: (skip)
+ * bd_btrfs_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean check() {
+gboolean bd_btrfs_check_deps () {
     GError *error = NULL;
     gboolean ret = bd_utils_check_util_version ("btrfs", BTRFS_MIN_VERSION, NULL, "[Bb]trfs.* v([\\d\\.]+)", &error);
 
@@ -102,6 +107,29 @@ gboolean check() {
         g_clear_error (&error);
     }
     return ret;
+}
+
+/**
+ * bd_btrfs_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_btrfs_init () {
+    /* nothing to do here */
+    return TRUE;
+};
+
+/**
+ * bd_btrfs_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_btrfs_close () {
+    /* nothing to do here */
 }
 
 static BDBtrfsDeviceInfo* get_device_info_from_match (GMatchInfo *match_info) {

--- a/src/plugins/btrfs.h.in
+++ b/src/plugins/btrfs.h.in
@@ -46,6 +46,19 @@ typedef struct BDBtrfsFilesystemInfo {
 void bd_btrfs_filesystem_info_free (BDBtrfsFilesystemInfo *info);
 BDBtrfsFilesystemInfo* bd_btrfs_filesystem_info_copy (BDBtrfsFilesystemInfo *info);
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_btrfs_check_deps ();
+gboolean bd_btrfs_init ();
+void bd_btrfs_close ();
+
 gboolean bd_btrfs_create_volume (const gchar **devices, const gchar *label, const gchar *data_level, const gchar *md_level, const BDExtraArg **extra, GError **error);
 gboolean bd_btrfs_add_device (const gchar *mountpoint, const gchar *device, const BDExtraArg **extra, GError **error);
 gboolean bd_btrfs_remove_device (const gchar *mountpoint, const gchar *device, const BDExtraArg **extra, GError **error);

--- a/src/plugins/crypto.c
+++ b/src/plugins/crypto.c
@@ -51,17 +51,38 @@
 static locale_t c_locale = (locale_t) 0;
 
 /**
- * init: (skip)
+ * bd_crypto_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean init () {
+gboolean bd_crypto_check_deps () {
+    /* nothing to do here */
+    return TRUE;
+}
+
+/**
+ * bd_crypto_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_crypto_init () {
     c_locale = newlocale (LC_ALL_MASK, "C", c_locale);
     return TRUE;
 }
 
 /**
- * close_plugin: (skip)
+ * bd_crypto_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
  */
-void close_plugin () {
+void bd_crypto_close () {
     c_locale = (locale_t) 0;
 }
 

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -32,6 +32,19 @@ typedef enum {
 #define DEFAULT_LUKS_KEYSIZE_BITS 256
 #define DEFAULT_LUKS_CIPHER "aes-xts-plain64"
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_crypto_check_deps ();
+gboolean bd_crypto_init ();
+void bd_crypto_close ();
+
 gchar* bd_crypto_generate_backup_passphrase(GError **error);
 gboolean bd_crypto_device_is_luks (const gchar *device, GError **error);
 gchar* bd_crypto_luks_uuid (const gchar *device, GError **error);

--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -59,27 +59,14 @@ static void discard_dm_log (int level __attribute__((unused)), const char *file 
 }
 
 /**
- * init: (skip)
+ * bd_dm_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean init () {
-    dm_log_with_errno_init ((dm_log_with_errno_fn) discard_dm_log);
-    dm_log_init_verbose (0);
-
-    return TRUE;
-}
-
-/**
- * close_plugin: (skip)
- */
-void close_plugin () {
-    dm_log_with_errno_init (NULL);
-    dm_log_init_verbose (0);
-}
-
-/**
- * check: (skip)
- */
-gboolean check() {
+gboolean bd_dm_check_deps () {
     GError *error = NULL;
     gboolean ret = bd_utils_check_util_version ("dmsetup", DM_MIN_VERSION, NULL, "Library version:\\s+([\\d\\.]+)", &error);
 
@@ -88,6 +75,32 @@ gboolean check() {
         g_clear_error (&error);
     }
     return ret;
+}
+
+/**
+ * bd_dm_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_dm_init () {
+    dm_log_with_errno_init ((dm_log_with_errno_fn) discard_dm_log);
+    dm_log_init_verbose (0);
+
+    return TRUE;
+}
+
+/**
+ * bd_dm_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_dm_close () {
+    dm_log_with_errno_init (NULL);
+    dm_log_init_verbose (0);
 }
 
 /**

--- a/src/plugins/dm.h
+++ b/src/plugins/dm.h
@@ -17,6 +17,19 @@ typedef enum {
     BD_DM_ERROR_RAID_NO_EXIST,
 } BDDMError;
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_dm_check_deps ();
+gboolean bd_dm_init ();
+void bd_dm_close ();
+
 gboolean bd_dm_create_linear (const gchar *map_name, const gchar *device, guint64 length, const gchar *uuid, GError **error);
 gboolean bd_dm_remove (const gchar *map_name, GError **error);
 gchar* bd_dm_name_from_node (const gchar *dm_node, GError **error);

--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -131,17 +131,14 @@ void bd_fs_vfat_info_free (BDFSVfatInfo *data) {
 }
 
 /**
- * init: (skip)
+ * bd_fs_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean init() {
-    ped_exception_set_handler ((PedExceptionHandler*) bd_exc_handler);
-    return TRUE;
-}
-
-/**
- * check: (skip)
- */
-gboolean check() {
+gboolean bd_fs_check_deps () {
     GError *error = NULL;
     gboolean ret = bd_utils_check_util_version ("mkfs.ext4", NULL, "", NULL, &error);
 
@@ -223,6 +220,29 @@ gboolean check() {
     }
 
     return ret;
+}
+
+/**
+ * bd_fs_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_fs_init () {
+    ped_exception_set_handler ((PedExceptionHandler*) bd_exc_handler);
+    return TRUE;
+}
+
+/**
+ * bd_fs_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_fs_close () {
+    /* nothing to do here */
 }
 
 /**

--- a/src/plugins/fs.h
+++ b/src/plugins/fs.h
@@ -44,6 +44,18 @@ typedef struct BDFSVfatInfo {
 BDFSVfatInfo* bd_fs_vfat_info_copy (BDFSVfatInfo *data);
 void bd_fs_vfat_info_free (BDFSVfatInfo *data);
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_fs_check_deps ();
+gboolean bd_fs_init ();
+void bd_fs_close ();
 
 gboolean bd_fs_wipe (const gchar *device, gboolean all, GError **error);
 

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -62,6 +62,19 @@ typedef struct BDKBDBcacheStats {
 BDKBDBcacheStats* bd_kbd_bcache_stats_copy (BDKBDBcacheStats *data);
 void bd_kbd_bcache_stats_free (BDKBDBcacheStats *data);
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_kbd_check_deps ();
+gboolean bd_kbd_init ();
+void bd_kbd_close ();
+
 gboolean bd_kbd_zram_create_devices (guint64 num_devices, const guint64 *sizes, const guint64 *nstreams, GError **error);
 gboolean bd_kbd_zram_destroy_devices (GError **error);
 gboolean bd_kbd_zram_add_device (guint64 size, guint64 nstreams, gchar **device, GError **error);

--- a/src/plugins/loop.c
+++ b/src/plugins/loop.c
@@ -42,9 +42,14 @@ GQuark bd_loop_error_quark (void)
 }
 
 /**
- * check: (skip)
+ * bd_loop_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean check() {
+gboolean bd_loop_check_deps () {
     GError *error = NULL;
     gboolean ret = bd_utils_check_util_version ("losetup", LOSETUP_MIN_VERSION, NULL, "losetup from util-linux\\s+([\\d\\.]+)", &error);
 
@@ -53,6 +58,29 @@ gboolean check() {
         g_clear_error (&error);
     }
     return ret;
+}
+
+/**
+ * bd_loop_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_loop_init () {
+    /* nothing to do here */
+    return TRUE;
+};
+
+/**
+ * bd_loop_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_loop_close () {
+    /* nothing to do here */
 }
 
 /**

--- a/src/plugins/loop.h
+++ b/src/plugins/loop.h
@@ -11,6 +11,19 @@ typedef enum {
     BD_LOOP_ERROR_DEVICE,
 } BDLoopError;
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_loop_check_deps ();
+gboolean bd_loop_init ();
+void bd_loop_close ();
+
 gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
 gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
 gboolean bd_loop_setup (const gchar *file, const gchar **loop_name, GError **error);

--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -209,9 +209,14 @@ static gboolean setup_dbus_connection (GError **error) {
 }
 
 /**
- * check: (skip)
+ * bd_lvm_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean check() {
+gboolean bd_lvm_check_deps () {
     GVariant *ret = NULL;
     GVariant *real_ret = NULL;
     GVariantIter iter;
@@ -276,9 +281,13 @@ gboolean check() {
 }
 
 /**
- * init: (skip)
+ * bd_lvm_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
  */
-gboolean init() {
+gboolean bd_lvm_init () {
     GError *error = NULL;
 
     /* the check() call should create the DBus connection for us, but let's not
@@ -292,9 +301,13 @@ gboolean init() {
 }
 
 /**
- * close_plugin: (skip)
+ * bd_lvm_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
  */
-void close_plugin () {
+void bd_lvm_close () {
     GError *error = NULL;
 
     /* the check() call should create the DBus connection for us, but let's not

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -150,9 +150,14 @@ void bd_lvm_cache_stats_free (BDLVMCacheStats *data) {
 }
 
 /**
- * check: (skip)
+ * bd_lvm_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean check() {
+gboolean bd_lvm_check_deps () {
     GError *error = NULL;
     gboolean ret = bd_utils_check_util_version ("lvm", LVM_MIN_VERSION, "version", "LVM version:\\s+([\\d\\.]+)", &error);
 
@@ -161,6 +166,29 @@ gboolean check() {
         g_clear_error (&error);
     }
     return ret;
+}
+
+/**
+ * bd_lvm_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_lvm_init () {
+    /* nothing to do here */
+    return TRUE;
+};
+
+/**
+ * bd_lvm_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_lvm_close () {
+    /* nothing to do here */
 }
 
 static gboolean call_lvm_and_report_error (const gchar **args, const BDExtraArg **extra, GError **error) {

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -129,6 +129,19 @@ typedef struct BDLVMCacheStats {
 void bd_lvm_cache_stats_free (BDLVMCacheStats *data);
 BDLVMCacheStats* bd_lvm_cache_stats_copy (BDLVMCacheStats *data);
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_lvm_check_deps ();
+gboolean bd_lvm_init ();
+void bd_lvm_close ();
+
 gboolean bd_lvm_is_supported_pe_size (guint64 size, GError **error);
 guint64 *bd_lvm_get_supported_pe_sizes (GError **error);
 guint64 bd_lvm_get_max_lv_size (GError **error);

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -127,9 +127,14 @@ void bd_md_detail_data_free (BDMDDetailData *data) {
 }
 
 /**
- * check: (skip)
+ * bd_md_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean check() {
+gboolean bd_md_check_deps () {
     GError *error = NULL;
     gboolean ret = bd_utils_check_util_version ("mdadm", MDADM_MIN_VERSION, NULL, "mdadm - v([\\d\\.]+)", &error);
 
@@ -138,6 +143,29 @@ gboolean check() {
         g_clear_error (&error);
     }
     return ret;
+}
+
+/**
+ * bd_md_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_md_init () {
+    /* nothing to do here */
+    return TRUE;
+};
+
+/**
+ * bd_md_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_md_close () {
+    /* nothing to do here */
 }
 
 /**

--- a/src/plugins/mdraid.h
+++ b/src/plugins/mdraid.h
@@ -56,6 +56,19 @@ typedef struct BDMDDetailData {
 void bd_md_detail_data_free (BDMDDetailData *data);
 BDMDDetailData* bd_md_detail_data_copy (BDMDDetailData *data);
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_md_check_deps ();
+gboolean bd_md_init ();
+void bd_md_close ();
+
 guint64 bd_md_get_superblock_size (guint64 member_size, const gchar *version, GError **error);
 gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, const BDExtraArg **extra, GError **error);
 gboolean bd_md_create_with_chunk_size (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error);

--- a/src/plugins/mpath.c
+++ b/src/plugins/mpath.c
@@ -43,9 +43,14 @@ GQuark bd_mpath_error_quark (void)
 }
 
 /**
- * check: (skip)
+ * bd_mpath_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean check() {
+gboolean bd_mpath_check_deps () {
     GError *error = NULL;
     gboolean ret = bd_utils_check_util_version ("multipath", MULTIPATH_MIN_VERSION, NULL, "multipath-tools v([\\d\\.]+)", &error);
 
@@ -64,6 +69,29 @@ gboolean check() {
         g_clear_error (&error);
     }
     return ret;
+}
+
+/**
+ * bd_mpath_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_mpath_init () {
+    /* nothing to do here */
+    return TRUE;
+};
+
+/**
+ * bd_mpath_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_mpath_close () {
+    /* nothing to do here */
 }
 
 /**

--- a/src/plugins/mpath.h
+++ b/src/plugins/mpath.h
@@ -14,6 +14,19 @@ typedef enum {
     BD_MPATH_ERROR_INVAL,
 } BDMpathError;
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_mpath_check_deps ();
+gboolean bd_mpath_init ();
+void bd_mpath_close ();
+
 gboolean bd_mpath_flush_mpaths (GError **error);
 gboolean bd_mpath_is_mpath_member (const gchar *device, GError **error);
 gchar** bd_mpath_get_mpath_members (GError **error);

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -117,25 +117,16 @@ static gboolean set_parted_error (GError **error, BDPartError type) {
     }
 }
 
-/**
- * init: (skip)
- */
-gboolean init() {
-    ped_exception_set_handler ((PedExceptionHandler*) bd_exc_handler);
-    return TRUE;
-}
 
 /**
- * close_plugin: (skip)
+ * bd_part_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-void close_plugin () {
-    ped_exception_set_handler (NULL);
-}
-
-/**
- * check: (skip)
- */
-gboolean check() {
+gboolean bd_part_check_deps () {
     GError *error = NULL;
     gboolean ret = bd_utils_check_util_version ("sgdisk", "1.0.1", NULL, "GPT fdisk \\(sgdisk\\) version ([\\d\\.]+)", &error);
 
@@ -144,6 +135,29 @@ gboolean check() {
         g_clear_error (&error);
     }
     return ret;
+}
+
+/**
+ * bd_part_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_part_init () {
+    ped_exception_set_handler ((PedExceptionHandler*) bd_exc_handler);
+    return TRUE;
+}
+
+/**
+ * bd_part_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_part_close () {
+    ped_exception_set_handler (NULL);
 }
 
 

--- a/src/plugins/part.h
+++ b/src/plugins/part.h
@@ -93,6 +93,18 @@ typedef struct BDPartDiskSpec {
 BDPartDiskSpec* bd_part_disk_spec_copy (BDPartDiskSpec *data);
 void bd_part_disk_spec_free (BDPartDiskSpec *data);
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_part_check_deps ();
+gboolean bd_part_init ();
+void bd_part_close ();
 
 gboolean bd_part_create_table (const gchar *disk, BDPartTableType type, gboolean ignore_existing, GError **error);
 

--- a/src/plugins/s390.c
+++ b/src/plugins/s390.c
@@ -47,9 +47,14 @@ GQuark bd_s390_error_quark (void) {
 
 
 /**
- * check: (skip)
+ * bd_s390_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean check() {
+gboolean bd_s390_check_deps () {
     GError *error = NULL;
     /* dasdfmt doesn't return version info */
     gboolean ret = bd_utils_check_util_version ("dasdfmt", NULL, NULL, NULL, &error);
@@ -58,6 +63,29 @@ gboolean check() {
         g_clear_error (&error);
     }
     return ret;
+}
+
+/**
+ * bd_s390_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_s390_init () {
+    /* nothing to do here */
+    return TRUE;
+};
+
+/**
+ * bd_s390_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_s390_close () {
+    /* nothing to do here */
 }
 
 /**

--- a/src/plugins/s390.h
+++ b/src/plugins/s390.h
@@ -16,6 +16,19 @@ typedef enum {
     BD_S390_ERROR_IO,
 } BDS390Error;
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_s390_check_deps ();
+gboolean bd_s390_init ();
+void bd_s390_close ();
+
 gboolean bd_s390_dasd_format (const gchar *dasd, const BDExtraArg **extra, GError **error);
 gboolean bd_s390_dasd_needs_format (const gchar *dasd, GError **error);
 gboolean bd_s390_dasd_online (const gchar *dasd, GError **error);

--- a/src/plugins/swap.c
+++ b/src/plugins/swap.c
@@ -41,9 +41,14 @@ GQuark bd_swap_error_quark (void)
 }
 
 /**
- * check: (skip)
+ * bd_swap_check_deps:
+ *
+ * Returns: whether the plugin's runtime dependencies are satisfied or not
+ *
+ * Function checking plugin's runtime dependencies.
+ *
  */
-gboolean check() {
+gboolean bd_swap_check_deps () {
     GError *error = NULL;
     gboolean ret = bd_utils_check_util_version ("mkswap", MKSWAP_MIN_VERSION, NULL, "mkswap from util-linux ([\\d\\.]+)", &error);
 
@@ -71,6 +76,29 @@ gboolean check() {
     }
 
     return ret;
+}
+
+/**
+ * bd_swap_init:
+ *
+ * Initializes the plugin. **This function is called automatically by the
+ * library's initialization functions.**
+ *
+ */
+gboolean bd_swap_init () {
+    /* nothing to do here */
+    return TRUE;
+};
+
+/**
+ * bd_swap_close:
+ *
+ * Cleans up after the plugin. **This function is called automatically by the
+ * library's functions that unload it.**
+ *
+ */
+void bd_swap_close () {
+    /* nothing to do here */
 }
 
 /**

--- a/src/plugins/swap.h
+++ b/src/plugins/swap.h
@@ -14,6 +14,19 @@ typedef enum {
     BD_SWAP_ERROR_ACTIVATE,
 } BDSwapError;
 
+/*
+ * If using the plugin as a standalone library, the following functions should
+ * be called to:
+ *
+ * check_deps() - check plugin's dependencies, returning TRUE if satisfied
+ * init()       - initialize the plugin, returning TRUE on success
+ * close()      - clean after the plugin at the end or if no longer used
+ *
+ */
+gboolean bd_swap_check_deps ();
+gboolean bd_swap_init ();
+void bd_swap_close ();
+
 gboolean bd_swap_mkswap (const gchar *device, const gchar *label, const BDExtraArg **extra, GError **error);
 gboolean bd_swap_swapon (const gchar *device, gint priority, GError **error);
 gboolean bd_swap_swapoff (const gchar *device, GError **error);

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -176,14 +176,14 @@ class LibraryOpsTestCase(unittest.TestCase):
         self.assertNotEqual(orig_max_size, 1024)
 
         # change the sources and recompile
-        os.system("sed -ri 's?gboolean check\(\) \{?gboolean check() { return FALSE;//test-change?' src/plugins/lvm.c > /dev/null")
+        os.system("sed -ri 's?gboolean bd_lvm_check_deps \(\) \{?gboolean bd_lvm_check_deps () { return FALSE;//test-change?' src/plugins/lvm.c > /dev/null")
         os.system("make -C src/plugins/ libbd_lvm.la &>/dev/null")
 
         # proclaim the new build a different plugin
         os.system("cp src/plugins/.libs/libbd_lvm.so src/plugins/.libs/libbd_lvm2.so.0")
 
         # change the sources back and recompile
-        os.system("sed -ri 's?gboolean check\(\) \{ return FALSE;//test-change?gboolean check() {?' src/plugins/lvm.c > /dev/null")
+        os.system("sed -ri 's?gboolean bd_lvm_check_deps \(\) \{ return FALSE;//test-change?gboolean bd_lvm_check_deps () {?' src/plugins/lvm.c > /dev/null")
         os.system("make -C src/plugins/ libbd_lvm.la &>/dev/null")
 
         # now reinit the library with the config preferring the new build


### PR DESCRIPTION
The first commit makes the check/init/close functions of plugins public and callable if plugins are used as standalone libraries. The rest are just minor fixes and tweaks making things nicer and better.