### PR TITLE
Make sure bcache functions are correctly provided or not

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,7 +144,7 @@ AC_ARG_WITH([bcache],
 AC_SUBST([WITH_BCACHE], [0])
 AM_CONDITIONAL(WITH_BCACHE, test "x$with_bcache" != "xno")
 AS_IF([test "x$with_bcache" != "xno"],
-      [AC_DEFINE([WITH_BCACHE], [], [Define if bcache is supported]) AC_SUBST([WITH_BCACHE], [1])],
+      [AC_DEFINE([WITH_BD_BCACHE], [], [Define if bcache is supported]) AC_SUBST([WITH_BCACHE], [1]) AC_SUBST([WITH_BCACHE_CFLAGS], [-DWITH_BD_BCACHE])],
       [skip_patterns="$skip_patterns bcache"])
 
 AC_SUBST([skip_patterns], [$skip_patterns])

--- a/src/lib/blockdev.pc.in
+++ b/src/lib/blockdev.pc.in
@@ -9,3 +9,4 @@ URL: https://github.com/rhinstaller/libblockdev
 Version: 2.0
 Requires: glib-2.0
 Libs: -lblockdev
+Cflags: @WITH_BCACHE_CFLAGS@

--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -38,7 +38,7 @@
  * A plugin for operations with kernel block devices.
  */
 
-#ifdef WITH_BCACHE
+#ifdef WITH_BD_BCACHE
 static const gchar * const mode_str[BD_KBD_MODE_UNKNOWN+1] = {"writethrough", "writeback", "writearound", "none", "unknown"};
 #endif
 
@@ -71,7 +71,7 @@ gboolean bd_kbd_check_deps () {
     if (!ret)
         return FALSE;
 
-#ifdef WITH_BCACHE
+#ifdef WITH_BD_BCACHE
     ret = bd_utils_check_util_version ("make-bcache", NULL, NULL, NULL, &error);
     if (!ret && error) {
         g_warning("Cannot load the kbd plugin: %s" , error->message);
@@ -134,7 +134,7 @@ void bd_kbd_zram_stats_free (BDKBDZramStats *data) {
     g_free (data);
 }
 
-#ifdef WITH_BCACHE
+#ifdef WITH_BD_BCACHE
 BDKBDBcacheStats* bd_kbd_bcache_stats_copy (BDKBDBcacheStats *data) {
     BDKBDBcacheStats *new = g_new0 (BDKBDBcacheStats, 1);
 
@@ -662,7 +662,7 @@ BDKBDZramStats* bd_kbd_zram_get_stats (const gchar *device, GError **error) {
 }
 
 
-#ifdef WITH_BCACHE
+#ifdef WITH_BD_BCACHE
 /**
  * bd_kbd_bcache_create:
  * @backing_device: backing (slow) device of the cache

--- a/src/plugins/kbd.h
+++ b/src/plugins/kbd.h
@@ -24,7 +24,7 @@ typedef enum {
     BD_KBD_ERROR_BCACHE_INVAL,
 } BDKBDError;
 
-#ifdef WITH_BCACHE
+#ifdef WITH_BD_BCACHE
 typedef enum {
     BD_KBD_MODE_WRITETHROUGH,
     BD_KBD_MODE_WRITEBACK,
@@ -51,7 +51,7 @@ typedef struct BDKBDZramStats {
 BDKBDZramStats* bd_kbd_zram_stats_copy (BDKBDZramStats *data);
 void bd_kbd_zram_stats_free (BDKBDZramStats *data);
 
-#ifdef WITH_BCACHE
+#ifdef WITH_BD_BCACHE
 typedef struct BDKBDBcacheStats {
     gchar *state;
     guint64 block_size;
@@ -86,7 +86,7 @@ gboolean bd_kbd_zram_add_device (guint64 size, guint64 nstreams, gchar **device,
 gboolean bd_kbd_zram_remove_device (const gchar *device, GError **error);
 BDKBDZramStats* bd_kbd_zram_get_stats (const gchar *device, GError **error);
 
-#ifdef WITH_BCACHE
+#ifdef WITH_BD_BCACHE
 gboolean bd_kbd_bcache_create (const gchar *backing_device, const gchar *cache_device, const BDExtraArg **extra, const gchar **bcache_device, GError **error);
 gboolean bd_kbd_bcache_attach (const gchar *c_set_uuid, const gchar *bcache_device, GError **error);
 gboolean bd_kbd_bcache_detach (const gchar *bcache_device, gchar **c_set_uuid, GError **error);


### PR DESCRIPTION
When compiling libblockdev, we define macros to make sure bcache support is
compiled in or not. However, when the library is built and we ship the header
files, there's no way to determine if the bcache support is built in or not and
the macros are of course no longer defined. By providing cflags for compiling
things with libblockdev, we can propagate the information if bcache is supported
or not.