### PR TITLE
Fixes to make tests passing on CentOS/RHEL 7

### DIFF
--- a/src/plugins/fs.c
+++ b/src/plugins/fs.c
@@ -1160,7 +1160,7 @@ static gboolean wipe_fs (const gchar *device, const gchar *fs_type, gboolean wip
  * Returns: whether a new ext4 fs was successfully created on @device or not
  */
 gboolean bd_fs_ext4_mkfs (const gchar *device, const BDExtraArg **extra, GError **error) {
-    const gchar *args[3] = {"mkfs.ext4", device, NULL};
+    const gchar *args[4] = {"mkfs.ext4", "-F", device, NULL};
 
     return bd_utils_exec_and_report_error (args, extra, error);
 }
@@ -1597,7 +1597,7 @@ gboolean bd_fs_xfs_resize (const gchar *mpoint, guint64 new_size, const BDExtraA
  * Returns: whether a new vfat fs was successfully created on @device or not
  */
 gboolean bd_fs_vfat_mkfs (const gchar *device, const BDExtraArg **extra, GError **error) {
-    const gchar *args[3] = {"mkfs.vfat", device, NULL};
+    const gchar *args[4] = {"mkfs.vfat", "-I", device, NULL};
 
     return bd_utils_exec_and_report_error (args, extra, error);
 }

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -1475,7 +1475,7 @@ gboolean bd_part_set_part_type (const gchar *disk, const gchar *part, const gcha
  * Returns: whether the @part_id type was successfully set for @part or not
  */
 gboolean bd_part_set_part_id (const gchar *disk, const gchar *part, const gchar *part_id, GError **error) {
-    const gchar *args[6] = {"sfdisk", "--part-type", disk, NULL, part_id, NULL};
+    const gchar *args[6] = {"sfdisk", "--id", disk, NULL, part_id, NULL};
     const gchar *part_num_str = NULL;
     gboolean success = FALSE;
     guint64 progress_id = 0;
@@ -1541,7 +1541,7 @@ gboolean bd_part_set_part_id (const gchar *disk, const gchar *part, const gchar 
  * Returns (transfer full): partition id type or %NULL in case of error
  */
 gchar* bd_part_get_part_id (const gchar *disk, const gchar *part, GError **error) {
-    const gchar *args[5] = {"sfdisk", "--part-type", disk, NULL, NULL};
+    const gchar *args[5] = {"sfdisk", "--id", disk, NULL, NULL};
     const gchar *part_num_str = NULL;
     gchar *output = NULL;
     gchar *ret = NULL;

--- a/src/plugins/part.c
+++ b/src/plugins/part.c
@@ -697,6 +697,8 @@ BDPartSpec* bd_part_get_best_free_region (const gchar *disk, BDPartType type, gu
     for (free_reg_p=free_regs; *free_reg_p; free_reg_p++)
         if (*free_reg_p != ret)
             bd_part_spec_free (*free_reg_p);
+    g_free (free_regs);
+
     return ret;
 }
 

--- a/tests/crypto_test.py
+++ b/tests/crypto_test.py
@@ -7,7 +7,7 @@ import subprocess
 import six
 import locale
 
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, skip_on
 from gi.repository import BlockDev, GLib
 if not BlockDev.is_initialized():
     BlockDev.init(None, None)
@@ -342,6 +342,7 @@ class CryptoTestEscrow(CryptoTestCase):
         self.addCleanup(os.unlink, self.public_cert)
 
     @unittest.skipIf("SKIP_SLOW" in os.environ, "skipping slow tests")
+    @skip_on(("centos", "enterprise_linux"))
     def test_escrow_packet(self):
         """Verify that an escrow packet can be created for a device"""
 

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 from contextlib import contextmanager
 import utils
+import six
 import overrides_hack
 
 from gi.repository import BlockDev, GLib
@@ -122,7 +123,7 @@ class TestGenericWipe(FSTestCase):
         self.assertEqual(fs_type, b"")
 
         # try to wipe empty device
-        with self.assertRaisesRegex(GLib.GError, "No signature detected on the device"):
+        with six.assertRaisesRegex(self, GLib.GError, "No signature detected on the device"):
             BlockDev.fs_wipe(self.loop_dev, True)
 
 

--- a/tests/fs_test.py
+++ b/tests/fs_test.py
@@ -89,7 +89,7 @@ class TestGenericWipe(FSTestCase):
 
         # vfat has multiple signatures on the device so it allows us to test the
         # 'all' argument of fs_wipe()
-        ret = os.system("mkfs.vfat %s &>/dev/null" % self.loop_dev)
+        ret = os.system("mkfs.vfat -I %s &>/dev/null" % self.loop_dev)
         self.assertEqual(ret, 0)
 
         time.sleep(0.5)
@@ -111,7 +111,7 @@ class TestGenericWipe(FSTestCase):
         self.assertEqual(fs_type, b"")
 
         # now do the wipe all in a one step
-        ret = os.system("mkfs.vfat %s &>/dev/null" % self.loop_dev)
+        ret = os.system("mkfs.vfat -I %s &>/dev/null" % self.loop_dev)
         self.assertEqual(ret, 0)
 
         succ = BlockDev.fs_wipe(self.loop_dev, True)
@@ -176,7 +176,7 @@ class Ext4TestWipe(FSTestCase):
 
         BlockDev.fs_wipe(self.loop_dev, True)
 
-        os.system("mkfs.ext2 %s &>/dev/null" % self.loop_dev)
+        os.system("mkfs.ext2 -F %s &>/dev/null" % self.loop_dev)
 
         # ext2, not an ext4 file system
         with self.assertRaises(GLib.GError):
@@ -368,7 +368,7 @@ class XfsTestWipe(FSTestCase):
 
         BlockDev.fs_wipe(self.loop_dev, True)
 
-        os.system("mkfs.ext2 %s &>/dev/null" % self.loop_dev)
+        os.system("mkfs.ext2 -F %s &>/dev/null" % self.loop_dev)
 
         # ext2, not an xfs file system
         with self.assertRaises(GLib.GError):
@@ -577,7 +577,7 @@ class VfatTestWipe(FSTestCase):
 
         BlockDev.fs_wipe(self.loop_dev, True)
 
-        os.system("mkfs.ext2 %s &>/dev/null" % self.loop_dev)
+        os.system("mkfs.ext2 -F %s &>/dev/null" % self.loop_dev)
 
         # ext2, not an vfat file system
         with self.assertRaises(GLib.GError):

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -2,7 +2,7 @@ import unittest
 import os
 import time
 from contextlib import contextmanager
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, wipe_all, fake_path, read_file
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, wipe_all, fake_path, read_file, skip_on
 import overrides_hack
 
 from gi.repository import BlockDev, GLib
@@ -201,6 +201,7 @@ class KbdZRAMStatsTestCase(KbdZRAMTestCase):
 class KbdBcacheNodevTestCase(unittest.TestCase):
     # no setUp/tearDown methods needed
 
+    @skip_on(("centos", "enterprise_linux"))
     def test_bcache_mode_str_bijection(self):
         """Verify that it's possible to transform between cache modes and their string representations"""
 
@@ -256,6 +257,7 @@ class KbdBcacheTestCase(unittest.TestCase):
 
 class KbdTestBcacheCreate(KbdBcacheTestCase):
     @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
+    @skip_on(("centos", "enterprise_linux"))
     def test_bcache_create_destroy(self):
         """Verify that it's possible to create and destroy a bcache device"""
 
@@ -274,6 +276,7 @@ class KbdTestBcacheCreate(KbdBcacheTestCase):
         wipe_all(self.loop_dev, self.loop_dev2)
 
     @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
+    @skip_on(("centos", "enterprise_linux"))
     def test_bcache_create_destroy_full_path(self):
         """Verify that it's possible to create and destroy a bcache device with full device path"""
 
@@ -293,6 +296,7 @@ class KbdTestBcacheCreate(KbdBcacheTestCase):
 
 class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
     @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
+    @skip_on(("centos", "enterprise_linux"))
     def test_bcache_attach_detach(self):
         """Verify that it's possible to detach/attach a cache from/to a bcache device"""
 
@@ -318,6 +322,7 @@ class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
         wipe_all(self.loop_dev, self.loop_dev2)
 
     @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
+    @skip_on(("centos", "enterprise_linux"))
     def test_bcache_attach_detach_full_path(self):
         """Verify that it's possible to detach/attach a cache from/to a bcache device with full device path"""
 
@@ -343,6 +348,7 @@ class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
         wipe_all(self.loop_dev, self.loop_dev2)
 
     @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
+    @skip_on(("centos", "enterprise_linux"))
     def test_bcache_detach_destroy(self):
         """Verify that it's possible to destroy a bcache device with no cache attached"""
 
@@ -366,6 +372,7 @@ class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
 
 class KbdTestBcacheGetSetMode(KbdBcacheTestCase):
     @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
+    @skip_on(("centos", "enterprise_linux"))
     def test_bcache_get_set_mode(self):
         """Verify that it is possible to get and set Bcache mode"""
 
@@ -414,6 +421,7 @@ class KbdTestBcacheGetSetMode(KbdBcacheTestCase):
 
 class KbdTestBcacheStatusTest(KbdBcacheTestCase):
     @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
+    @skip_on(("centos", "enterprise_linux"))
     def test_bcache_status(self):
         succ, dev = BlockDev.kbd_bcache_create(self.loop_dev, self.loop_dev2, None)
         self.assertTrue(succ)
@@ -443,6 +451,7 @@ class KbdTestBcacheStatusTest(KbdBcacheTestCase):
 
 class KbdTestBcacheBackingCacheDevTest(KbdBcacheTestCase):
     @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
+    @skip_on(("centos", "enterprise_linux"))
     def test_bcache_backing_cache_dev(self):
         """Verify that is is possible to get the backing and cache devices for a Bcache"""
 
@@ -469,6 +478,7 @@ class KbdUnloadTest(unittest.TestCase):
         # tests
         self.addCleanup(BlockDev.reinit, None, True, None)
 
+    @skip_on(("centos", "enterprise_linux"))
     def test_check_no_bcache_progs(self):
         """Verify that checking the availability of make-bcache works as expected"""
 

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -508,7 +508,7 @@ class PartCreatePartFullCase(PartTestCase):
         self.assertEqual(ps3.flags, 0)  # no flags (combination of bit flags)
 
         # we should get a logical partition which has number 5
-        ps5 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps3.start + 1,
+        ps5 = BlockDev.part_create_part (self.loop_dev, BlockDev.PartTypeReq.NEXT, ps3.start + ps3.size + 1,
                                          10 * 1024**2, BlockDev.PartAlign.OPTIMAL)
         ps4 = BlockDev.part_get_part_spec (self.loop_dev, self.loop_dev + "4")
         self.assertTrue(ps4)

--- a/tests/part_test.py
+++ b/tests/part_test.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-from utils import create_sparse_tempfile, create_lio_device, delete_lio_device
+from utils import create_sparse_tempfile, create_lio_device, delete_lio_device, skip_on
 import overrides_hack
 
 from gi.repository import BlockDev, GLib
@@ -628,6 +628,7 @@ class PartGetDiskPartsCase(PartTestCase):
             BlockDev.part_get_disk_parts (self.loop_dev)
 
 class PartGetDiskFreeRegions(PartTestCase):
+    @skip_on(("centos", "enterprise_linux"), reason="libparted provides weird values here")
     def test_get_disk_free_regions(self):
         """Verify that it is possible to get info about free regions on a disk"""
 
@@ -716,6 +717,7 @@ class PartGetDiskFreeRegions(PartTestCase):
         self.assertGreater(fi.size, 89 * 1024**2)
 
 class PartGetBestFreeRegion(PartTestCase):
+    @skip_on(("centos", "enterprise_linux"), reason="libparted provides weird values here")
     def test_get_best_free_region(self):
         """Verify that it is possible to get info about the best free region on a disk"""
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -196,7 +196,7 @@ def run_command(command):
     out, err = res.communicate()
     return (res.returncode, out.decode().strip(), err.decode().strip())
 
-def skip_on(skip_on_distros, skip_on_version=""):
+def skip_on(skip_on_distros, skip_on_version="", reason=""):
     """A function returning a decorator to skip some test on a given distribution-version combination
 
     :param skip_on_distros: distro(s) to skip the test on
@@ -219,6 +219,7 @@ def skip_on(skip_on_distros, skip_on_version=""):
 
     def decorator(func):
         if distro in skip_on_distros and (not skip_on_version or skip_on_version == version):
-            return unittest.skip("not supported on this distribution in this version")(func)
+            msg = "not supported on this distribution in this version" + (": %s" % reason if reason else "")
+            return unittest.skip(msg)(func)
 
     return decorator

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,12 +3,15 @@ import re
 import glob
 import subprocess
 import tempfile
-import subprocess
-from subprocess import DEVNULL
 from contextlib import contextmanager
 from itertools import chain
 
 from gi.repository import GLib
+
+try:
+    from subprocess import DEVNULL
+except ImportError:
+    DEVNULL = open("/dev/null", "w")
 
 _lio_devs = dict()
 


### PR DESCRIPTION
These are the fixes and adaptations of both the code and tests to allow us running tests on CentOS/RHEL 7. The only remaining failing test is the one for getting *zram* stats where the failure is caused by incompatibilities between the 3.10 and almost-vanilla kernels in el7 and Fedora respectively.

Apart from disabling tests related to bcache (which is not available on el7) there are bugs in the el7 versions of ``volume_key`` and ``libparted`` that make it impossible to run some tests properly. Those will be reported.