### PR TITLE
Use ioctl() call to teardown loop devices

### DIFF
--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -277,7 +277,6 @@ with the libblockdev-kbd plugin/library.
 %package loop
 Summary:     The loop plugin for the libblockdev library
 Requires: %{name}-utils%{?_isa} >= 0.11
-Requires: util-linux
 
 %description loop
 The libblockdev library plugin (and in the same time a standalone library)

--- a/src/plugins/loop.c
+++ b/src/plugins/loop.c
@@ -354,7 +354,8 @@ gboolean bd_loop_get_autoclear (const gchar *loop, GError **error) {
         return ret;
     }
 
-    /* else try using the ioctl() */
+    /* else try using the ioctl() (and ignore all previous errors) */
+    g_clear_error (error);
     if (!g_str_has_prefix (loop, "/dev/"))
         dev_loop = g_strdup_printf ("/dev/%s", loop);
 


### PR DESCRIPTION
There's no need to fork and exec the 'losetup' utility.