### PR TITLE
Make sure the returned thpool MD size is valid

### DIFF
--- a/src/plugins/lvm-dbus.c
+++ b/src/plugins/lvm-dbus.c
@@ -1097,7 +1097,7 @@ guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n
         return 0;
     }
 
-    return ret;
+    return MAX (ret, BD_LVM_MIN_THPOOL_MD_SIZE);
 }
 
 /**

--- a/src/plugins/lvm.c
+++ b/src/plugins/lvm.c
@@ -615,7 +615,7 @@ guint64 bd_lvm_get_thpool_meta_size (guint64 size, guint64 chunk_size, guint64 n
         return 0;
     }
 
-    return ret;
+    return MAX (ret, BD_LVM_MIN_THPOOL_MD_SIZE);
 }
 
 /**

--- a/tests/lvm_dbus_tests.py
+++ b/tests/lvm_dbus_tests.py
@@ -130,6 +130,10 @@ class LvmNoDevTestCase(unittest.TestCase):
         # twice the chunk_size -> roughly half the metadata needed
         self.assertAlmostEqual(float(out1) / float(out2), 2, places=2)
 
+        # unless thin_metadata_size gives a value that is not valid (too small)
+        self.assertEqual(BlockDev.lvm_get_thpool_meta_size (100 * 1024**2, 128 * 1024, 100),
+                         BlockDev.LVM_MIN_THPOOL_MD_SIZE)
+
     def test_is_valid_thpool_md_size(self):
         """Verify that is_valid_thpool_md_size works as expected"""
 

--- a/tests/lvm_test.py
+++ b/tests/lvm_test.py
@@ -114,6 +114,10 @@ class LvmNoDevTestCase(unittest.TestCase):
         # twice the chunk_size -> roughly half the metadata needed
         self.assertAlmostEqual(float(out1) / float(out2), 2, places=2)
 
+        # unless thin_metadata_size gives a value that is not valid (too small)
+        self.assertEqual(BlockDev.lvm_get_thpool_meta_size (100 * 1024**2, 128 * 1024, 100),
+                         BlockDev.LVM_MIN_THPOOL_MD_SIZE)
+
     def test_is_valid_thpool_md_size(self):
         """Verify that is_valid_thpool_md_size works as expected"""
 


### PR DESCRIPTION
It may be too small as given by the thin_metadata_size tool which
obviously doesn't guard for too small values.