### PR TITLE
Try harder to register a new bcache device

### DIFF
--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -226,7 +226,6 @@ class KbdBcacheTestCase(unittest.TestCase):
         os.unlink(self.dev_file2)
 
 class KbdTestBcacheCreate(KbdBcacheTestCase):
-    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     def test_bcache_create_destroy(self):
         """Verify that it's possible to create and destroy a bcache device"""
 
@@ -244,7 +243,6 @@ class KbdTestBcacheCreate(KbdBcacheTestCase):
 
         wipe_all(self.loop_dev, self.loop_dev2)
 
-    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     def test_bcache_create_destroy_full_path(self):
         """Verify that it's possible to create and destroy a bcache device with full device path"""
 


### PR DESCRIPTION
Sometimes the /sys/.../register file doesn't exist when we try to write to
it. Let's give it a chance to appear in some sensible time frame. With some luck
the file appears and the bcache device is successfully registered (and then
properly created and set up).

Also enable some of the risky tests that seem to have been failing due to the
issue fixed here.