### PR TITLE
Add extra parameters to loop_setup required by storaged

### DIFF
--- a/src/lib/plugin_apis/loop.api
+++ b/src/lib/plugin_apis/loop.api
@@ -29,12 +29,16 @@ gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
 /**
  * bd_loop_setup:
  * @file: file to setup as a loop device
+ * @offset: offset of the start of the device (in @file)
+ * @size: maximum size of the device (or 0 to leave unspecified)
+ * @read_only: whether to setup as read-only (%TRUE) or read-write (%FALSE)
+ * @part_scan: whether to enforce partition scan on the newly created device or not
  * @loop_name: (allow-none) (out): if not %NULL, it is used to store the name of the loop device
  * @error: (out): place to store error (if any)
  *
  * Returns: whether the @file was successfully setup as a loop device or not
  */
-gboolean bd_loop_setup (const gchar *file, const gchar **loop_name, GError **error);
+gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
 
 /**
  * bd_loop_teardown:

--- a/src/plugins/loop.h
+++ b/src/plugins/loop.h
@@ -26,7 +26,7 @@ void bd_loop_close ();
 
 gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
 gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
-gboolean bd_loop_setup (const gchar *file, const gchar **loop_name, GError **error);
+gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
 gboolean bd_loop_teardown (const gchar *loop, GError **error);
 
 #endif  /* BD_LOOP */

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -237,6 +237,13 @@ def dm_get_member_raid_sets(name=None, uuid=None, major=-1, minor=-1):
 __all__.append("dm_get_member_raid_sets")
 
 
+_loop_setup = BlockDev.loop_setup
+@override(BlockDev.loop_setup)
+def loop_setup(file, offset=0, size=0, read_only=False, part_scan=True):
+    return _loop_setup(file, offset, size, read_only, part_scan)
+__all__.append("loop_setup")
+
+
 _fs_ext4_mkfs = BlockDev.fs_ext4_mkfs
 @override(BlockDev.fs_ext4_mkfs)
 def fs_ext4_mkfs(device, extra=None, **kwargs):


### PR DESCRIPTION
storaged supports almost everything that's possible to do as part of setting up
a loop device. In order to be a sufficient backend for storaged we need to
support the same set of features.

We need to reorganize the tests a little bit to make sure that everything is
cleaned up properly in case of failure.