### PR TITLE
Try to search for "RAID Level" in mdadm's output (#1379865)

### DIFF
--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -185,8 +185,14 @@ static BDMDExamineData* get_examine_data_from_table (GHashTable *table, gboolean
     char time_str[20];
 
     data->level = g_strdup ((gchar*) g_hash_table_lookup (table, "Raid Level"));
+    if (!(data->level))
+        /* BUG: mdadm outputs "RAID Level" for some metadata formats (rhbz#1380034) */
+        data->level = g_strdup ((gchar*) g_hash_table_lookup (table, "RAID Level"));
 
     value = (gchar*) g_hash_table_lookup (table, "Raid Devices");
+    if (!value)
+        /* BUG: mdadm outputs "RAID Devices" for some metadata formats (rhbz#1380034) */
+        value = (gchar*) g_hash_table_lookup (table, "RAID Devices");
     if (value)
         data->num_devices = g_ascii_strtoull (value, NULL, 0);
     else

--- a/tests/md_test.py
+++ b/tests/md_test.py
@@ -404,6 +404,15 @@ class FakeMDADMutilTest(unittest.TestCase):
 
         self.assertEqual(ex_data.device, "/dev/md/Volume0")
 
+    def test_fw_raid_uppercase_examine(self):
+        """Verify that md_examine works with output using "RAID" instead of "Raid" """
+
+        with fake_utils("tests/mdadm_fw_RAID_examine"):
+            ex_data = BlockDev.md_examine("fake_dev")
+
+        self.assertEqual(ex_data.level, "0")
+        self.assertEqual(ex_data.num_devices, 1)
+
     def test_no_metadata_examine(self):
         """Verify that md_examine works as expected with no metadata spec"""
 

--- a/tests/mdadm_fw_RAID_examine/mdadm
+++ b/tests/mdadm_fw_RAID_examine/mdadm
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+echo "$@"|grep -- "--brief" &>/dev/null
+is_brief=$?
+
+if [ $is_brief -eq 0 ]; then
+    cat <<EOF
+ARRAY metadata=imsm UUID=b42756a2:37e43e47:674bd1dd:6e822145
+ARRAY /dev/md/Volume0 container=b42756a2:37e43e47:674bd1dd:6e822145 member=0 UUID=8f0b5240:06168ed1:bbafeaf5:2a7b04fc
+EOF
+else
+    cat <<EOF
+/dev/sda:
+          Magic : Intel Raid ISM Cfg Sig.
+        Version : 1.0.00
+    Orig Family : e56dd6e1
+         Family : e56dd6e1
+     Generation : 0000000c
+     Attributes : All supported
+           UUID : b42756a2:37e43e47:674bd1dd:6e822145
+       Checksum : d4553058 correct
+    MPB Sectors : 1
+          Disks : 2
+   RAID Devices : 1
+
+  Disk00 Serial : 5QM2XY4V
+          State : active
+             Id : 00000000
+    Usable Size : 976768264 (465.76 GiB 500.11 GB)
+
+[Volume0]:
+           UUID : 8f0b5240:06168ed1:bbafeaf5:2a7b04fc
+     RAID Level : 0
+        Members : 2
+          Slots : [UU]
+    Failed disk : none
+      This Slot : 0
+     Array Size : 1953536000 (931.52 GiB 1000.21 GB)
+   Per Dev Size : 976768264 (465.76 GiB 500.11 GB)
+  Sector Offset : 0
+    Num Stripes : 3815500
+     Chunk Size : 128 KiB
+       Reserved : 0
+  Migrate State : idle
+      Map State : normal
+    Dirty State : clean
+
+  Disk01 Serial : 9VM1BT6B
+          State : active
+             Id : 00010000
+    Usable Size : 976768264 (465.76 GiB 500.11 GB)
+EOF
+fi


### PR DESCRIPTION
mdadm's API (CLI) is ambiguous and may provide the RAID level as either the
"RAID Level" or "Raid Level" item. Since we store these items in a hashtable,
let's try to lookup both if the first one fails. Another approach would be to
cannonicalize all the items keys when creating the hash table, but that seems
like an overkill for one weird quirk.