### PR TITLE
Ignore parted warnings if possible

### DIFF
--- a/src/plugins/part_err.c
+++ b/src/plugins/part_err.c
@@ -17,6 +17,7 @@
  * Author: Vojtech Trefny <vtrefny@redhat.com>
  */
 
+#include <glib.h>
 #include <parted/parted.h>
 
 #include "part_err.h"
@@ -24,6 +25,10 @@
 static __thread gchar *error_msg = NULL;
 
 PedExceptionOption bd_exc_handler (PedException *ex) {
+    if (ex->type <= PED_EXCEPTION_WARNING && (ex->options & PED_EXCEPTION_IGNORE) != 0) {
+      g_warning ("[parted] %s", ex->message);
+      return PED_EXCEPTION_IGNORE;
+    }
     error_msg = g_strdup (ex->message);
     return PED_EXCEPTION_UNHANDLED;
 }


### PR DESCRIPTION
Ignore parted exceptions of type warning and information if parted marks them as ignorable. Fixes #214.

~~I haven't tested this yet \*cough*. Plus I should probably add at least one test case in which a parted warning is ignored. So please don't merge yet.~~