### PR TITLE
Do not link libraries required by plugins to the GI files

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -44,9 +44,8 @@ BlockDev-2.0.gir: libblockdev.la
 BlockDev_2_0_gir_FILES = $(GIHEADERS)
 BlockDev_2_0_gir_LIBS = libblockdev.la
 BlockDev_2_0_gir_INCLUDES = GObject-2.0
-BlockDev_2_0_gir_PACKAGES = devmapper libudev libcryptsetup libparted blkid bytesize
 BlockDev_2_0_gir_CFLAGS = -I${builddir}/../../include/
-BlockDev_2_0_gir_LDFLAGS = -lm -ldmraid -L${builddir}/../utils/ -lbd_utils
+BlockDev_2_0_gir_LDFLAGS = -L${builddir}/../utils/ -lbd_utils
 BlockDev_2_0_gir_SCANNERFLAGS = --warn-error --warn-all --identifier-prefix=BD --symbol-prefix=bd
 BlockDev_2_0_gir_EXPORT_PACKAGES = blockdev
 


### PR DESCRIPTION
Only the plugins require those not the library itself.