### PR TITLE
Add functions for resolving device (symlinks) and getting device symlinks

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -638,6 +638,7 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 %{_includedir}/blockdev/sizes.h
 %{_includedir}/blockdev/exec.h
 %{_includedir}/blockdev/extra_arg.h
+%{_includedir}/blockdev/dev_utils.h
 
 
 %if %{with_btrfs}

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -130,6 +130,7 @@ bd_extra_arg_new
 bd_extra_arg_copy
 bd_extra_arg_free
 bd_extra_arg_get_type
+bd_utils_resolve_device
 EXBIBYTE
 EiB
 GIBIBYTE

--- a/docs/libblockdev-sections.txt
+++ b/docs/libblockdev-sections.txt
@@ -131,6 +131,7 @@ bd_extra_arg_copy
 bd_extra_arg_free
 bd_extra_arg_get_type
 bd_utils_resolve_device
+bd_utils_get_device_symlinks
 EXBIBYTE
 EiB
 GIBIBYTE

--- a/src/plugins/dm.c
+++ b/src/plugins/dm.c
@@ -188,22 +188,18 @@ gchar* bd_dm_name_from_node (const gchar *dm_node, GError **error) {
  * the error in such cases)
  */
 gchar* bd_dm_node_from_name (const gchar *map_name, GError **error) {
-    gchar *symlink = NULL;
+    gchar *dev_path = NULL;
     gchar *ret = NULL;
     gchar *dev_mapper_path = g_strdup_printf ("/dev/mapper/%s", map_name);
 
-    symlink = g_file_read_link (dev_mapper_path, error);
-    if (!symlink) {
-        /* error is already populated */
-        g_free (dev_mapper_path);
-        return NULL;
-    }
-
-    g_strstrip (symlink);
-    ret = g_path_get_basename (symlink);
-
-    g_free (symlink);
+    dev_path = bd_utils_resolve_device (dev_mapper_path, error);
     g_free (dev_mapper_path);
+    if (!dev_path)
+        /* error is already populated */
+        return NULL;
+
+    ret = g_path_get_basename (dev_path);
+    g_free (dev_path);
 
     return ret;
 }

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -2,9 +2,9 @@ lib_LTLIBRARIES = libbd_utils.la
 libbd_utils_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
 libbd_utils_la_LDFLAGS = -version-info 3:0:1 -Wl,--no-undefined
 libbd_utils_la_LIBADD = $(GLIB_LIBS) -lm $(GIO_LIBS)
-libbd_utils_la_SOURCES = utils.h exec.c exec.h sizes.h extra_arg.c extra_arg.h
+libbd_utils_la_SOURCES = utils.h exec.c exec.h sizes.h extra_arg.c extra_arg.h dev_utils.c dev_utils.h
 
 libincludedir = $(includedir)/blockdev
-libinclude_HEADERS = utils.h exec.h sizes.h extra_arg.h
+libinclude_HEADERS = utils.h exec.h sizes.h extra_arg.h dev_utils.h
 
 MAINTAINERCLEANFILES = Makefile.in

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES = libbd_utils.la
-libbd_utils_la_CFLAGS = $(GLIB_CFLAGS) -Wall -Wextra -Werror
+libbd_utils_la_CFLAGS = $(GLIB_CFLAGS) $(UDEV_CFLAGS) -Wall -Wextra -Werror
 libbd_utils_la_LDFLAGS = -version-info 3:0:1 -Wl,--no-undefined
-libbd_utils_la_LIBADD = $(GLIB_LIBS) -lm $(GIO_LIBS)
+libbd_utils_la_LIBADD = $(GLIB_LIBS) -lm $(GIO_LIBS) $(UDEV_LIBS)
 libbd_utils_la_SOURCES = utils.h exec.c exec.h sizes.h extra_arg.c extra_arg.h dev_utils.c dev_utils.h
 
 libincludedir = $(includedir)/blockdev

--- a/src/utils/dev_utils.c
+++ b/src/utils/dev_utils.c
@@ -18,8 +18,17 @@
  */
 
 #include <glib.h>
+#include <libudev.h>
 
 #include "dev_utils.h"
+
+/**
+ * bd_utils_dev_utils_error_quark: (skip)
+ */
+GQuark bd_utils_dev_utils_error_quark (void)
+{
+    return g_quark_from_static_string ("g-bd-utils-dev_utils-error-quark");
+}
 
 /**
  * bd_utils_resolve_device:
@@ -62,4 +71,72 @@ gchar* bd_utils_resolve_device (const gchar *dev_spec, GError **error) {
     g_free (symlink);
 
     return path;
+}
+
+/**
+ * bd_utils_get_device_symlinks:
+ * @dev_spec: specification of the device (e.g. "/dev/sda", any symlink, or the name of a file
+ *            under "/dev")
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full) (array zero-terminated=1): a list of all symlinks (known to udev) for the
+ *                                                     device specified with @dev_spec or %NULL in
+ *                                                     case of error
+ */
+gchar** bd_utils_get_device_symlinks (const gchar *dev_spec, GError **error) {
+    gchar *dev_path;
+    struct udev *context;
+    struct udev_device *device;
+    struct udev_list_entry *entry = NULL;
+    struct udev_list_entry *ent_it = NULL;
+    guint64 n_links = 0;
+    guint64 i = 0;
+    gchar **ret = NULL;
+
+    dev_path = bd_utils_resolve_device (dev_spec, error);
+    if (!dev_path)
+        return NULL;
+
+    context = udev_new ();
+    /* dev_path is the full path like "/dev/sda", we only need the device name ("sda") */
+    device = udev_device_new_from_subsystem_sysname (context, "block", dev_path + 5);
+
+    if (!device) {
+        g_set_error (error, BD_UTILS_DEV_UTILS_ERROR, BD_UTILS_DEV_UTILS_ERROR_FAILED,
+                     "Failed to get information about the device '%s' from udev database",
+                     dev_path);
+        g_free (dev_path);
+        udev_unref (context);
+        return NULL;
+    }
+
+    entry = udev_device_get_devlinks_list_entry (device);
+    if (!entry) {
+        g_set_error (error, BD_UTILS_DEV_UTILS_ERROR, BD_UTILS_DEV_UTILS_ERROR_FAILED,
+                     "Failed to get symlinks for the device '%s'", dev_path);
+        g_free (dev_path);
+        udev_device_unref (device);
+        udev_unref (context);
+        return NULL;
+    }
+    g_free (dev_path);
+
+    ent_it = entry;
+    while (ent_it) {
+        n_links++;
+        ent_it = udev_list_entry_get_next (ent_it);
+    }
+
+    ret = g_new0 (gchar*, n_links + 1);
+    ent_it = entry;
+    while (ent_it) {
+        ret[i++] = g_strdup (udev_list_entry_get_name (ent_it));
+        ent_it = udev_list_entry_get_next (ent_it);
+    }
+    ret[i] = NULL;
+
+    udev_device_unref (device);
+    udev_unref (context);
+
+    return ret;
 }

--- a/src/utils/dev_utils.c
+++ b/src/utils/dev_utils.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2017  Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Vratislav Podzimek <vpodzime@redhat.com>
+ */
+
+#include <glib.h>
+
+#include "dev_utils.h"
+
+/**
+ * bd_utils_resolve_device:
+ * @dev_spec: specification of the device (e.g. "/dev/sda", any symlink, or the name of a file
+ *            under "/dev")
+ * @error: (out): place to store error (if any)
+ *
+ * Returns: (transfer full): the full real path of the device (e.g. "/dev/md126"
+ *                           for "/dev/md/my_raid") or %NULL in case of error
+ */
+gchar* bd_utils_resolve_device (const gchar *dev_spec, GError **error) {
+    gchar *path = NULL;
+    gchar *symlink = NULL;
+
+    /* TODO: check that the resulting path is a block device? */
+
+    if (!g_str_has_prefix (dev_spec, "/dev/"))
+        path = g_strdup_printf ("/dev/%s", dev_spec);
+    else
+        path = g_strdup (dev_spec);
+
+    symlink = g_file_read_link (path, error);
+    if (!symlink) {
+        if (g_error_matches (*error, G_FILE_ERROR, G_FILE_ERROR_INVAL)) {
+            /* invalid argument -> not a symlink -> nothing to resolve */
+            g_clear_error (error);
+            return path;
+        } else {
+            /* some other error, just report it */
+            g_free (path);
+            return NULL;
+        }
+    }
+    g_free (path);
+
+    if (g_str_has_prefix (symlink, "../"))
+        path = g_strdup_printf ("/dev/%s", symlink + 3);
+    else
+        path = g_strdup_printf ("/dev/%s", symlink);
+    g_free (symlink);
+
+    return path;
+}

--- a/src/utils/dev_utils.h
+++ b/src/utils/dev_utils.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017  Red Hat, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author: Vratislav Podzimek <vpodzime@redhat.com>
+ */
+
+#include <glib.h>
+
+#ifndef BD_UTILS_DEV_UTILS
+#define BD_UTILS_DEV_UTILS
+
+gchar* bd_utils_resolve_device (const gchar *dev_spec, GError **error);
+
+#endif  /* BD_UTILS_DEV_UTILS */

--- a/src/utils/dev_utils.h
+++ b/src/utils/dev_utils.h
@@ -22,6 +22,14 @@
 #ifndef BD_UTILS_DEV_UTILS
 #define BD_UTILS_DEV_UTILS
 
+GQuark bd_utils_dev_utils_error_quark (void);
+#define BD_UTILS_DEV_UTILS_ERROR bd_utils_dev_utils_error_quark ()
+
+typedef enum {
+    BD_UTILS_DEV_UTILS_ERROR_FAILED,
+} BDUtilsDevUtilsError;
+
 gchar* bd_utils_resolve_device (const gchar *dev_spec, GError **error);
+gchar** bd_utils_get_device_symlinks (const gchar *dev_spec, GError **error);
 
 #endif  /* BD_UTILS_DEV_UTILS */

--- a/src/utils/utils.h
+++ b/src/utils/utils.h
@@ -4,6 +4,7 @@
 #include "sizes.h"
 #include "exec.h"
 #include "extra_arg.h"
+#include "dev_utils.h"
 
 /**
  * SECTION: utils

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,7 +1,8 @@
 import unittest
 import re
+import os
 import overrides_hack
-from utils import fake_utils
+from utils import fake_utils, create_sparse_tempfile, create_lio_device, delete_lio_device
 
 from gi.repository import BlockDev, GLib
 if not BlockDev.is_initialized():
@@ -128,3 +129,35 @@ class UtilsExecLoggingTest(unittest.TestCase):
 
             # exit code != 0
             self.assertTrue(BlockDev.utils_check_util_version("libblockdev-fake-util-fail", "1.1", "version", "Version:\\s(.*)"))
+
+class UtilsDevUtilsTestCase(unittest.TestCase):
+    def test_resolve_device(self):
+        """Verify that resolving device spec works as expected"""
+
+        with self.assertRaises(GLib.GError):
+            BlockDev.utils_resolve_device("no_such_device")
+
+        dev = "/dev/libblockdev-test-dev"
+        with open(dev, "w"):
+            pass
+        self.addCleanup(os.unlink, dev)
+
+        # full path, no symlink, should just return the same
+        self.assertEqual(BlockDev.utils_resolve_device(dev), dev)
+
+        # just the name of the device, should return the full path
+        self.assertEqual(BlockDev.utils_resolve_device(dev[5:]), dev)
+
+        dev_dir = "/dev/libblockdev-test-dir"
+        os.mkdir(dev_dir)
+        self.addCleanup(os.rmdir, dev_dir)
+
+        dev_link = dev_dir + "/test-dev-link"
+        os.symlink(src="../" + dev[5:], dst=dev_link)
+        self.addCleanup(os.unlink, dev_link)
+
+        # should resolve the symlink
+        self.assertEqual(BlockDev.utils_resolve_device(dev_link), dev)
+
+        # should resolve the symlink even without the "/dev" prefix
+        self.assertEqual(BlockDev.utils_resolve_device(dev_link[5:]), dev)


### PR DESCRIPTION
These often come handy. Is the fact that the *utils* library now requires *libudev* a problem? I think it should be fine since that library is required by a number of core system components and the *libblockdv-dm* plugin already requires it too.