### PR TITLE
kbd.c: Make bd_kbd_bcache_create work without abort

### DIFF
--- a/src/plugins/kbd.c
+++ b/src/plugins/kbd.c
@@ -755,11 +755,11 @@ gboolean wait_for_file (const char *filename) {
     while (count > 0) {
         g_usleep (100000); /* microseconds */
         if (g_file_test (filename, G_FILE_TEST_EXISTS)) {
-            break;
+            return TRUE;
         }
         --count;
     }
-    return (count > 0) ? TRUE : FALSE;
+    return FALSE;
 }
 
 /**
@@ -817,14 +817,11 @@ gboolean bd_kbd_bcache_create (const gchar *backing_device, const gchar *cache_d
         return FALSE;
     }
 
-    for (i=0; lines[i]; i++) {
+    for (i=0; lines[i] && n < 2; i++) {
         success = g_regex_match (regex, lines[i], 0, &match_info);
         if (success) {
-            strcpy(device_uuid[n++], g_match_info_fetch (match_info, 1));
+            strcpy (device_uuid[n++], g_match_info_fetch (match_info, 1));
             g_match_info_free (match_info);
-            if (n == 2) {
-                break;
-            }
         }
     }
     g_regex_unref (regex);
@@ -842,11 +839,11 @@ gboolean bd_kbd_bcache_create (const gchar *backing_device, const gchar *cache_d
     /* Wait for the symlinks to show up, would it be better to do a udev settle? */
     for (i=0; i < 2; i++) {
         const char *uuid_file = g_strdup_printf ("/dev/disk/by-uuid/%s", device_uuid[i]);
-        gboolean present = wait_for_file(uuid_file);
+        gboolean present = wait_for_file (uuid_file);
         g_free ((gpointer)uuid_file);
         if (!present) {
             g_set_error (error, BD_KBD_ERROR, BD_KBD_ERROR_BCACHE_NOEXIST,
-                     "Failed to locate uuid symlink '%s'", device_uuid[i]);
+                         "Failed to locate uuid symlink '%s'", device_uuid[i]);
             return FALSE;
         }
      }

--- a/tests/kbd_test.py
+++ b/tests/kbd_test.py
@@ -294,7 +294,6 @@ class KbdBcacheTestCase(unittest.TestCase):
         os.unlink(self.dev_file2)
 
 class KbdTestBcacheCreate(KbdBcacheTestCase):
-    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     @skip_on(("centos", "enterprise_linux"))
     def test_bcache_create_destroy(self):
         """Verify that it's possible to create and destroy a bcache device"""
@@ -313,7 +312,6 @@ class KbdTestBcacheCreate(KbdBcacheTestCase):
 
         wipe_all(self.loop_dev, self.loop_dev2)
 
-    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     @skip_on(("centos", "enterprise_linux"))
     def test_bcache_create_destroy_full_path(self):
         """Verify that it's possible to create and destroy a bcache device with full device path"""
@@ -333,7 +331,6 @@ class KbdTestBcacheCreate(KbdBcacheTestCase):
         wipe_all(self.loop_dev, self.loop_dev2)
 
 class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
-    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     @skip_on(("centos", "enterprise_linux"))
     def test_bcache_attach_detach(self):
         """Verify that it's possible to detach/attach a cache from/to a bcache device"""
@@ -359,7 +356,6 @@ class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
 
         wipe_all(self.loop_dev, self.loop_dev2)
 
-    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     @skip_on(("centos", "enterprise_linux"))
     def test_bcache_attach_detach_full_path(self):
         """Verify that it's possible to detach/attach a cache from/to a bcache device with full device path"""
@@ -385,7 +381,6 @@ class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
 
         wipe_all(self.loop_dev, self.loop_dev2)
 
-    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     @skip_on(("centos", "enterprise_linux"))
     def test_bcache_detach_destroy(self):
         """Verify that it's possible to destroy a bcache device with no cache attached"""
@@ -409,7 +404,6 @@ class KbdTestBcacheAttachDetach(KbdBcacheTestCase):
         wipe_all(self.loop_dev, self.loop_dev2)
 
 class KbdTestBcacheGetSetMode(KbdBcacheTestCase):
-    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     @skip_on(("centos", "enterprise_linux"))
     def test_bcache_get_set_mode(self):
         """Verify that it is possible to get and set Bcache mode"""
@@ -458,7 +452,6 @@ class KbdTestBcacheGetSetMode(KbdBcacheTestCase):
         wipe_all(self.loop_dev, self.loop_dev2)
 
 class KbdTestBcacheStatusTest(KbdBcacheTestCase):
-    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     @skip_on(("centos", "enterprise_linux"))
     def test_bcache_status(self):
         succ, dev = BlockDev.kbd_bcache_create(self.loop_dev, self.loop_dev2, None)
@@ -488,7 +481,6 @@ class KbdTestBcacheStatusTest(KbdBcacheTestCase):
         wipe_all(self.loop_dev, self.loop_dev2)
 
 class KbdTestBcacheBackingCacheDevTest(KbdBcacheTestCase):
-    @unittest.skipUnless("FEELINGLUCKY" in os.environ, "skipping, not feeling lucky")
     @skip_on(("centos", "enterprise_linux"))
     def test_bcache_backing_cache_dev(self):
         """Verify that is is possible to get the backing and cache devices for a Bcache"""


### PR DESCRIPTION
When you create a cached device with a backing device at the same
time you do not need to separately register and attach devices.
This is done by the udev rules.  This fixes an issue where the
code was doing an attach for a device that was already attached.
The bcache sysfs attach kernel entry will return -2 in an unsigned,
which yields 2**32-2 returned to user space.  This will cause an
abort if you are running G_DEBUG=fatal-criticals in glib as
g_io_channel_flush does a g_string_erase of the write buffer for
the number of bytes written, which is ~4G, and we only actually
have a 1K buffer that we wrote 36 bytes of.

Signed-off-by: Tony Asleson <tasleson@redhat.com>