### PR TITLE
Add functions using BLOBs as LUKS passphrases

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -66,11 +66,16 @@ bd_crypto_device_is_luks
 bd_crypto_luks_uuid
 bd_crypto_luks_status
 bd_crypto_luks_format
+bd_crypto_luks_format_blob
 bd_crypto_luks_open
+bd_crypto_luks_open_blob
 bd_crypto_luks_close
 bd_crypto_luks_add_key
+bd_crypto_luks_add_key_blob
 bd_crypto_luks_remove_key
+bd_crypto_luks_remove_key_blob
 bd_crypto_luks_change_key
+bd_crypto_luks_change_key_blob
 bd_crypto_luks_resize
 bd_crypto_escrow_device
 </SECTION>

--- a/src/lib/plugin_apis/crypto.api
+++ b/src/lib/plugin_apis/crypto.api
@@ -86,6 +86,26 @@ gchar* bd_crypto_luks_status (const gchar *luks_device, GError **error);
 gboolean bd_crypto_luks_format (const gchar *device, const gchar *cipher, guint64 key_size, const gchar *passphrase, const gchar *key_file, guint64 min_entropy, GError **error);
 
 /**
+ * bd_crypto_luks_format_blob:
+ * @device: a device to format as LUKS
+ * @cipher: (allow-none): cipher specification (type-mode, e.g. "aes-xts-plain64") or %NULL to use the default
+ * @key_size: size of the volume key in bits or 0 to use the default
+ * @pass_data: (array length=data_len): a passphrase for the new LUKS device (may contain arbitrary binary data)
+ * @data_len: length of the @pass_data buffer
+ * @min_entropy: minimum random data entropy (in bits) required to format @device as LUKS
+ * @error: (out): place to store error (if any)
+ *
+ * Formats the given @device as LUKS according to the other parameters given. If
+ * @min_entropy is specified (greater than 0), the function waits for enough
+ * entropy to be available in the random data pool (WHICH MAY POTENTIALLY TAKE
+ * FOREVER).
+ *
+ * Returns: whether the given @device was successfully formatted as LUKS or not
+ * (the @error) contains the error in such cases)
+ */
+gboolean bd_crypto_luks_format_blob (const gchar *device, const gchar *cipher, guint64 key_size, const guint8 *pass_data, gsize data_len, guint64 min_entropy, GError **error);
+
+/**
  * bd_crypto_luks_open:
  * @device: the device to open
  * @name: name for the LUKS device
@@ -99,6 +119,20 @@ gboolean bd_crypto_luks_format (const gchar *device, const gchar *cipher, guint6
  * One of @passphrase, @key_file has to be != %NULL.
  */
 gboolean bd_crypto_luks_open (const gchar *device, const gchar *name, const gchar *passphrase, const gchar *key_file, gboolean read_only, GError **error);
+
+/**
+ * bd_crypto_luks_open_blob:
+ * @device: the device to open
+ * @name: name for the LUKS device
+ * @pass_data: (array length=data_len): a passphrase for the new LUKS device (may contain arbitrary binary data)
+ * @data_len: length of the @pass_data buffer
+ * @read_only: whether to open as read-only or not (meaning read-write)
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @device was successfully opened or not
+ *
+ */
+gboolean bd_crypto_luks_open_blob (const gchar *device, const gchar *name, const guint8* pass_data, gsize data_len, gboolean read_only, GError **error);
 
 /**
  * bd_crypto_luks_close:
@@ -127,6 +161,20 @@ gboolean bd_crypto_luks_close (const gchar *luks_device, GError **error);
 gboolean bd_crypto_luks_add_key (const gchar *device, const gchar *pass, const gchar *key_file, const gchar *npass, const gchar *nkey_file, GError **error);
 
 /**
+ * bd_crypto_luks_add_key_blob:
+ * @device: device to add new key to
+ * @pass_data: (array length=data_len): a passphrase for the new LUKS device (may contain arbitrary binary data)
+ * @data_len: length of the @pass_data buffer
+ * @npass_data: (array length=ndata_len): a new passphrase for the new LUKS device (may contain arbitrary binary data)
+ * @ndata_len: length of the @npass_data buffer
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the @npass_data was successfully added to @device or not
+ *
+ */
+gboolean bd_crypto_luks_add_key_blob (const gchar *device, const guint8 *pass_data, gsize data_len, const guint8 *npass_data, gsize ndata_len, GError **error);
+
+/**
  * bd_crypto_luks_remove_key:
  * @device: device to add new key to
  * @pass: (allow-none): passphrase for the @device or %NULL
@@ -140,6 +188,20 @@ gboolean bd_crypto_luks_add_key (const gchar *device, const gchar *pass, const g
 gboolean bd_crypto_luks_remove_key (const gchar *device, const gchar *pass, const gchar *key_file, GError **error);
 
 /**
+ * bd_crypto_luks_remove_key_blob:
+ * @device: device to add new key to
+ * @pass_data: (array length=data_len): a passphrase for the new LUKS device (may contain arbitrary binary data) to remove
+ * @data_len: length of the @pass_data buffer
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the key was successfully removed or not
+ *
+ * Either @pass or @key_file has to be != %NULL.
+ */
+gboolean bd_crypto_luks_remove_key_blob (const gchar *device, const guint8 *pass_data, gsize data_len, GError **error);
+
+
+/**
  * bd_crypto_luks_change_key:
  * @device: device to change key of
  * @pass: old passphrase
@@ -151,6 +213,20 @@ gboolean bd_crypto_luks_remove_key (const gchar *device, const gchar *pass, cons
  * No support for changing key files (yet).
  */
 gboolean bd_crypto_luks_change_key (const gchar *device, const gchar *pass, const gchar *npass, GError **error);
+
+/**
+ * bd_crypto_luks_change_key_blob:
+ * @device: device to change key of
+ * @pass_data: (array length=data_len): a passphrase for the new LUKS device (may contain arbitrary binary data)
+ * @data_len: length of the @pass_data buffer
+ * @npass_data: (array length=ndata_len): a new passphrase for the new LUKS device (may contain arbitrary binary data)
+ * @ndata_len: length of the @npass_data buffer
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether the key was successfully changed or not
+ *
+ */
+gboolean bd_crypto_luks_change_key_blob (const gchar *device, const guint8 *pass_data, gsize data_len, const guint8 *npass_data, gsize ndata_len, GError **error);
 
 /**
  * bd_crypto_luks_resize:

--- a/src/plugins/crypto.h
+++ b/src/plugins/crypto.h
@@ -50,11 +50,16 @@ gboolean bd_crypto_device_is_luks (const gchar *device, GError **error);
 gchar* bd_crypto_luks_uuid (const gchar *device, GError **error);
 gchar* bd_crypto_luks_status (const gchar *luks_device, GError **error);
 gboolean bd_crypto_luks_format (const gchar *device, const gchar *cipher, guint64 key_size, const gchar *passphrase, const gchar *key_file, guint64 min_entropy, GError **error);
+gboolean bd_crypto_luks_format_blob (const gchar *device, const gchar *cipher, guint64 key_size, const guint8 *pass_data, gsize data_len, guint64 min_entropy, GError **error);
 gboolean bd_crypto_luks_open (const gchar *device, const gchar *name, const gchar *passphrase, const gchar *key_file, gboolean read_only, GError **error);
+gboolean bd_crypto_luks_open_blob (const gchar *device, const gchar *name, const guint8* pass_data, gsize data_len, gboolean read_only, GError **error);
 gboolean bd_crypto_luks_close (const gchar *luks_device, GError **error);
 gboolean bd_crypto_luks_add_key (const gchar *device, const gchar *pass, const gchar *key_file, const gchar *npass, const gchar *nkey_file, GError **error);
+gboolean bd_crypto_luks_add_key_blob (const gchar *device, const guint8 *pass_data, gsize data_len, const guint8 *npass_data, gsize ndata_len, GError **error);
 gboolean bd_crypto_luks_remove_key (const gchar *device, const gchar *pass, const gchar *key_file, GError **error);
+gboolean bd_crypto_luks_remove_key_blob (const gchar *device, const guint8 *pass_data, gsize data_len, GError **error);
 gboolean bd_crypto_luks_change_key (const gchar *device, const gchar *pass, const gchar *npass, GError **error);
+gboolean bd_crypto_luks_change_key_blob (const gchar *device, const guint8 *pass_data, gsize data_len, const guint8 *npass_data, gsize ndata_len, GError **error);
 gboolean bd_crypto_luks_resize (const gchar *device, guint64 size, GError **error);
 gboolean bd_crypto_escrow_device (const gchar *device, const gchar *passphrase, const gchar *cert_data, const gchar *directory, const gchar *backup_passphrase, GError **error);
 

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -83,6 +83,10 @@ class CryptoTestFormat(CryptoTestCase):
         succ = BlockDev.crypto_luks_format(self.loop_dev, "aes-cbc-essiv:sha256", 0, None, self.keyfile, 0)
         self.assertTrue(succ)
 
+        # the simple case with password blob
+        succ = BlockDev.crypto_luks_format_blob(self.loop_dev, "aes-cbc-essiv:sha256", 0, [ord(c) for c in PASSWD], 0)
+        self.assertTrue(succ)
+
 class CryptoTestResize(CryptoTestCase):
     @unittest.skipIf("SKIP_SLOW" in os.environ, "skipping slow tests")
     def test_resize(self):
@@ -154,6 +158,9 @@ class CryptoTestAddKey(CryptoTestCase):
         succ = BlockDev.crypto_luks_add_key(self.loop_dev, PASSWD, None, PASSWD2, None)
         self.assertTrue(succ)
 
+        succ = BlockDev.crypto_luks_add_key_blob(self.loop_dev, [ord(c) for c in PASSWD2], [ord(c) for c in PASSWD3])
+        self.assertTrue(succ)
+
 class CryptoTestRemoveKey(CryptoTestCase):
     @unittest.skipIf("SKIP_SLOW" in os.environ, "skipping slow tests")
     def test_remove_key(self):
@@ -165,10 +172,16 @@ class CryptoTestRemoveKey(CryptoTestCase):
         succ = BlockDev.crypto_luks_add_key(self.loop_dev, PASSWD, None, PASSWD2, None)
         self.assertTrue(succ)
 
+        succ = BlockDev.crypto_luks_add_key(self.loop_dev, PASSWD, None, PASSWD3, None)
+        self.assertTrue(succ)
+
         with self.assertRaises(GLib.GError):
             BlockDev.crypto_luks_remove_key(self.loop_dev, "wrong-passphrase", None)
 
         succ = BlockDev.crypto_luks_remove_key(self.loop_dev, PASSWD, None)
+        self.assertTrue(succ)
+
+        succ = BlockDev.crypto_luks_remove_key_blob(self.loop_dev, [ord(c) for c in PASSWD2])
         self.assertTrue(succ)
 
 class CryptoTestErrorLocale(CryptoTestCase):
@@ -204,6 +217,9 @@ class CryptoTestChangeKey(CryptoTestCase):
         self.assertTrue(succ)
 
         succ = BlockDev.crypto_luks_change_key(self.loop_dev, PASSWD, PASSWD2)
+        self.assertTrue(succ)
+
+        succ = BlockDev.crypto_luks_change_key_blob(self.loop_dev, [ord(c) for c in PASSWD2], [ord(c) for c in PASSWD3])
         self.assertTrue(succ)
 
 class CryptoTestIsLuks(CryptoTestCase):


### PR DESCRIPTION
A LUKS passphrase can be an arbitrary sequence of bytes including '\0' (0) bytes
which are terminating strings in C. If we take the passphrase argument as
'gchar *', we need it to be '\0'-terminated otherwise we don't know its
length. We need a set of new functions taking the passphrase argument as
'guint8 *' together with its length (gsize) if we want to support arbitrary
sequences of bytes as LUKS passphrases.

Note: this is required by https://github.com/storaged-project/udisks/pull/195