### PR TITLE
Handle mdadm --examine output during migration

### DIFF
--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -183,6 +183,7 @@ static GHashTable* parse_mdadm_vars (const gchar *str, const gchar *item_sep, co
     gchar **items = NULL;
     gchar **item_p = NULL;
     gchar **key_val = NULL;
+    gchar **vals = NULL;
 
     table = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_free);
     *num_items = 0;
@@ -193,8 +194,16 @@ static GHashTable* parse_mdadm_vars (const gchar *str, const gchar *item_sep, co
         if (g_strv_length ((gchar **) key_val) == 2) {
             /* we only want to process valid lines (with the separator) */
             /* only use the first value for the given key */
-            if (!g_hash_table_contains (table, g_strstrip (key_val[0])))
-                g_hash_table_insert (table, g_strstrip (key_val[0]), g_strstrip (key_val[1]));
+            if (!g_hash_table_contains (table, g_strstrip (key_val[0]))) {
+                if (strstr (key_val[1], "<--")) {
+                    /* mdadm --examine output for a set being migrated */
+                    vals = g_strsplit (key_val[1], "<--", 2);
+                    g_hash_table_insert (table, g_strstrip (key_val[0]), g_strstrip (vals[0]));
+                    g_free (vals[1]);
+                } else {
+                    g_hash_table_insert (table, g_strstrip (key_val[0]), g_strstrip (key_val[1]));
+                }
+            }
             (*num_items)++;
         } else
             /* invalid line, just free key_val */

--- a/tests/mdadm_fw_RAID_examine_migrate/mdadm
+++ b/tests/mdadm_fw_RAID_examine_migrate/mdadm
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+echo "$@"|grep -- "--brief" &>/dev/null
+is_brief=$?
+
+echo "$@"|grep -- "--export" &>/dev/null
+is_export=$?
+
+if [ $is_brief -eq 0 ]; then
+    cat <<EOF
+ARRAY metadata=imsm UUID=83c77249:90fb26a2:882bfb52:87f71b59
+ARRAY /dev/md/Volume0 container=83c77249:90fb26a2:882bfb52:87f71b59 member=0 UUID=76508998:aea211a0:b4fa4eda:78e41fbb
+EOF
+elif [ $is_export -eq 0 ]; then
+    cat <<EOF
+MD_METADATA=imsm
+MD_LEVEL=container
+MD_UUID=83c77249:90fb26a2:882bfb52:87f71b59
+MD_DEVICES=3
+EOF
+else
+    cat <<EOF
+/dev/sda:
+          Magic : Intel Raid ISM Cfg Sig.
+        Version : 1.2.02
+    Orig Family : 56330de5
+         Family : 56330de5
+     Generation : 00000005
+     Attributes : All supported
+           UUID : 83c77249:90fb26a2:882bfb52:87f71b59
+       Checksum : 359f2642 correct
+    MPB Sectors : 2
+          Disks : 3
+   RAID Devices : 1
+
+  Disk00 Serial : 50026B723702E422
+          State : active
+             Id : 00000000
+    Usable Size : 234436872 (111.79 GiB 120.03 GB)
+
+[Volume0]:
+           UUID : 76508998:aea211a0:b4fa4eda:78e41fbb
+     RAID Level : 5 <-- 5
+        Members : 3 <-- 3
+          Slots : [UUU] <-- [UUU]
+    Failed disk : none
+      This Slot : 0
+     Array Size : 468873216 (223.58 GiB 240.06 GB)
+   Per Dev Size : 234436872 (111.79 GiB 120.03 GB)
+  Sector Offset : 0
+    Num Stripes : 915768
+     Chunk Size : 128 KiB <-- 128 KiB
+       Reserved : 0
+  Migrate State : initialize
+      Map State : normal <-- uninitialized
+     Checkpoint : 0 (768)
+    Dirty State : clean
+
+  Disk01 Serial : 2327B37FS
+          State : active
+             Id : 00000002
+    Usable Size : 976768392 (465.76 GiB 500.11 GB)
+
+  Disk02 Serial : 232K7DDFS
+          State : active
+             Id : 00000003
+    Usable Size : 976768392 (465.76 GiB 500.11 GB)
+EOF
+fi

--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -469,6 +469,14 @@ class FakeMDADMutilTest(unittest.TestCase):
 
         self.assertIs(ex_data.metadata, None)
 
+    def test_fw_raid_migrating(self):
+        """Verify that md_examine works when array is migrating ("foo <-- bar" values in output) """
+
+        with fake_utils("tests/mdadm_fw_RAID_examine_migrate"):
+            ex_data = BlockDev.md_examine("fake_dev")
+
+        self.assertEqual(ex_data.chunk_size, 128 * 1024)
+
 
 class MDUnloadTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
If a RAID set is undergoing any operation considered to be a
'migration' - which includes initialization of a new set at any
RAID level that includes redundancy - mdadm --examine will have
lines like this:

     RAID Level : 5 <-- 5
        Members : 3 <-- 3
      Map State : normal <-- uninitialized

At present we don't understand this at all. This is a fairly
minimal fix which just has parse_mdadm_vars notice such lines,
split the 'value' on "<--", and stuff the first value (the one
being migrated *to*, which is usually what we care about, I
think) into the table. We could do something more elaborate
like store both values and make `get_examine_data_from_table`
understand that, but it's more complicated and this should be
all we truly need for now.