### PR TITLE
storaged mdadm extra

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -262,7 +262,6 @@ bd_md_detail_data_free
 bd_md_detail_data_copy
 bd_md_get_superblock_size
 bd_md_create
-bd_md_create_with_chunk_size
 bd_md_destroy
 bd_md_deactivate
 bd_md_activate

--- a/src/lib/plugin_apis/mdraid.api
+++ b/src/lib/plugin_apis/mdraid.api
@@ -209,22 +209,6 @@ guint64 bd_md_get_superblock_size (guint64 member_size, const gchar *version, GE
  * @spares: number of spare devices
  * @version: (allow-none): metadata version
  * @bitmap: whether to create an internal bitmap on the device or not
- * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now
- *                                                 passed to the 'mdadm' utility)
- * @error: (out): place to store error (if any)
- *
- * Returns: whether the new MD RAID device @device_name was successfully created or not
- */
-gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, const BDExtraArg **extra, GError **error);
-
-/**
- * bd_md_create_with_chunk_size:
- * @device_name: name of the device to create
- * @level: RAID level (as understood by mdadm, see mdadm(8))
- * @disks: (array zero-terminated=1): disks to use for the new RAID (including spares)
- * @spares: number of spare devices
- * @version: (allow-none): metadata version
- * @bitmap: whether to create an internal bitmap on the device or not
  * @chunk_size: chunk size of the device to create
  * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now
  *                                                 passed to the 'mdadm' utility)
@@ -232,7 +216,7 @@ gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar
  *
  * Returns: whether the new MD RAID device @device_name was successfully created or not
  */
-gboolean bd_md_create_with_chunk_size (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error);
+gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_md_destroy:

--- a/src/lib/plugin_apis/mdraid.api
+++ b/src/lib/plugin_apis/mdraid.api
@@ -254,9 +254,10 @@ gboolean bd_md_deactivate (const gchar *device_name, GError **error);
 
 /**
  * bd_md_activate:
- * @device_name: name of the RAID device to activate
+ * @device_name: (allow-none): name of the RAID device to activate (if not given "--scan" is implied and @members is ignored)
  * @members: (allow-none) (array zero-terminated=1): member devices to be considered for @device activation
  * @uuid: (allow-none): UUID (in the MD RAID format!) of the MD RAID to activate
+ * @start_degraded: whether to start the array even if it's degraded
  * @extra: (allow-none) (array zero-terminated=1): extra options for the activation (right now
  *                                                 passed to the 'mdadm' utility)
  * @error: (out): place to store error (if any)
@@ -265,7 +266,7 @@ gboolean bd_md_deactivate (const gchar *device_name, GError **error);
  *
  * Note: either @members or @uuid (or both) have to be specified.
  */
-gboolean bd_md_activate (const gchar *device_name, const gchar **members, const gchar *uuid, const BDExtraArg **extra, GError **error);
+gboolean bd_md_activate (const gchar *device_name, const gchar **members, const gchar *uuid, gboolean start_degraded, const BDExtraArg **extra, GError **error);
 
 /**
  * bd_md_run:

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -409,80 +409,6 @@ guint64 bd_md_get_superblock_size (guint64 member_size, const gchar *version, GE
  * @spares: number of spare devices
  * @version: (allow-none): metadata version
  * @bitmap: whether to create an internal bitmap on the device or not
- * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now
- *                                                 passed to the 'mdadm' utility)
- * @error: (out): place to store error (if any)
- *
- * Returns: whether the new MD RAID device @device_name was successfully created or not
- */
-gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, const BDExtraArg **extra, GError **error) {
-    const gchar **argv = NULL;
-    /* ["mdadm", "create", device, "--run", "level", "raid-devices",...] */
-    guint argv_len = 6;
-    guint argv_top = 0;
-    guint i = 0;
-    guint num_disks = 0;
-    gchar *level_str = NULL;
-    gchar *rdevices_str = NULL;
-    gchar *spares_str = NULL;
-    gchar *version_str = NULL;
-    gboolean ret = FALSE;
-
-    if (spares != 0)
-        argv_len++;
-    if (version)
-        argv_len++;
-    if (bitmap)
-        argv_len++;
-    num_disks = g_strv_length ((gchar **) disks);
-    argv_len += num_disks;
-
-    argv = g_new0 (const gchar*, argv_len + 1);
-
-    level_str = g_strdup_printf ("--level=%s", level);
-    rdevices_str = g_strdup_printf ("--raid-devices=%"G_GUINT64_FORMAT, (num_disks - spares));
-
-    argv[argv_top++] = "mdadm";
-    argv[argv_top++] = "--create";
-    argv[argv_top++] = device_name;
-    argv[argv_top++] = "--run";
-    argv[argv_top++] = level_str;
-    argv[argv_top++] = rdevices_str;
-
-    if (spares != 0) {
-        spares_str = g_strdup_printf ("--spare-devices=%"G_GUINT64_FORMAT, spares);
-        argv[argv_top++] = spares_str;
-    }
-    if (version) {
-        version_str = g_strdup_printf ("--metadata=%s", version);
-        argv[argv_top++] = version_str;
-    }
-    if (bitmap)
-        argv[argv_top++] = "--bitmap=internal";
-
-    for (i=0; i < num_disks; i++)
-        argv[argv_top++] = disks[i];
-    argv[argv_top] = NULL;
-
-    ret = bd_utils_exec_and_report_error (argv, extra, error);
-
-    g_free (level_str);
-    g_free (rdevices_str);
-    g_free (spares_str);
-    g_free (version_str);
-    g_free (argv);
-
-    return ret;
-}
-
-/**
- * bd_md_create_with_chunk_size:
- * @device_name: name of the device to create
- * @level: RAID level (as understood by mdadm, see mdadm(8))
- * @disks: (array zero-terminated=1): disks to use for the new RAID (including spares)
- * @spares: number of spare devices
- * @version: (allow-none): metadata version
- * @bitmap: whether to create an internal bitmap on the device or not
  * @chunk_size: chunk size of the device to create
  * @extra: (allow-none) (array zero-terminated=1): extra options for the creation (right now
  *                                                 passed to the 'mdadm' utility)
@@ -490,7 +416,7 @@ gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar
  *
  * Returns: whether the new MD RAID device @device_name was successfully created or not
  */
-gboolean bd_md_create_with_chunk_size (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error) {
+gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error) {
     const gchar **argv = NULL;
     /* {"mdadm", "create", device, "--run", "level", "raid-devices",...} */
     guint argv_len = 6;

--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -598,9 +598,10 @@ gboolean bd_md_deactivate (const gchar *device_name, GError **error) {
 
 /**
  * bd_md_activate:
- * @device_name: name of the RAID device to activate
+ * @device_name: (allow-none): name of the RAID device to activate (if not given "--scan" is implied and @members is ignored)
  * @members: (allow-none) (array zero-terminated=1): member devices to be considered for @device activation
  * @uuid: (allow-none): UUID (in the MD RAID format!) of the MD RAID to activate
+ * @start_degraded: whether to start the array even if it's degraded
  * @extra: (allow-none) (array zero-terminated=1): extra options for the activation (right now
  *                                                 passed to the 'mdadm' utility)
  * @error: (out): place to store error (if any)
@@ -609,30 +610,34 @@ gboolean bd_md_deactivate (const gchar *device_name, GError **error) {
  *
  * Note: either @members or @uuid (or both) have to be specified.
  */
-gboolean bd_md_activate (const gchar *device_name, const gchar **members, const gchar *uuid, const BDExtraArg **extra, GError **error) {
-    guint64 num_members = members ? g_strv_length ((gchar **) members) : 0;
+gboolean bd_md_activate (const gchar *device_name, const gchar **members, const gchar *uuid, gboolean start_degraded, const BDExtraArg **extra, GError **error) {
+    guint64 num_members = (device_name && members) ? g_strv_length ((gchar **) members) : 0;
     const gchar **argv = NULL;
     gchar *uuid_str = NULL;
     guint argv_top = 0;
     guint i = 0;
     gboolean ret = FALSE;
 
-    /* mdadm, --assemble, device_name, --run, --uuid=uuid, member1, member2,..., NULL*/
-    if (uuid) {
-        argv = g_new0 (const gchar*, num_members + 6);
-        uuid_str = g_strdup_printf ("--uuid=%s", uuid);
-    }
-    else
-        argv = g_new0 (const gchar*, num_members + 5);
+    /* mdadm, --assemble, device_name/--scan, --run, --uuid=uuid, member1, member2,..., NULL*/
+    argv = g_new0 (const gchar*, num_members + 6);
 
     argv[argv_top++] = "mdadm";
     argv[argv_top++] = "--assemble";
-    argv[argv_top++] = device_name;
-    argv[argv_top++] = "--run";
-    if (uuid)
+    if (device_name)
+        argv[argv_top++] = device_name;
+    else
+        argv[argv_top++] = "--scan";
+    if (start_degraded)
+        argv[argv_top++] = "--run";
+    if (uuid) {
+        uuid_str = g_strdup_printf ("--uuid=%s", uuid);
         argv[argv_top++] = uuid_str;
-    for (i=0; i < num_members; i++)
-        argv[argv_top++] = members[i];
+    }
+    /* only add member device if device_name given (a combination of --scan with
+       a list of members doesn't work) */
+    if (device_name && members)
+        for (i=0; i < num_members; i++)
+            argv[argv_top++] = members[i];
     argv[argv_top] = NULL;
 
     ret = bd_utils_exec_and_report_error (argv, extra, error);

--- a/src/plugins/mdraid.h
+++ b/src/plugins/mdraid.h
@@ -74,7 +74,7 @@ gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar
 gboolean bd_md_create_with_chunk_size (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error);
 gboolean bd_md_destroy (const gchar *device, GError **error);
 gboolean bd_md_deactivate (const gchar *device_name, GError **error);
-gboolean bd_md_activate (const gchar *device_name, const gchar **members, const gchar *uuid, const BDExtraArg **extra, GError **error);
+gboolean bd_md_activate (const gchar *device_name, const gchar **members, const gchar *uuid, gboolean start_degraded, const BDExtraArg **extra, GError **error);
 gboolean bd_md_run (const gchar *raid_name, GError **error);
 gboolean bd_md_nominate (const gchar *device, GError **error);
 gboolean bd_md_denominate (const gchar *device, GError **error);

--- a/src/plugins/mdraid.h
+++ b/src/plugins/mdraid.h
@@ -70,8 +70,7 @@ gboolean bd_md_init ();
 void bd_md_close ();
 
 guint64 bd_md_get_superblock_size (guint64 member_size, const gchar *version, GError **error);
-gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, const BDExtraArg **extra, GError **error);
-gboolean bd_md_create_with_chunk_size (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error);
+gboolean bd_md_create (const gchar *device_name, const gchar *level, const gchar **disks, guint64 spares, const gchar *version, gboolean bitmap, guint64 chunk_size, const BDExtraArg **extra, GError **error);
 gboolean bd_md_destroy (const gchar *device, GError **error);
 gboolean bd_md_deactivate (const gchar *device_name, GError **error);
 gboolean bd_md_activate (const gchar *device_name, const gchar **members, const gchar *uuid, gboolean start_degraded, const BDExtraArg **extra, GError **error);

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -562,9 +562,9 @@ __all__.append("md_remove")
 
 _md_activate = BlockDev.md_activate
 @override(BlockDev.md_activate)
-def md_activate(device_name, members=None, uuid=None, extra=None, **kwargs):
+def md_activate(device_name=None, members=None, uuid=None, start_degraded=True, extra=None, **kwargs):
     extra = _get_extra(extra, kwargs)
-    return _md_activate(device_name, members, uuid, extra)
+    return _md_activate(device_name, members, uuid, start_degraded, extra)
 __all__.append("md_activate")
 
 

--- a/src/python/gi/overrides/BlockDev.py
+++ b/src/python/gi/overrides/BlockDev.py
@@ -536,14 +536,10 @@ def md_get_superblock_size(size, version=None):
 __all__.append("md_get_superblock_size")
 
 _md_create = BlockDev.md_create
-_md_create_with_chunk_size = BlockDev.md_create_with_chunk_size
 @override(BlockDev.md_create)
 def md_create(device_name, level, disks, spares=0, version=None, bitmap=False, chunk_size=0, extra=None, **kwargs):
     extra = _get_extra(extra, kwargs)
-    if chunk_size == 0:
-        return _md_create(device_name, level, disks, spares, version, bitmap, extra)
-    else:
-        return _md_create_with_chunk_size(device_name, level, disks, spares, version, bitmap, chunk_size, extra)
+    return _md_create(device_name, level, disks, spares, version, bitmap, chunk_size, extra)
 __all__.append("md_create")
 
 _md_add = BlockDev.md_add

--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -222,6 +222,60 @@ class MDTestActivateDeactivate(MDTestCase):
                                         [self.loop_dev, self.loop_dev2, self.loop_dev3], None)
             self.assertTrue(succ)
 
+class MDTestActivateWithUUID(MDTestCase):
+    @unittest.skipIf("SKIP_SLOW" in os.environ, "skipping slow tests")
+    def test_activate_with_uuid(self):
+        """Verify that it is possible to activate an MD RAID with UUID"""
+
+        with wait_for_resync():
+            succ = BlockDev.md_create("bd_test_md", "raid1",
+                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
+                                      1, None, True)
+            self.assertTrue(succ)
+
+        with wait_for_resync():
+            succ = BlockDev.md_deactivate("bd_test_md")
+            self.assertTrue(succ)
+
+        md_info = BlockDev.md_examine(self.loop_dev)
+        self.assertTrue(md_info)
+        self.assertTrue(md_info.uuid)
+
+        with wait_for_resync():
+            succ = BlockDev.md_activate("bd_test_md", [self.loop_dev, self.loop_dev2, self.loop_dev3], md_info.uuid)
+
+class MDTestActivateByUUID(MDTestCase):
+    @unittest.skipIf("SKIP_SLOW" in os.environ, "skipping slow tests")
+    def test_activate_by_uuid(self):
+        """Verify that it is possible to activate an MD RAID by UUID"""
+
+        with wait_for_resync():
+            succ = BlockDev.md_create("bd_test_md", "raid1",
+                                      [self.loop_dev, self.loop_dev2, self.loop_dev3],
+                                      1, None, True)
+            self.assertTrue(succ)
+
+        with wait_for_resync():
+            succ = BlockDev.md_deactivate("bd_test_md")
+            self.assertTrue(succ)
+
+        md_info = BlockDev.md_examine(self.loop_dev)
+        self.assertTrue(md_info)
+        self.assertTrue(md_info.uuid)
+
+        # should work with member devices specified
+        with wait_for_resync():
+            succ = BlockDev.md_activate(None, [self.loop_dev, self.loop_dev2, self.loop_dev3], md_info.uuid)
+
+        with wait_for_resync():
+            succ = BlockDev.md_deactivate("bd_test_md")
+            self.assertTrue(succ)
+
+        # as well as without them
+        with wait_for_resync():
+            succ = BlockDev.md_activate(None, None, md_info.uuid)
+
+
 class MDTestNominateDenominate(MDTestCase):
     @unittest.skipIf("SKIP_SLOW" in os.environ, "skipping slow tests")
     def test_nominate_denominate(self):

--- a/tests/s390_test.py
+++ b/tests/s390_test.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import overrides_hack
 
 from utils import fake_path
 from gi.repository import BlockDev, GLib


### PR DESCRIPTION
The first commit adds features required by storaged from the mdraid plugin. The other removes a function we no longer need for the new 2.0 API.