### PR TITLE
Add function for getting recommended thpool metadata size

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -239,6 +239,8 @@ with the libblockdev-loop plugin/library.
 Summary:     The LVM plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} >= 0.11
 Requires: lvm2
+# for thin_metadata_size
+Requires: device-mapper-persistent-data
 
 %description lvm
 The libblockdev library plugin (and in the same time a standalone library)
@@ -258,6 +260,8 @@ with the libblockdev-lvm plugin/library.
 Summary:     The LVM plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} >= 1.4
 Requires: lvm2-dbusd >= 2.02.156
+# for thin_metadata_size
+Requires: device-mapper-persistent-data
 
 %description lvm-dbus
 The libblockdev library plugin (and in the same time a standalone library)

--- a/src/lib/plugin_apis/lvm.api
+++ b/src/lib/plugin_apis/lvm.api
@@ -21,6 +21,7 @@
 #define BD_LVM_MAX_THPOOL_MD_SIZE (16 GiB)
 #define BD_LVM_MIN_THPOOL_CHUNK_SIZE (64 KiB)
 #define BD_LVM_MAX_THPOOL_CHUNK_SIZE (1 GiB)
+#define BD_LVM_DEFAULT_CHUNK_SIZE (64 KiB)
 
 /* according to lvmcache (7) */
 #define BD_LVM_MIN_CACHE_MD_SIZE (8 MiB)
@@ -442,6 +443,18 @@ guint64 bd_lvm_get_lv_physical_size (guint64 lv_size, guint64 pe_size, GError **
  *         according to the @pe_size and @included
  */
 guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean included, GError **error);
+
+/**
+ * bd_lvm_get_thpool_meta_size:
+ * @size: size of the thin pool
+ * @chunk_size: chunk size of the thin pool or 0 to use the default (%BD_LVM_DEFAULT_CHUNK_SIZE)
+ * @n_snapshots: number of snapshots that will be created in the pool
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: recommended size of the metadata space for the specified pool or 0
+ *          in case of error
+ */
+guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n_snapshots, GError **error);
 
 /**
  * bd_lvm_is_valid_thpool_md_size:

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -164,12 +164,23 @@ void bd_lvm_cache_stats_free (BDLVMCacheStats *data) {
  */
 gboolean bd_lvm_check_deps () {
     GError *error = NULL;
-    gboolean ret = bd_utils_check_util_version ("lvm", LVM_MIN_VERSION, "version", "LVM version:\\s+([\\d\\.]+)", &error);
+    gboolean success = FALSE;
+    gboolean ret = FALSE;
 
-    if (!ret && error) {
+    success = bd_utils_check_util_version ("lvm", LVM_MIN_VERSION, "version", "LVM version:\\s+([\\d\\.]+)", &error);
+    if (!success && error) {
         g_warning("Cannot load the LVM plugin: %s" , error->message);
         g_clear_error (&error);
     }
+    ret = success;
+
+    success = bd_utils_check_util_version ("thin_metadata_size", NULL, NULL, NULL, &error);
+    if (!success && error) {
+        g_warning("Cannot load the LVM plugin: %s" , error->message);
+        g_clear_error (&error);
+    }
+    ret = ret && success;
+
     return ret;
 }
 
@@ -559,6 +570,52 @@ guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean inclu
 
     return MIN (bd_lvm_round_size_to_pe(raw_md_size, pe_size, TRUE, error),
                 bd_lvm_round_size_to_pe(BD_LVM_MAX_THPOOL_MD_SIZE, pe_size, TRUE, error));
+}
+
+/**
+ * bd_lvm_get_thpool_meta_size:
+ * @size: size of the thin pool
+ * @chunk_size: chunk size of the thin pool or 0 to use the default (%BD_LVM_DEFAULT_CHUNK_SIZE)
+ * @n_snapshots: number of snapshots that will be created in the pool
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: recommended size of the metadata space for the specified pool or 0
+ *          in case of error
+ */
+guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n_snapshots, GError **error) {
+    /* ub - output in bytes, n - output just the number */
+    const gchar* args[7] = {"thin_metadata_size", "-ub", "-n", NULL, NULL, NULL, NULL};
+    gchar *output = NULL;
+    gboolean success = FALSE;
+    guint64 ret = 0;
+
+    /* s - total size, b - chunk size, m - number of snapshots */
+    args[3] = g_strdup_printf ("-s%"G_GUINT64_FORMAT, size);
+    args[4] = g_strdup_printf ("-b%"G_GUINT64_FORMAT,
+                               chunk_size != 0 ? chunk_size : (guint64) BD_LVM_DEFAULT_CHUNK_SIZE);
+    args[5] = g_strdup_printf ("-m%"G_GUINT64_FORMAT, n_snapshots);
+
+    success = bd_utils_exec_and_capture_output (args, NULL, &output, error);
+    g_free ((gchar*) args[3]);
+    g_free ((gchar*) args[4]);
+    g_free ((gchar*) args[5]);
+
+    if (!success) {
+        /* error is already set */
+        g_free (output);
+        return 0;
+    }
+
+    ret = g_ascii_strtoull (output, NULL, 0);
+    g_free (output);
+    if (ret == 0) {
+        g_set_error (error, BD_LVM_ERROR, BD_LVM_ERROR_PARSE,
+                     "Failed to parse number from thin_metadata_size's output: '%s'",
+                     output);
+        return 0;
+    }
+
+    return ret;
 }
 
 /**

--- a/src/plugins/lvm.h
+++ b/src/plugins/lvm.h
@@ -25,6 +25,8 @@
 #define BD_LVM_MAX_THPOOL_MD_SIZE (16 GiB)
 #define BD_LVM_MIN_THPOOL_CHUNK_SIZE (64 KiB)
 #define BD_LVM_MAX_THPOOL_CHUNK_SIZE (1 GiB)
+#define BD_LVM_DEFAULT_CHUNK_SIZE (64 KiB)
+
 #define THPOOL_MD_FACTOR_NEW (0.2)
 #define THPOOL_MD_FACTOR_EXISTS (1 / 6.0)
 
@@ -152,6 +154,7 @@ guint64 bd_lvm_get_max_lv_size (GError **error);
 guint64 bd_lvm_round_size_to_pe (guint64 size, guint64 pe_size, gboolean roundup, GError **error);
 guint64 bd_lvm_get_lv_physical_size (guint64 lv_size, guint64 pe_size, GError **error);
 guint64 bd_lvm_get_thpool_padding (guint64 size, guint64 pe_size, gboolean included, GError **error);
+guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n_snapshots, GError **error);
 gboolean bd_lvm_is_valid_thpool_md_size (guint64 size, GError **error);
 gboolean bd_lvm_is_valid_thpool_chunk_size (guint64 size, gboolean discard, GError **error);
 

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -331,7 +331,7 @@ class LibraryOpsTestCase(unittest.TestCase):
 
         # try reinitializing with only some utilities being available and thus
         # only some plugins able to load
-        with fake_path("tests/lib_missing_utils", keep_utils=["swapon", "swapoff", "mkswap", "lvm", "btrfs"]):
+        with fake_path("tests/lib_missing_utils", keep_utils=["swapon", "swapoff", "mkswap", "lvm", "btrfs", "thin_metadata_size"]):
             succ, loaded = BlockDev.try_reinit(None, True, None)
             self.assertFalse(succ)
             for plug_name in ("swap", "lvm", "btrfs"):
@@ -342,7 +342,7 @@ class LibraryOpsTestCase(unittest.TestCase):
 
         # now the same with a subset of plugins requested
         plugins = BlockDev.plugin_specs_from_names(["btrfs", "lvm", "swap"])
-        with fake_path("tests/lib_missing_utils", keep_utils=["swapon", "swapoff", "mkswap", "lvm", "btrfs"]):
+        with fake_path("tests/lib_missing_utils", keep_utils=["swapon", "swapoff", "mkswap", "lvm", "btrfs", "thin_metadata_size"]):
             succ, loaded = BlockDev.try_reinit(plugins, True, None)
             self.assertTrue(succ)
             self.assertEqual(set(loaded), set(["swap", "lvm", "btrfs"]))

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -5,6 +5,7 @@ import math
 import overrides_hack
 import six
 import re
+import subprocess
 from itertools import chain
 
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device
@@ -114,6 +115,20 @@ class LvmNoDevTestCase(unittest.TestCase):
                                                          4 * 1024**2, True)
         self.assertEqual(BlockDev.lvm_get_thpool_padding(11 * 1024**2, 4 * 1024**2, True),
                          expected_padding)
+
+    def test_get_thpool_meta_size(self):
+        """Verify that getting recommended thin pool metadata size works as expected"""
+
+        # no idea how thin_metadata_size works, but let's at least check that
+        # the function works and returns what thin_metadata_size says
+        out1 = subprocess.check_output(["thin_metadata_size", "-ub", "-n", "-b64k", "-s1t", "-m100"])
+        self.assertEqual(int(out1), BlockDev.lvm_get_thpool_meta_size (1 * 1024**4, 64 * 1024, 100))
+
+        out2 = subprocess.check_output(["thin_metadata_size", "-ub", "-n", "-b128k", "-s1t", "-m100"])
+        self.assertEqual(int(out2), BlockDev.lvm_get_thpool_meta_size (1 * 1024**4, 128 * 1024, 100))
+
+        # twice the chunk_size -> roughly half the metadata needed
+        self.assertAlmostEqual(float(out1) / float(out2), 2, places=2)
 
     def test_is_valid_thpool_md_size(self):
         """Verify that is_valid_thpool_md_size works as expected"""

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -5,6 +5,7 @@ import math
 import overrides_hack
 import six
 import re
+import subprocess
 
 from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, fake_utils, fake_path
 from gi.repository import BlockDev, GLib
@@ -98,6 +99,20 @@ class LvmNoDevTestCase(unittest.TestCase):
                                                          4 * 1024**2, True)
         self.assertEqual(BlockDev.lvm_get_thpool_padding(11 * 1024**2, 4 * 1024**2, True),
                          expected_padding)
+
+    def test_get_thpool_meta_size(self):
+        """Verify that getting recommended thin pool metadata size works as expected"""
+
+        # no idea how thin_metadata_size works, but let's at least check that
+        # the function works and returns what thin_metadata_size says
+        out1 = subprocess.check_output(["thin_metadata_size", "-ub", "-n", "-b64k", "-s1t", "-m100"])
+        self.assertEqual(int(out1), BlockDev.lvm_get_thpool_meta_size (1 * 1024**4, 64 * 1024, 100))
+
+        out2 = subprocess.check_output(["thin_metadata_size", "-ub", "-n", "-b128k", "-s1t", "-m100"])
+        self.assertEqual(int(out2), BlockDev.lvm_get_thpool_meta_size (1 * 1024**4, 128 * 1024, 100))
+
+        # twice the chunk_size -> roughly half the metadata needed
+        self.assertAlmostEqual(float(out1) / float(out2), 2, places=2)
 
     def test_is_valid_thpool_md_size(self):
         """Verify that is_valid_thpool_md_size works as expected"""


### PR DESCRIPTION
So that it can be shown to users for confirmation or simply
because the caller code may need to make sure everything fits in
the space available in a VG when creating thin pool.

Resolves: #167