### PR TITLE
Reimplement swapon/swapoff functions by using syscalls

### DIFF
--- a/src/plugins/swap.h
+++ b/src/plugins/swap.h
@@ -5,8 +5,6 @@
 #define BD_SWAP
 
 #define MKSWAP_MIN_VERSION "2.23.2"
-#define SWAPON_MIN_VERSION "2.23.2"
-#define SWAPOFF_MIN_VERSION "2.23.2"
 
 GQuark bd_swap_error_quark (void);
 #define BD_SWAP_ERROR bd_swap_error_quark ()

--- a/tests/swap_test.py
+++ b/tests/swap_test.py
@@ -120,37 +120,3 @@ class SwapUnloadTest(unittest.TestCase):
         # load the plugins back
         self.assertTrue(BlockDev.reinit(None, True, None))
         self.assertIn("swap", BlockDev.get_available_plugin_names())
-
-    def test_check_no_swapon(self):
-        """Verify that checking swapon tool availability works as expected"""
-
-        # unload all plugins first
-        self.assertTrue(BlockDev.reinit([], True, None))
-
-        with fake_path("tests/swap_no_swapon", keep_utils=["cat"]):
-            # no mkswap available, the swap plugin should fail to load
-            with self.assertRaises(GLib.GError):
-                BlockDev.reinit(None, True, None)
-
-            self.assertNotIn("swap", BlockDev.get_available_plugin_names())
-
-        # load the plugins back
-        self.assertTrue(BlockDev.reinit(None, True, None))
-        self.assertIn("swap", BlockDev.get_available_plugin_names())
-
-    def test_check_no_swapoff(self):
-        """Verify that checking swapoff tool availability works as expected"""
-
-        # unload all plugins first
-        self.assertTrue(BlockDev.reinit([], True, None))
-
-        with fake_path("tests/swap_no_swapoff", keep_utils=["cat"]):
-            # no mkswap available, the swap plugin should fail to load
-            with self.assertRaises(GLib.GError):
-                BlockDev.reinit(None, True, None)
-
-            self.assertNotIn("swap", BlockDev.get_available_plugin_names())
-
-        # load the plugins back
-        self.assertTrue(BlockDev.reinit(None, True, None))
-        self.assertIn("swap", BlockDev.get_available_plugin_names())


### PR DESCRIPTION
The kernel API for swap (de)activation is very simple and
straightforward. There's no need to fork and exec the swapon/swapoff utilities,
we can use the system calls directly.