### PR TITLE
Add xfsprogs and dosfstools as dependencies of the fs plugin

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -165,6 +165,8 @@ Summary:     Development files for the libblockdev-fs plugin/library
 Requires: %{name}-fs%{?_isa} = %{version}-%{release}
 Requires: %{name}-utils-devel%{?_isa}
 Requires: glib2-devel
+Requires: xfsprogs
+Requires: dosfstools
 
 %description fs-devel
 This package contains header files and pkg-config files needed for development


### PR DESCRIPTION
It clearly requires these packages to be installed because it needs many
utilities from them.