### PR TITLE
Fix hardcoded reference to pkg-config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,12 +156,12 @@ AS_IF([test "x$with_fs" != "xno"],
        LIBBLOCKDEV_PKG_CHECK_MODULES([BLKID], [blkid >= 2.23.0])
        # older versions of libblkid don't support BLKID_SUBLKS_BADCSUM so let's just
        # define it as 0 (neutral value for bit combinations of flags)
-       AS_IF([pkg-config --atleast-version=2.27.0 blkid], [],
+       AS_IF([$PKG_CONFIG --atleast-version=2.27.0 blkid], [],
              [AC_DEFINE([BLKID_SUBLKS_BADCSUM], [0],
               [Define as neutral value if libblkid doesn't provide the definition])])
 
        # older versions of parted don't provide the libparted-fs-resize.pc file
-       AS_IF([pkg-config libparted-fs-resize],
+       AS_IF([$PKG_CONFIG libparted-fs-resize],
              [LIBBLOCKDEV_PKG_CHECK_MODULES([PARTED_FS], [libparted-fs-resize >= 3.2])],
              [AC_SUBST([PARTED_FS_LIBS], [-lparted-fs-resize])
               AC_SUBST([PARTED_FS_CFLAGS], [])])],


### PR DESCRIPTION
Fixes build failures in cross environments where the tools may be
prefixed with the host triplet, e.g. x86_64-pc-linux-gnu-pkg-config.