### PR TITLE
Make GObject introspection optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,9 @@ m4_ifdef([GOBJECT_INTROSPECTION_CHECK],
 [GOBJECT_INTROSPECTION_CHECK([1.3.0])],
 [found_introspection=no
 AM_CONDITIONAL(HAVE_INTROSPECTION, false)])
+AS_IF([test "x$found_introspection" = xyes],
+      [AC_SUBST(WITH_GI, 1)],
+      [AC_SUBST(WITH_GI, 0)])
 
 uname -p|grep s390
 on_s390=$?
@@ -47,10 +50,6 @@ on_s390=$?
 AM_CONDITIONAL(ON_S390, test "$on_s390" = "0")
 
 skip_patterns=""
-
-# Complain if introspection was not enabled
-AS_IF([test "x$found_introspection" = xyes], [:],
-      [LIBBLOCKDEV_SOFT_FAILURE([GObject introspection (devel) must be installed and enabled])])
 
 AC_ARG_WITH([python3],
     AS_HELP_STRING([--with-python3], [support python3 @<:@default=check@:>@]),

--- a/dist/libblockdev.spec.in
+++ b/dist/libblockdev.spec.in
@@ -13,6 +13,7 @@
 %define with_kbd @WITH_KBD@
 %define with_part @WITH_PART@
 %define with_fs @WITH_FS@
+%define with_gi @WITH_GI@
 
 %define is_rhel 0%{?rhel} != 0
 
@@ -60,8 +61,11 @@
 %if %{with_fs} != 1
 %define fs_copts --without-fs
 %endif
+%if %{with_gi} != 1
+%define gi_copts --disable-introspection
+%endif
 
-%define configure_opts %{?distro_copts} %{?btrfs_copts} %{?crypto_copts} %{?dm_copts} %{?loop_copts} %{?lvm_copts} %{?lvm_dbus_copts} %{?mdraid_copts} %{?mpath_copts} %{?swap_copts} %{?kbd_copts} %{?part_copts} %{?fs_copts}
+%define configure_opts %{?distro_copts} %{?btrfs_copts} %{?crypto_copts} %{?dm_copts} %{?loop_copts} %{?lvm_copts} %{?lvm_dbus_copts} %{?mdraid_copts} %{?mpath_copts} %{?swap_copts} %{?kbd_copts} %{?part_copts} %{?fs_copts} %{?gi_copts}
 
 Name:        libblockdev
 Version:     2.8
@@ -72,7 +76,9 @@ URL:         https://github.com/rhinstaller/libblockdev
 Source0:     https://github.com/rhinstaller/libblockdev/archive/%{name}-%{version}.tar.gz
 
 BuildRequires: glib2-devel
+%if %{with_gi}
 BuildRequires: gobject-introspection-devel
+%endif
 BuildRequires: python-devel
 %if %{with_python3}
 BuildRequires: python3-devel
@@ -602,7 +608,9 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 %{!?_licensedir:%global license %%doc}
 %license LICENSE
 %{_libdir}/libblockdev.so.*
+%if %{with_gi}
 %{_libdir}/girepository*/BlockDev*.typelib
+%endif
 %config %{_sysconfdir}/libblockdev/conf.d/00-default.cfg
 
 %files devel
@@ -615,7 +623,9 @@ find %{buildroot} -type f -name "*.la" | xargs %{__rm}
 %if %{with_gtk_doc}
 %{_datadir}/gtk-doc/html/libblockdev
 %endif
+%if %{with_gi}
 %{_datadir}/gir*/BlockDev*.gir
+%endif
 
 %files -n python2-blockdev
 %{python2_sitearch}/gi/overrides/*

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -58,12 +58,13 @@ typelib_DATA = $(INTROSPECTION_GIRS:.gir=.typelib)
 girdir = $(datadir)/gir-1.0
 gir_DATA = $(INTROSPECTION_GIRS)
 
+CLEANFILES = BlockDev-2.0.gir $(typelib_DATA)
+endif
+
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = ${builddir}/blockdev.pc
 
 libincludedir = $(includedir)/blockdev
 libinclude_HEADERS = blockdev.h plugins.h
 
-CLEANFILES = BlockDev-2.0.gir $(typelib_DATA)
 MAINTAINERCLEANFILES = Makefile.in blockdev.pc blockdev.c
-endif


### PR DESCRIPTION
Support for GObject introspection is one of the best features of
libblockdev. However, there are cases when the C API is enough
which means the GI support should be optional. The common GI
macros already support the '--enable/disable-introspection'
option for './configure', we just need to respect it properly.