### PR TITLE
Fix md_name_from_node to work with the "/dev/" prefix

### DIFF
--- a/src/plugins/mdraid.c
+++ b/src/plugins/mdraid.c
@@ -1075,7 +1075,6 @@ gchar* bd_md_node_from_name (const gchar *name, GError **error) {
  * Returns: @name of the MD RAID the device node belongs to or %NULL in case of error
  */
 gchar* bd_md_name_from_node (const gchar *node, GError **error) {
-    gchar *node_path = NULL;
     glob_t glob_buf;
     gchar **path_p;
     gboolean found = FALSE;
@@ -1083,13 +1082,11 @@ gchar* bd_md_name_from_node (const gchar *node, GError **error) {
     gchar *name = NULL;
     gchar *node_name = NULL;
 
-    if (!g_str_has_prefix (node, "/dev/"))
-        node_path = g_strdup_printf ("/dev/%s", node);
-    else
-        node_path = g_strdup (node);
+    /* get rid of the "/dev/" prefix (if any) */
+    if (g_str_has_prefix (node, "/dev/"))
+        node = node + 5;
 
     if (glob ("/dev/md/*", GLOB_NOSORT, NULL, &glob_buf) != 0) {
-        g_free (node_path);
         g_set_error (error, BD_MD_ERROR, BD_MD_ERROR_NO_MATCH,
                      "No name found for the node '%s'", node);
         return NULL;
@@ -1106,7 +1103,6 @@ gchar* bd_md_name_from_node (const gchar *node, GError **error) {
         g_free (node_name);
     }
     globfree (&glob_buf);
-    g_free (node_path);
 
     if (!found)
         g_set_error (error, BD_MD_ERROR, BD_MD_ERROR_NO_MATCH,

--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -430,6 +430,7 @@ class MDTestNameNodeBijection(MDTestCase):
 
         node = BlockDev.md_node_from_name("bd_test_md")
         self.assertEqual(BlockDev.md_name_from_node(node), "bd_test_md")
+        self.assertEqual(BlockDev.md_name_from_node("/dev/" + node), "bd_test_md")
 
         with self.assertRaises(GLib.GError):
             node = BlockDev.md_node_from_name("made_up_md")


### PR DESCRIPTION
Also update the tests to test this case.