### PR TITLE
Revert "Use different BTRFS_MIN_MEMBER_SIZE on aarch64"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,11 +18,9 @@ LT_INIT
 
 AC_CONFIG_FILES([Makefile src/Makefile \
                           src/plugins/Makefile \
-                          src/plugins/btrfs.h \
                           src/utils/Makefile \
                           src/lib/Makefile \
                           src/lib/plugin_apis/Makefile \
-                          src/lib/plugin_apis/btrfs.api \
                           src/lib/blockdev.c \
                           src/lib/blockdev.pc \
                           src/python/Makefile \
@@ -48,12 +46,7 @@ on_s390=$?
 
 AM_CONDITIONAL(ON_S390, test "$on_s390" = "0")
 
-uname -p|grep aarch64
-on_aarch64=$?
-
 skip_patterns=""
-
-AS_IF([test "$on_aarch64" = "0"], AC_SUBST([BTRFS_MIN_SIZE], ["(256 MiB)"]), AC_SUBST([BTRFS_MIN_SIZE], ["(128 MiB)"]))
 
 # Complain if introspection was not enabled
 AS_IF([test "x$found_introspection" = xyes], [:],

--- a/src/lib/plugin_apis/btrfs.api
+++ b/src/lib/plugin_apis/btrfs.api
@@ -3,7 +3,7 @@
 #include <blockdev/utils.h>
 
 #define BD_BTRFS_MAIN_VOLUME_ID 5
-#define BD_BTRFS_MIN_MEMBER_SIZE @BTRFS_MIN_SIZE@
+#define BD_BTRFS_MIN_MEMBER_SIZE (128 MiB)
 
 GQuark bd_btrfs_error_quark (void) {
     return g_quark_from_static_string ("g-bd-btrfs-error-quark");

--- a/src/plugins/btrfs.h
+++ b/src/plugins/btrfs.h
@@ -8,7 +8,7 @@
 #define BTRFS_MIN_VERSION "3.18.2"
 
 #define BD_BTRFS_MAIN_VOLUME_ID 5
-#define BD_BTRFS_MIN_MEMBER_SIZE @BTRFS_MIN_SIZE@
+#define BD_BTRFS_MIN_MEMBER_SIZE (128 MiB)
 
 GQuark bd_btrfs_error_quark (void);
 #define BD_BTRFS_ERROR bd_btrfs_error_quark ()


### PR DESCRIPTION
This reverts commit 37d568d3c286e3d455da54ddd004712a864d9f3d.

It seems to be 128 MiB on aarch64 too now.