### PR TITLE
Add the bd_s390_dasd_is_fba function to check if DASD is FBA

### DIFF
--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -459,6 +459,7 @@ bd_s390_dasd_needs_format
 bd_s390_sanitize_dev_input
 bd_s390_dasd_online
 bd_s390_dasd_is_ldl
+bd_s390_dasd_is_fba
 bd_s390_zfcp_sanitize_wwpn_input
 bd_s390_zfcp_sanitize_lun_input
 bd_s390_zfcp_online

--- a/features.rst
+++ b/features.rst
@@ -247,6 +247,7 @@ s390
    * s390_dasd_needs_format
    * s390_dasd_online
    * s390_dasd_is_ldl
+   * s390_dasd_is_fba
    * s390_sanitize_dev_input
    * s390_zfcp_sanitize_wwpn_input
    * s390_zfcp_sanitize_lun_input

--- a/src/lib/plugin_apis/s390.api
+++ b/src/lib/plugin_apis/s390.api
@@ -57,6 +57,15 @@ gboolean bd_s390_dasd_online (const gchar *dasd, GError **error);
 gboolean bd_s390_dasd_is_ldl (const gchar *dasd, GError **error);
 
 /**
+ * bd_s390_dasd_is_fba:
+ * @dasd: dasd to check, whether it is FBA
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a dasd is FBA
+ */
+gboolean bd_s390_dasd_is_fba (const gchar *dasd, GError **error);
+
+/**
  * bd_s390_sanitize_dev_input:
  * @dev a DASD or zFCP device number
  * @error: (out): place to store error (if any)

--- a/src/plugins/s390.c
+++ b/src/plugins/s390.c
@@ -290,6 +290,57 @@ gboolean bd_s390_dasd_is_ldl (const gchar *dasd, GError **error) {
 }
 
 /**
+ * bd_s390_dasd_is_fba:
+ * @dasd: dasd to check, whether it is FBA
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: whether a dasd is FBA
+ */
+gboolean bd_s390_dasd_is_fba (const gchar *dasd, GError **error) {
+    gchar *devname = NULL;
+    gint f = 0;
+    gint blksize = 0;
+    dasd_information2_t dasd_info;
+
+    memset(&dasd_info, 0, sizeof(dasd_info));
+
+    /* complete the device name */
+    if (g_str_has_prefix (dasd, "/dev/")) {
+        devname = g_strdup (dasd);
+    }
+    else {
+        devname = g_strdup_printf ("/dev/%s", dasd);
+    }
+
+    /* open the device */
+    if ((f = open(devname, O_RDONLY)) == -1) {
+        g_set_error (error, BD_S390_ERROR, BD_S390_ERROR_DEVICE,
+                     "Unable to open device %s", devname);
+        g_free (devname);
+        return FALSE;
+    }
+
+    g_free (devname);
+
+    /* check if this is a block device */
+    if (ioctl(f, BLKSSZGET, &blksize) != 0) {
+        close(f);
+        return FALSE;
+    }
+
+    /* get some info about DASD */
+    if (ioctl(f, BIODASDINFO2, &dasd_info) != 0) {
+        close(f);
+        return FALSE;
+    }
+
+    close(f);
+
+    /* check if we're on an FBA DASD */
+    return strncmp(dasd_info.type, "FBA", 3) == 0;
+}
+
+/**
  * bd_s390_sanitize_dev_input:
  * @dev a DASD or zFCP device number
  * @error: (out): place to store error (if any)

--- a/src/plugins/s390.h
+++ b/src/plugins/s390.h
@@ -33,6 +33,7 @@ gboolean bd_s390_dasd_format (const gchar *dasd, const BDExtraArg **extra, GErro
 gboolean bd_s390_dasd_needs_format (const gchar *dasd, GError **error);
 gboolean bd_s390_dasd_online (const gchar *dasd, GError **error);
 gboolean bd_s390_dasd_is_ldl (const gchar *dasd, GError **error);
+gboolean bd_s390_dasd_is_fba (const gchar *dasd, GError **error);
 gchar* bd_s390_sanitize_dev_input (const gchar *dev, GError **error);
 gchar* bd_s390_zfcp_sanitize_wwpn_input (const gchar *wwpn, GError **error);
 gchar* bd_s390_zfcp_sanitize_lun_input (const gchar *lun, GError **error);


### PR DESCRIPTION
This will enable blivet to choose a correct disklabel type for an FBA device.