### PR TITLE
Allow using both path and raid name in bd_md_set_bitmap_location

### DIFF
--- a/src/lib/plugin_apis/mdraid.api
+++ b/src/lib/plugin_apis/mdraid.api
@@ -407,7 +407,7 @@ gboolean bd_md_set_bitmap_location (const gchar *raid_name, const gchar *locatio
 
 /**
  * bd_md_get_bitmap_location:
- * @raid_name: name of the RAID device to get the bitmap location
+ * @raid_name: name or path of the RAID device to get the bitmap location
  * @error: (out): place to store error (if any)
  *
  * Returns: bitmap location for @raid_name

--- a/tests/mdraid_test.py
+++ b/tests/mdraid_test.py
@@ -476,6 +476,22 @@ class MDTestSetBitmapLocation(MDTestCase):
         loc = BlockDev.md_get_bitmap_location("bd_test_md")
         self.assertEqual(loc, "+8")
 
+        # test some different name specifications
+        # (need to switch between internal and none because setting the same
+        # location multiple times results in an error)
+        succ = BlockDev.md_set_bitmap_location("/dev/md/bd_test_md", "none")
+        self.assertTrue(succ)
+
+        node = BlockDev.md_node_from_name("bd_test_md")
+        self.assertIsNotNone(node)
+
+        succ = BlockDev.md_set_bitmap_location(node, "internal")
+        self.assertTrue(succ)
+
+        succ = BlockDev.md_set_bitmap_location("/dev/%s" % node, "none")
+        self.assertTrue(succ)
+
+
 class MDTestRequestSyncAction(MDTestCase):
     @unittest.skipIf("SKIP_SLOW" in os.environ, "skipping slow tests")
     def test_request_sync_action(self):


### PR DESCRIPTION
'mdadm --grow' accepts either '/dev/mdXXX' or '/dev/md/name' so
allow using both name (or just node name) and full path from
libblockdev.