### PR TITLE
Extra functions for the loop plugin required by storaged

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -149,6 +149,7 @@ BDLoopError
 bd_loop_get_backing_file
 bd_loop_get_loop_name
 bd_loop_setup
+bd_loop_setup_from_fd
 bd_loop_teardown
 bd_loop_get_autoclear
 bd_loop_set_autoclear

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -150,6 +150,8 @@ bd_loop_get_backing_file
 bd_loop_get_loop_name
 bd_loop_setup
 bd_loop_teardown
+bd_loop_get_autoclear
+bd_loop_set_autoclear
 </SECTION>
 
 <SECTION>

--- a/src/lib/plugin_apis/loop.api
+++ b/src/lib/plugin_apis/loop.api
@@ -3,8 +3,8 @@
 
 #define BD_LOOP_ERROR bd_loop_error_quark ()
 typedef enum {
-    BD_LOOP_ERROR_SYS,
     BD_LOOP_ERROR_DEVICE,
+    BD_LOOP_ERROR_FAIL,
 } BDLoopError;
 
 /**
@@ -48,3 +48,22 @@ gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolea
  * Returns: whether the @loop device was successfully torn down or not
  */
 gboolean bd_loop_teardown (const gchar *loop, GError **error);
+
+/**
+ * bd_loop_get_autoclear:
+ * @loop: path or name of the loop device
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the autoclear flag is set on the @loop device or not (if %FALSE, @error may be set)
+ */
+gboolean bd_loop_get_autoclear (const gchar *loop, GError **error);
+
+/**
+ * bd_loop_set_autoclear:
+ * @loop: path or name of the loop device
+ * @autoclear: whether to set or unset the autoclear flag
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the autoclear flag was successfully set on the @loop device or not
+ */
+gboolean bd_loop_set_autoclear (const gchar *loop, gboolean autoclear, GError **error);

--- a/src/lib/plugin_apis/loop.api
+++ b/src/lib/plugin_apis/loop.api
@@ -41,6 +41,20 @@ gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
 gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
 
 /**
+ * bd_loop_setup_from_fd:
+ * @fd: file descriptor for a file to setup as a new loop device
+ * @offset: offset of the start of the device (in file given by @fd)
+ * @size: maximum size of the device (or 0 to leave unspecified)
+ * @read_only: whether to setup as read-only (%TRUE) or read-write (%FALSE)
+ * @part_scan: whether to enforce partition scan on the newly created device or not
+ * @loop_name: (allow-none) (out): if not %NULL, it is used to store the name of the loop device
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether an new loop device was successfully setup for @fd or not
+ */
+gboolean bd_loop_setup_from_fd (gint fd, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
+
+/**
  * bd_loop_teardown:
  * @loop: path or name of the loop device to tear down
  * @error: (out): place to store error (if any)

--- a/src/plugins/loop.h
+++ b/src/plugins/loop.h
@@ -28,6 +28,7 @@ void bd_loop_close ();
 gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
 gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
 gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
+gboolean bd_loop_setup_from_fd (gint fd, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
 gboolean bd_loop_teardown (const gchar *loop, GError **error);
 
 gboolean bd_loop_get_autoclear (const gchar *loop, GError **error);

--- a/src/plugins/loop.h
+++ b/src/plugins/loop.h
@@ -9,6 +9,7 @@ GQuark bd_loop_error_quark (void);
 #define BD_LOOP_ERROR bd_loop_error_quark ()
 typedef enum {
     BD_LOOP_ERROR_DEVICE,
+    BD_LOOP_ERROR_FAIL,
 } BDLoopError;
 
 /*
@@ -28,5 +29,8 @@ gchar* bd_loop_get_backing_file (const gchar *dev_name, GError **error);
 gchar* bd_loop_get_loop_name (const gchar *file, GError **error);
 gboolean bd_loop_setup (const gchar *file, guint64 offset, guint64 size, gboolean read_only, gboolean part_scan, const gchar **loop_name, GError **error);
 gboolean bd_loop_teardown (const gchar *loop, GError **error);
+
+gboolean bd_loop_get_autoclear (const gchar *loop, GError **error);
+gboolean bd_loop_set_autoclear (const gchar *loop, gboolean autoclear, GError **error);
 
 #endif  /* BD_LOOP */

--- a/tests/loop_test.py
+++ b/tests/loop_test.py
@@ -100,6 +100,34 @@ class LoopTestGetBackingFile(LoopTestCase):
         f_name = BlockDev.loop_get_backing_file(self.loop)
         self.assertEqual(f_name, self.dev_file)
 
+class LoopTestGetSetAutoclear(LoopTestCase):
+    def testLoop_get_set_autoclear(self):
+        """Verify that getting and setting the autoclear flag works as expected"""
+
+        with self.assertRaises(GLib.Error):
+            BlockDev.loop_get_autoclear("/non/existing")
+
+        with self.assertRaises(GLib.Error):
+            BlockDev.loop_set_autoclear("/non/existing", True)
+
+        succ, self.loop = BlockDev.loop_setup(self.dev_file)
+        self.assertFalse(BlockDev.loop_get_autoclear(self.loop))
+
+        self.assertTrue(BlockDev.loop_set_autoclear(self.loop, True))
+        self.assertTrue(BlockDev.loop_get_autoclear(self.loop))
+
+        self.assertTrue(BlockDev.loop_set_autoclear(self.loop, False))
+        self.assertFalse(BlockDev.loop_get_autoclear(self.loop))
+
+        # now the same, but with the "/dev/" prefix
+        loop = "/dev/" + self.loop
+        self.assertTrue(BlockDev.loop_set_autoclear(loop, True))
+        self.assertTrue(BlockDev.loop_get_autoclear(loop))
+
+        self.assertTrue(BlockDev.loop_set_autoclear(loop, False))
+        self.assertFalse(BlockDev.loop_get_autoclear(loop))
+
+
 class LoopUnloadTest(unittest.TestCase):
     def setUp(self):
         # make sure the library is initialized with all plugins loaded for other


### PR DESCRIPTION
There are basically two things required by storaged which are not currently provided by the loop plugin:

- [x] functions to get/set the *autoclear* attribute
- [x] function to setup a loop device from/on a file descriptor