### PR TITLE
Bump version numbers to 2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # configure.ac for libblockdev
 
-AC_INIT([libblockdev], [1.999], [vpodzime@redhat.com])
+AC_INIT([libblockdev], [2.0], [vpodzime@redhat.com])
 
 # Disable building static libraries.
 # This needs to be set before initializing automake
@@ -89,7 +89,7 @@ AC_CHECK_HEADERS([dlfcn.h string.h unistd.h sys/fcntl.h sys/ioctl.h linux/random
                  [LIBBLOCKDEV_SOFT_FAILURE([Header file $ac_header not found.])],
                  [])
 
-AC_SUBST([MAJOR_VER], [\"0\"])
+AC_SUBST([MAJOR_VER], [\"2\"])
 
 AC_OUTPUT
 LIBBLOCKDEV_FAILURES

--- a/data/conf.d/00-default.cfg
+++ b/data/conf.d/00-default.cfg
@@ -13,31 +13,31 @@
 # to be loaded.
 
 [btrfs]
-sonames=libbd_btrfs.so.0
+sonames=libbd_btrfs.so.2
 
 [crypto]
-sonames=libbd_crypto.so.0
+sonames=libbd_crypto.so.2
 
 [dm]
-sonames=libbd_dm.so.0
+sonames=libbd_dm.so.2
 
 [kbd]
-sonames=libbd_kbd.so.0
+sonames=libbd_kbd.so.2
 
 [loop]
-sonames=libbd_loop.so.0
+sonames=libbd_loop.so.2
 
 [lvm]
-sonames=libbd_lvm.so.0
+sonames=libbd_lvm.so.2
 
 [mdraid]
-sonames=libbd_mdraid.so.0
+sonames=libbd_mdraid.so.2
 
 [mpath]
-sonames=libbd_mpath.so.0
+sonames=libbd_mpath.so.2
 
 [swap]
-sonames=libbd_swap.so.0
+sonames=libbd_swap.so.2
 
 [s390]
-sonames=libbd_s390.so.0
+sonames=libbd_s390.so.2

--- a/data/conf.d/10-lvm-dbus.cfg
+++ b/data/conf.d/10-lvm-dbus.cfg
@@ -1,2 +1,2 @@
 [lvm]
-sonames=libbd_lvm-dbus.so.0
+sonames=libbd_lvm-dbus.so.2

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -5,7 +5,7 @@ SUBDIRS = plugin_apis
 lib_LTLIBRARIES = libblockdev.la
 libblockdev_la_CFLAGS = $(GLIB_CFLAGS)
 libblockdev_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la -ldl
-libblockdev_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 4:1:4 -Wl,--no-undefined
+libblockdev_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libblockdev_la_CPPFLAGS = -I${builddir}/../../include/
 libblockdev_la_SOURCES = blockdev.c blockdev.h plugins.c plugins.h
 
@@ -29,18 +29,18 @@ if ON_S390
 GIHEADERS += ${builddir}/plugin_apis/s390.h
 endif
 
-BlockDev-1.0.gir: libblockdev.la
+BlockDev-2.0.gir: libblockdev.la
 
-BlockDev_1_0_gir_FILES = $(GIHEADERS)
-BlockDev_1_0_gir_LIBS = libblockdev.la
-BlockDev_1_0_gir_INCLUDES = GObject-2.0
-BlockDev_1_0_gir_PACKAGES = devmapper libudev libcryptsetup libparted blkid bytesize
-BlockDev_1_0_gir_CFLAGS = -I${builddir}/../../include/
-BlockDev_1_0_gir_LDFLAGS = -lm -ldmraid -L${builddir}/../utils/ -lbd_utils
-BlockDev_1_0_gir_SCANNERFLAGS = --warn-error --warn-all --identifier-prefix=BD --symbol-prefix=bd
-BlockDev_1_0_gir_EXPORT_PACKAGES = blockdev
+BlockDev_2_0_gir_FILES = $(GIHEADERS)
+BlockDev_2_0_gir_LIBS = libblockdev.la
+BlockDev_2_0_gir_INCLUDES = GObject-2.0
+BlockDev_2_0_gir_PACKAGES = devmapper libudev libcryptsetup libparted blkid bytesize
+BlockDev_2_0_gir_CFLAGS = -I${builddir}/../../include/
+BlockDev_2_0_gir_LDFLAGS = -lm -ldmraid -L${builddir}/../utils/ -lbd_utils
+BlockDev_2_0_gir_SCANNERFLAGS = --warn-error --warn-all --identifier-prefix=BD --symbol-prefix=bd
+BlockDev_2_0_gir_EXPORT_PACKAGES = blockdev
 
-INTROSPECTION_GIRS = BlockDev-1.0.gir
+INTROSPECTION_GIRS = BlockDev-2.0.gir
 
 typelibdir = $(libdir)/girepository-1.0
 typelib_DATA = $(INTROSPECTION_GIRS:.gir=.typelib)
@@ -54,6 +54,6 @@ pkgconfig_DATA = ${builddir}/blockdev.pc
 libincludedir = $(includedir)/blockdev
 libinclude_HEADERS = blockdev.h plugins.h
 
-CLEANFILES = BlockDev-1.0.gir $(typelib_DATA)
+CLEANFILES = BlockDev-2.0.gir $(typelib_DATA)
 MAINTAINERCLEANFILES = Makefile.in blockdev.pc blockdev.c
 endif

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -7,88 +7,89 @@ endif
 
 libbd_btrfs_la_CFLAGS = $(GLIB_CFLAGS) $(BYTESIZE_CFLAGS) -Wall -Wextra -Werror
 libbd_btrfs_la_LIBADD = $(GLIB_LIBS) $(BYTESIZE_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_btrfs_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
+libbd_btrfs_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_btrfs_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_btrfs_la_SOURCES = btrfs.c btrfs.h
 
 libbd_crypto_la_CFLAGS = $(GLIB_CFLAGS) $(CRYPTSETUP_CFLAGS) $(NSS_CFLAGS) -Wall -Wextra -Werror
 libbd_crypto_la_LIBADD = $(GLIB_LIBS) $(CRYPTSETUP_LIBS) $(NSS_LIBS) -lvolume_key ${builddir}/../utils/libbd_utils.la
-libbd_crypto_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
+libbd_crypto_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_crypto_la_CPPFLAGS = -I${builddir}/../../include/ -I/usr/include/volume_key
 libbd_crypto_la_SOURCES = crypto.c crypto.h
 
 libbd_dm_la_CFLAGS = $(GLIB_CFLAGS) $(DEVMAPPER_CFLAGS) $(UDEV_CFLAGS) -Wall -Wextra -Werror
 libbd_dm_la_LIBADD = $(GLIB_LIBS) $(DEVMAPPER_LIBS) $(UDEV_LIBS) -ldmraid ${builddir}/../utils/libbd_utils.la
-libbd_dm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
+libbd_dm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 # Dear author of libdmdraid, VERSION really is not a good name for an enum member!
 libbd_dm_la_CPPFLAGS = -I${builddir}/../../include/ -UVERSION
 libbd_dm_la_SOURCES = dm.c dm.h
 
 libbd_loop_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
 libbd_loop_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_loop_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
+libbd_loop_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_loop_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_loop_la_SOURCES = loop.c loop.h
 
 libbd_lvm_la_CFLAGS = $(GLIB_CFLAGS) $(DEVMAPPER_CFLAGS) -Wall -Wextra -Werror
 libbd_lvm_la_LIBADD = $(GLIB_LIBS) $(DEVMAPPER_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_lvm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 4:1:4 -Wl,--no-undefined
+libbd_lvm_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_lvm_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_lvm_la_SOURCES = lvm.c lvm.h
 
 libbd_lvm_dbus_la_CFLAGS = $(GLIB_CFLAGS) $(GIO_CFLAGS) $(DEVMAPPER_CFLAGS) -Wall -Wextra -Werror
 libbd_lvm_dbus_la_LIBADD = $(GLIB_LIBS) $(GIO_LIBS) $(DEVMAPPER_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_lvm_dbus_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1 -Wl,--no-undefined
+libbd_lvm_dbus_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_lvm_dbus_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_lvm_dbus_la_SOURCES = lvm-dbus.c lvm.h
 
 libbd_mdraid_la_CFLAGS = $(GLIB_CFLAGS) $(BYTESIZE_CFLAGS) -Wall -Wextra -Werror
 libbd_mdraid_la_LIBADD = $(GLIB_LIBS) $(BYTESIZE_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_mdraid_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1 -Wl,--no-undefined
+libbd_mdraid_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_mdraid_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_mdraid_la_SOURCES = mdraid.c mdraid.h
 
 libbd_mpath_la_CFLAGS = $(GLIB_CFLAGS) $(DEVMAPPER_CFLAGS) -Wall -Wextra -Werror
 libbd_mpath_la_LIBADD = $(GLIB_LIBS) $(DEVMAPPER_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_mpath_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1 -Wl,--no-undefined
+libbd_mpath_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_mpath_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_mpath_la_SOURCES = mpath.c mpath.h
 
 libbd_swap_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
 libbd_swap_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_swap_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
+libbd_swap_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_swap_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_swap_la_SOURCES = swap.c swap.h
 
 libbd_kbd_la_CFLAGS = $(GLIB_CFLAGS) $(KMOD_CFLAGS) -Wall -Wextra -Werror
 libbd_kbd_la_LIBADD = $(GLIB_LIBS) $(KMOD_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_kbd_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
+libbd_kbd_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_kbd_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_kbd_la_SOURCES = kbd.c kbd.h
 
 if ON_S390
 libbd_s390_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
 libbd_s390_la_LIBADD = $(GLIB_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_s390_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
+libbd_s390_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
+libbd_s390_la_CPPFLAGS = -I${srcdir}/../utils/
 libbd_s390_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_s390_la_SOURCES = s390.c s390.h
 endif
 
 libbd_part_la_CFLAGS = $(GLIB_CFLAGS) $(PARTED_CFLAGS) -Wall -Wextra -Werror
 libbd_part_la_LIBADD = $(GLIB_LIBS) $(PARTED_LIBS) ${builddir}/../utils/libbd_utils.la ${builddir}/libbd_part_err.la
-libbd_part_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 1:1:1 -Wl,--no-undefined
+libbd_part_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_part_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_part_la_SOURCES = part.c part.h
 
 libbd_fs_la_CFLAGS = $(GLIB_CFLAGS) $(BLKID_CFLAGS) $(PARTED_CFLAGS) $(PARTED_FS_CFLAGS) -Wall -Wextra -Werror
 libbd_fs_la_LIBADD = $(GLIB_LIBS) $(BLKID_LIBS) $(PARTED_LIBS) $(PARTED_FS_LIBS) ${builddir}/../utils/libbd_utils.la ${builddir}/libbd_part_err.la
-libbd_fs_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 0:1:0 -Wl,--no-undefined
+libbd_fs_la_LDFLAGS = -L${srcdir}/../utils/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_fs_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_fs_la_SOURCES = fs.c fs.h
 
 libbd_part_err_la_CFLAGS = $(GLIB_CFLAGS) $(PARTED_CFLAGS) $(PARTED_FS_CFLAGS) -Wall -Wextra -Werror
 libbd_part_err_la_LIBADD = $(GLIB_LIBS) $(PARTED_LIBS) $(PARTED_FS_LIBS) ${builddir}/../utils/libbd_utils.la
-libbd_part_err_la_LDFLAGS = -L${srcdir}/ -version-info 0:1:0 -Wl,--no-undefined
+libbd_part_err_la_LDFLAGS = -L${srcdir}/ -version-info 2:0:0 -Wl,--no-undefined
 libbd_part_err_la_CPPFLAGS = -I${builddir}/../../include/
 libbd_part_err_la_SOURCES = part_err.c part_err.h
 

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -1,6 +1,6 @@
 lib_LTLIBRARIES = libbd_utils.la
 libbd_utils_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
-libbd_utils_la_LDFLAGS = -version-info 4:1:2 -Wl,--no-undefined
+libbd_utils_la_LDFLAGS = -version-info 2:0:0 -Wl,--no-undefined
 libbd_utils_la_LIBADD = $(GLIB_LIBS) -lm $(GIO_LIBS)
 libbd_utils_la_SOURCES = utils.h exec.c exec.h sizes.h extra_arg.c extra_arg.h
 


### PR DESCRIPTION
This is an incomplatible release breaking the API. We need to make it clear by
bumping the library versions as well as the package version.
